### PR TITLE
Adding support for outbound EventMessage filtering

### DIFF
--- a/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
+++ b/axon-server-connector/src/main/java/org/axonframework/axonserver/connector/event/axon/AxonServerEventStore.java
@@ -184,7 +184,8 @@ public class AxonServerEventStore extends AbstractEventStore {
         private Supplier<Serializer> eventSerializer;
         private EventUpcaster upcasterChain = NoOpEventUpcaster.INSTANCE;
         private SnapshotFilter snapshotFilter;
-
+        private Predicate<? super EventMessage<?>> eventMessageFilter = event -> true;
+        
         @Override
         public Builder storageEngine(EventStorageEngine storageEngine) {
             super.storageEngine(storageEngine);
@@ -297,6 +298,12 @@ public class AxonServerEventStore extends AbstractEventStore {
             return this;
         }
 
+        public Builder eventMessageFilter(Predicate<? super EventMessage<?>> eventMessageFilter) {
+            assertNonNull(eventMessageFilter, "The eventMessageFilter may not be null");
+            this.eventMessageFilter = eventMessageFilter;
+            return this;
+        }
+        
         /**
          * Sets the {@link EventUpcaster} used to deserialize events of older revisions. Defaults to a {@link
          * NoOpEventUpcaster}.
@@ -359,6 +366,7 @@ public class AxonServerEventStore extends AbstractEventStore {
                                                         .upcasterChain(upcasterChain)
                                                         .snapshotFilter(snapshotFilter)
                                                         .eventSerializer(eventSerializer.get())
+                                                        .eventMessageFilter(eventMessageFilter)
                                                         .configuration(configuration)
                                                         .eventStoreClient(axonServerConnectionManager)
                                                         .converter(new GrpcMetaDataConverter(eventSerializer.get()))
@@ -742,6 +750,14 @@ public class AxonServerEventStore extends AbstractEventStore {
                     super.snapshotFilter(snapshotFilter);
                     snapshotFilterSet = true;
                 }
+                return this;
+            }
+
+            public Builder eventMessageFilter(Predicate<? super EventMessage<?>> eventMessageFilter) {
+                if (eventMessageFilter != null) {
+                    super.eventMessageFilter(eventMessageFilter);
+                }
+                
                 return this;
             }
 

--- a/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
+++ b/config/src/main/java/org/axonframework/config/DefaultConfigurer.java
@@ -749,7 +749,8 @@ public class DefaultConfigurer implements Configurer {
             try {
                 handlers.stream()
                         .map(LifecycleHandler::run)
-                        .reduce((cf1, cf2) -> CompletableFuture.allOf(cf1, cf2))
+                        .map(c -> c.thenRun(() -> {}))
+                        .reduce(CompletableFuture::allOf)
                         .orElse(CompletableFuture.completedFuture(null))
                         .get(lifecyclePhaseTimeout, lifecyclePhaseTimeunit);
             } catch (CompletionException | ExecutionException e) {


### PR DESCRIPTION
These are the changes I made to support my use-case of not wanting to publish certain events to AxonServerEventStore to alleviate possible quota issues. I don't anticipate this feature being used outside of the context of migrating to this kind of event store. But, anything is possible I imagine. I was getting errors in DefaultConfigurer and back ported the 4.6 version of code, so you can ignore that bit. I had to check that filteredEvents wasn't empty before passing the value along because it was causing a timeout in my code.

This is how my Spring (non-Boot) config looks now...
```
public Configuration serverConfiguration(AxonServerConfiguration axonServerConfiguration) {
    return DefaultConfigurer.defaultConfiguration()
        ...
        .configureEventStore(this::buildEventStore)
        ...
        .start();
}

private AxonServerEventStore buildEventStore(Configuration c) {
    return AxonServerEventStore.builder()
       .configuration(c.getComponent(AxonServerConfiguration.class))
       .platformConnectionManager(c.getComponent(AxonServerConnectionManager.class))
       .messageMonitor(c.messageMonitor(AxonServerEventStore.class, "eventStore"))
       .snapshotSerializer(c.serializer())
       .eventSerializer(c.eventSerializer())
       .snapshotFilter(c.snapshotFilter())
       .upcasterChain(c.upcasterChain())
       .eventMessageFilter(event -> event.getPayloadType().getName().startsWith("com.acme.api"))
       .build();
}
```