### PR TITLE
[#4815] Implement lowerBound on the aggregate-based consistency marker

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarker.java
@@ -95,6 +95,10 @@ public class AggregateBasedConsistencyMarker extends AbstractConsistencyMarker<A
     /**
      * Returns a marker containing the aggregates of both {@code this} and the given {@code other} marker, keeping the
      * <em>highest</em> position for any aggregate both markers know about.
+     * <p>
+     * Positions of distinct aggregates are independent of one another, so an aggregate that only one of the two markers
+     * knows about keeps its position in the result. Dropping it would reset that aggregate to the start of its event
+     * stream, which both loses conflict detection for the aggregate and restarts its sequence numbers at zero.
      *
      * @param other the other marker to combine with
      * @return a marker holding the highest known position per aggregate of both markers

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarker.java
@@ -21,6 +21,7 @@ import org.axonframework.common.CollectionUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.BinaryOperator;
 
 /**
  * {@link ConsistencyMarker} implementation that keeps track of a position per aggregate identifier. A single
@@ -75,19 +76,38 @@ public class AggregateBasedConsistencyMarker extends AbstractConsistencyMarker<A
         throw new IllegalArgumentException("Unsupported consistency marker: " + appendCondition.consistencyMarker());
     }
 
+    /**
+     * Returns a marker containing the aggregates of both {@code this} and the given {@code other} marker, keeping the
+     * <em>lowest</em> position for any aggregate both markers know about.
+     * <p>
+     * Positions of distinct aggregates are independent of one another, so an aggregate that only one of the two markers
+     * knows about keeps its position in the result. Dropping it would reset that aggregate to the start of its event
+     * stream, which both loses conflict detection for the aggregate and restarts its sequence numbers at zero.
+     *
+     * @param other the other marker to combine with
+     * @return a marker holding the lowest known position per aggregate of both markers
+     */
     @Override
     public AggregateBasedConsistencyMarker doLowerBound(AggregateBasedConsistencyMarker other) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        return combineWith(other, Math::min);
     }
 
+    /**
+     * Returns a marker containing the aggregates of both {@code this} and the given {@code other} marker, keeping the
+     * <em>highest</em> position for any aggregate both markers know about.
+     *
+     * @param other the other marker to combine with
+     * @return a marker holding the highest known position per aggregate of both markers
+     */
     @Override
     public AggregateBasedConsistencyMarker doUpperBound(AggregateBasedConsistencyMarker other) {
+        return combineWith(other, Math::max);
+    }
+
+    private AggregateBasedConsistencyMarker combineWith(AggregateBasedConsistencyMarker other,
+                                                        BinaryOperator<Long> positionSelector) {
         Map<String, Long> newPositions = new HashMap<>(aggregatePositions);
-        other.aggregatePositions.forEach((id, seq) -> {
-            if (!newPositions.containsKey(id) || newPositions.get(id) < seq) {
-                newPositions.put(id, seq);
-            }
-        });
+        other.aggregatePositions.forEach((id, position) -> newPositions.merge(id, position, positionSelector));
         return new AggregateBasedConsistencyMarker(newPositions);
     }
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
@@ -25,6 +25,13 @@ import org.axonframework.messaging.core.Context;
  * Consistency Markers are used to identify the expected position new events should be inserted at, in order to avoid
  * conflicts. If the actual insert position doesn't match the position described in this ConsistencyMarker, there may
  * have been a concurrency conflict.
+ * <p/>
+ * A ConsistencyMarker does not have to describe a single position. An implementation may instead track a position per
+ * key, such as one position per aggregate identifier. Since those positions are independent of one another,
+ * {@link #lowerBound(ConsistencyMarker)} and {@link #upperBound(ConsistencyMarker)} combine such markers per key, over
+ * the keys of <em>both</em> markers, and never drop a key that only one of the two markers holds a position for. As a
+ * result, two such markers without any key in common have the same lower and upper bound: neither marker describes the
+ * keys of the other, so all positions of both are retained.
  *
  * @author Allard Buijze
  * @author Steven van Beelen
@@ -58,7 +65,8 @@ public interface ConsistencyMarker {
     /**
      * Returns a ConsistencyMarker that represents the lower bound of {@code this} and given {@code other} markers.
      * Effectively, this means that any events whose position in the event stream is beyond either {@code this} or the
-     * {@code other} marker, will also be beyond the returned marker.
+     * {@code other} marker, will also be beyond the returned marker. For markers that track a position per key, this
+     * holds per key, as described in the class-level documentation.
      *
      * @param other The other marker to create the lower bound for
      * @return a ConsistencyMarker that represents the lower bound of two other markers
@@ -68,7 +76,8 @@ public interface ConsistencyMarker {
     /**
      * Returns a ConsistencyMarker that represents the upper bound of {@code this} and given {@code other} markers.
      * Effectively, this means that only events whose position in the event stream is beyond both {@code this} and the
-     * {@code other} marker, will also be beyond the returned marker.
+     * {@code other} marker, will also be beyond the returned marker. For markers that track a position per key, this
+     * holds per key, as described in the class-level documentation.
      *
      * @param other The other marker to create the upper bound for
      * @return a ConsistencyMarker that represents the upper bound of two other markers

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConsistencyMarker.java
@@ -25,13 +25,6 @@ import org.axonframework.messaging.core.Context;
  * Consistency Markers are used to identify the expected position new events should be inserted at, in order to avoid
  * conflicts. If the actual insert position doesn't match the position described in this ConsistencyMarker, there may
  * have been a concurrency conflict.
- * <p/>
- * A ConsistencyMarker does not have to describe a single position. An implementation may instead track a position per
- * key, such as one position per aggregate identifier. Since those positions are independent of one another,
- * {@link #lowerBound(ConsistencyMarker)} and {@link #upperBound(ConsistencyMarker)} combine such markers per key, over
- * the keys of <em>both</em> markers, and never drop a key that only one of the two markers holds a position for. As a
- * result, two such markers without any key in common have the same lower and upper bound: neither marker describes the
- * keys of the other, so all positions of both are retained.
  *
  * @author Allard Buijze
  * @author Steven van Beelen
@@ -65,8 +58,7 @@ public interface ConsistencyMarker {
     /**
      * Returns a ConsistencyMarker that represents the lower bound of {@code this} and given {@code other} markers.
      * Effectively, this means that any events whose position in the event stream is beyond either {@code this} or the
-     * {@code other} marker, will also be beyond the returned marker. For markers that track a position per key, this
-     * holds per key, as described in the class-level documentation.
+     * {@code other} marker, will also be beyond the returned marker.
      *
      * @param other The other marker to create the lower bound for
      * @return a ConsistencyMarker that represents the lower bound of two other markers
@@ -76,8 +68,7 @@ public interface ConsistencyMarker {
     /**
      * Returns a ConsistencyMarker that represents the upper bound of {@code this} and given {@code other} markers.
      * Effectively, this means that only events whose position in the event stream is beyond both {@code this} and the
-     * {@code other} marker, will also be beyond the returned marker. For markers that track a position per key, this
-     * holds per key, as described in the class-level documentation.
+     * {@code other} marker, will also be beyond the returned marker.
      *
      * @param other The other marker to create the upper bound for
      * @return a ConsistencyMarker that represents the upper bound of two other markers

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarkerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarkerTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the {@link AggregateBasedConsistencyMarker}.
+ *
+ * @author Stefan Dragisic
+ */
+class AggregateBasedConsistencyMarkerTest {
+
+    private static final String AGGREGATE_ID = "aggregate-one";
+    private static final String OTHER_AGGREGATE_ID = "aggregate-two";
+
+    /**
+     * Returns the sequence number the next event of the given {@code aggregateIdentifier} would be appended with,
+     * according to the given {@code marker}. This is the observable effect of a marker's position for an aggregate, as
+     * an aggregate-based storage engine derives the sequence numbers of appended events from it.
+     */
+    private static long nextSequenceOf(ConsistencyMarker marker, String aggregateIdentifier) {
+        return ((AggregateBasedConsistencyMarker) marker).createSequencer()
+                                                         .incrementAndGetSequenceOf(aggregateIdentifier);
+    }
+
+    @Nested
+    class LowerBound {
+
+        @Test
+        void keepsTheLowestPositionOfAnAggregateBothMarkersKnow() {
+            // given
+            ConsistencyMarker earlier = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+            ConsistencyMarker later = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 7);
+
+            // when
+            ConsistencyMarker result = later.lowerBound(earlier);
+
+            // then
+            assertThat(result).isEqualTo(earlier);
+            assertThat(result.position()).isEqualTo(new AggregateSequenceNumberPosition(3));
+        }
+
+        @Test
+        void isSymmetric() {
+            // given
+            ConsistencyMarker earlier = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+            ConsistencyMarker later = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 7);
+
+            // when / then
+            assertThat(earlier.lowerBound(later)).isEqualTo(later.lowerBound(earlier));
+        }
+
+        @Test
+        void retainsThePositionOfAnAggregateOnlyOneMarkerKnows() {
+            // given two sourcings in one processing context, each of a different aggregate
+            ConsistencyMarker first = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+            ConsistencyMarker second = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 7);
+
+            // when
+            ConsistencyMarker result = first.lowerBound(second);
+
+            // then neither aggregate is reset to the start of its event stream
+            assertThat(nextSequenceOf(result, AGGREGATE_ID)).isEqualTo(3);
+            assertThat(nextSequenceOf(result, OTHER_AGGREGATE_ID)).isEqualTo(8);
+        }
+
+        @Test
+        void combinesPerAggregateWhenMarkersPartiallyOverlap() {
+            // given a marker of two aggregates, and a later marker of only the second aggregate
+            ConsistencyMarker combined = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2)
+                    .lowerBound(new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 7));
+            ConsistencyMarker laterOther = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 9);
+
+            // when
+            ConsistencyMarker result = combined.lowerBound(laterOther);
+
+            // then only the overlapping aggregate is lowered
+            assertThat(nextSequenceOf(result, AGGREGATE_ID)).isEqualTo(3);
+            assertThat(nextSequenceOf(result, OTHER_AGGREGATE_ID)).isEqualTo(8);
+        }
+
+        @Test
+        void resolvesOriginAndInfinityWithoutConsultingTheAggregatePositions() {
+            // given
+            ConsistencyMarker testSubject = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+
+            // when / then
+            assertThat(testSubject.lowerBound(ConsistencyMarker.ORIGIN)).isEqualTo(ConsistencyMarker.ORIGIN);
+            assertThat(testSubject.lowerBound(ConsistencyMarker.INFINITY)).isEqualTo(testSubject);
+        }
+    }
+
+    @Nested
+    class UpperBound {
+
+        @Test
+        void keepsTheHighestPositionOfAnAggregateBothMarkersKnow() {
+            // given
+            ConsistencyMarker earlier = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+            ConsistencyMarker later = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 7);
+
+            // when
+            ConsistencyMarker result = earlier.upperBound(later);
+
+            // then
+            assertThat(result).isEqualTo(later);
+            assertThat(result.position()).isEqualTo(new AggregateSequenceNumberPosition(8));
+        }
+
+        @Test
+        void retainsThePositionOfAnAggregateOnlyOneMarkerKnows() {
+            // given
+            ConsistencyMarker first = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+            ConsistencyMarker second = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 7);
+
+            // when
+            ConsistencyMarker result = first.upperBound(second);
+
+            // then
+            assertThat(nextSequenceOf(result, AGGREGATE_ID)).isEqualTo(3);
+            assertThat(nextSequenceOf(result, OTHER_AGGREGATE_ID)).isEqualTo(8);
+        }
+    }
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarkerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedConsistencyMarkerTest.java
@@ -137,5 +137,40 @@ class AggregateBasedConsistencyMarkerTest {
             assertThat(nextSequenceOf(result, AGGREGATE_ID)).isEqualTo(3);
             assertThat(nextSequenceOf(result, OTHER_AGGREGATE_ID)).isEqualTo(8);
         }
+
+        @Test
+        void isSymmetric() {
+            // given
+            ConsistencyMarker earlier = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+            ConsistencyMarker later = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 7);
+
+            // when / then
+            assertThat(earlier.upperBound(later)).isEqualTo(later.upperBound(earlier));
+        }
+
+        @Test
+        void combinesPerAggregateWhenMarkersPartiallyOverlap() {
+            // given a marker of two aggregates, and a later marker of only the second aggregate
+            ConsistencyMarker combined = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2)
+                    .upperBound(new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 7));
+            ConsistencyMarker laterOther = new AggregateBasedConsistencyMarker(OTHER_AGGREGATE_ID, 9);
+
+            // when
+            ConsistencyMarker result = combined.upperBound(laterOther);
+
+            // then only the overlapping aggregate is raised
+            assertThat(nextSequenceOf(result, AGGREGATE_ID)).isEqualTo(3);
+            assertThat(nextSequenceOf(result, OTHER_AGGREGATE_ID)).isEqualTo(10);
+        }
+
+        @Test
+        void resolvesOriginAndInfinityWithoutConsultingTheAggregatePositions() {
+            // given
+            ConsistencyMarker testSubject = new AggregateBasedConsistencyMarker(AGGREGATE_ID, 2);
+
+            // when / then
+            assertThat(testSubject.upperBound(ConsistencyMarker.ORIGIN)).isEqualTo(testSubject);
+            assertThat(testSubject.upperBound(ConsistencyMarker.INFINITY)).isEqualTo(ConsistencyMarker.INFINITY);
+        }
     }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine.AppendTransaction;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.messaging.core.Context;
@@ -27,15 +28,22 @@ import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.messaging.eventstreaming.StreamingCondition;
 import org.axonframework.messaging.eventstreaming.Tag;
 import org.axonframework.modelling.entity.EntityMetamodel;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 import reactor.test.StepVerifier;
 
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -334,6 +342,135 @@ class DefaultEventStoreTransactionTest {
                     GlobalIndexConsistencyMarker.position(new GlobalIndexConsistencyMarker(4)),
                     GlobalIndexConsistencyMarker.position(result.get())
             );
+        }
+    }
+
+    @Nested
+    class SourcingMultipleAggregates {
+
+        private static final String FIRST_AGGREGATE_ID = "aggregate-one";
+        private static final String SECOND_AGGREGATE_ID = "aggregate-two";
+
+        private final AggregateBasedStorageEngine aggregateStorageEngine = new AggregateBasedStorageEngine(
+                Map.of(FIRST_AGGREGATE_ID, 2L, SECOND_AGGREGATE_ID, 6L)
+        );
+
+        @Test
+        void appendsEachAggregateAtItsOwnNextSequenceNumberWhenTwoAggregatesAreSourced() {
+            // given two aggregates whose last events are at sequence number 2 and 6 respectively
+
+            // when both are sourced in one processing context, and an event is appended for each
+            var uow = aUnitOfWork();
+            uow.runOnPreInvocation(context -> {
+                EventStoreTransaction transaction = aggregateBasedTransactionFor(context);
+                FluxUtils.of(transaction.source(sourcingConditionFor(FIRST_AGGREGATE_ID))).blockLast();
+                FluxUtils.of(transaction.source(sourcingConditionFor(SECOND_AGGREGATE_ID))).blockLast();
+                transaction.appendEvent(eventFor(FIRST_AGGREGATE_ID));
+                transaction.appendEvent(eventFor(SECOND_AGGREGATE_ID));
+            });
+            awaitSuccessfulCompletion(uow.execute());
+
+            // then the condition reaching the storage engine still holds a position for both aggregates, so each
+            // event continues the event stream of its own aggregate
+            assertThat(aggregateStorageEngine.assignedSequenceNumbers)
+                    .as("A sequence number of 0 means the aggregate lost its position while the sourcing markers "
+                                + "were combined, restarting its event stream and colliding with its existing events")
+                    .containsExactlyInAnyOrderEntriesOf(Map.of(FIRST_AGGREGATE_ID, 3L, SECOND_AGGREGATE_ID, 7L));
+        }
+
+        private EventStoreTransaction aggregateBasedTransactionFor(ProcessingContext context) {
+            return context.computeResourceIfAbsent(
+                    testEventStoreTransactionKey,
+                    () -> new DefaultEventStoreTransaction(
+                            aggregateStorageEngine,
+                            context,
+                            // The payload of an event carries the identifier of the aggregate it belongs to.
+                            event -> new GenericTaggedEventMessage<>(
+                                    event, Set.of(new Tag("aggregateIdentifier", (String) event.payload()))
+                            )
+                    )
+            );
+        }
+
+        private static SourcingCondition sourcingConditionFor(String aggregateIdentifier) {
+            return SourcingCondition.conditionFor(
+                    EventCriteria.havingTags(new Tag("aggregateIdentifier", aggregateIdentifier))
+            );
+        }
+
+        private static EventMessage eventFor(String aggregateIdentifier) {
+            return new GenericEventMessage(new MessageType("test", "event", "0.0.1"), aggregateIdentifier);
+        }
+
+        /**
+         * Minimal aggregate-based {@link EventStorageEngine}. It reports an {@link AggregateBasedConsistencyMarker} for
+         * every sourced aggregate, and derives the sequence number of each appended event from the marker of the
+         * {@link AppendCondition} it receives, which is how an aggregate-based storage engine numbers its events.
+         */
+        private static class AggregateBasedStorageEngine implements EventStorageEngine {
+
+            private final Map<String, Long> lastSequenceNumbers;
+            private final Map<String, Long> assignedSequenceNumbers = new HashMap<>();
+
+            private AggregateBasedStorageEngine(Map<String, Long> lastSequenceNumbers) {
+                this.lastSequenceNumbers = lastSequenceNumbers;
+            }
+
+            @Override
+            public MessageStream<EventMessage> source(SourcingCondition condition,
+                                                      @Nullable ProcessingContext context) {
+                String aggregateIdentifier = AggregateBasedEventStorageEngineUtils.resolveAggregateIdentifier(
+                        condition.criteria().flatten().iterator().next().tags()
+                );
+                ConsistencyMarker marker = new AggregateBasedConsistencyMarker(
+                        aggregateIdentifier, lastSequenceNumbers.get(aggregateIdentifier)
+                );
+                return MessageStream.<EventMessage>empty()
+                                    .concatWith(MessageStream.fromFuture(
+                                            CompletableFuture.completedFuture(TerminalEventMessage.INSTANCE),
+                                            unused -> Context.with(ConsistencyMarker.RESOURCE_KEY, marker)
+                                    ));
+            }
+
+            @Override
+            public CompletableFuture<AppendTransaction<?>> appendEvents(AppendCondition condition,
+                                                                        @Nullable ProcessingContext context,
+                                                                        List<TaggedEventMessage<?>> events) {
+                var sequencer = AggregateBasedConsistencyMarker.from(condition).createSequencer();
+                for (TaggedEventMessage<?> taggedEvent : events) {
+                    String aggregateIdentifier =
+                            AggregateBasedEventStorageEngineUtils.resolveAggregateIdentifier(taggedEvent.tags());
+                    assignedSequenceNumbers.put(aggregateIdentifier,
+                                                sequencer.incrementAndGetSequenceOf(aggregateIdentifier));
+                }
+                // Nothing is persisted, so there is no transactional work to perform on commit.
+                return CompletableFuture.completedFuture(EmptyAppendTransaction.INSTANCE);
+            }
+
+            @Override
+            public MessageStream<EventMessage> stream(StreamingCondition condition) {
+                throw new UnsupportedOperationException("Not used by this test");
+            }
+
+            @Override
+            public CompletableFuture<TrackingToken> firstToken() {
+                throw new UnsupportedOperationException("Not used by this test");
+            }
+
+            @Override
+            public CompletableFuture<TrackingToken> latestToken() {
+                throw new UnsupportedOperationException("Not used by this test");
+            }
+
+            @Override
+            public CompletableFuture<TrackingToken> tokenAt(Instant at) {
+                throw new UnsupportedOperationException("Not used by this test");
+            }
+
+            @Override
+            public void describeTo(ComponentDescriptor descriptor) {
+                descriptor.describeProperty("lastSequenceNumbers", lastSequenceNumbers);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #4815

## What changed

`doLowerBound` was an unconditional `throw new UnsupportedOperationException("Not implemented yet")`. `DefaultEventStoreTransaction.updateAppendPosition:152` is its single production caller and runs on every sourcing after the first in one processing context, so any command handler that loaded two entities, or the same entity twice, failed on the JPA event store while working on the in-memory one.

It is now the mirror of `doUpperBound`: both delegate to one helper that takes the union of aggregate identifiers and picks the lowest or highest recorded position per identifier.

## Union, not intersection

The aggregate-based engine derives the next event's sequence number from a marker's position. Intersection semantics would drop an identifier only one marker knows about and silently reset that aggregate to sequence 0, losing its conflict detection. Driving the real caller with an intersection implementation instead:

```
union (this PR):  consistencyMarker={agg-A=3, agg-B=8}   next sequence A=3, B=8   PASS
intersection:     consistencyMarker={}                   expected: 3L but was: 0L
```

Intersection collapses to the empty marker, so `positionOf`'s `getOrDefault(id, 0L)` restarts both aggregates at sequence 0 and the unique key rejects every multi-entity command. `AggregateBasedJpaEventStorageEngine.combineAggregateMarkers:336` already reduces per-aggregate markers with `upperBound`, so the interface Javadoc's scalar reading is what is out of step.

## `doUpperBound` is unchanged

The refactor swapped a hand-rolled `if (!containsKey || get < seq) put` for `merge(id, position, Math::max)`. Identical semantics: absent means put, present means max, and `Math::max` never returns null so `merge` never removes a key. A differential over 20,000 random map pairs against a verbatim reimplementation of the old branch shows zero divergence. `merge` is also strictly more robust on a null-valued key, where the old code NPEs.

The genuine pre-existing oracle is `sourcingFromTwoAggregateStreamsReturnsACombinedStream`, which compares against a marker built by the append path. It passes.

## Pinned where the consequence is visible

`DefaultEventStoreTransactionTest.SourcingMultipleAggregates` sources two aggregates in one processing context and asserts the sequence numbers the engine derives from the resulting `AppendCondition` are 3 and 7, not 0. Under an intersection implementation it fails with a message that names the consequence rather than the mechanism:

```
[A sequence number of 0 means the aggregate lost its position while the sourcing markers were
 combined, restarting its event stream and colliding with its existing events]
Expecting map: {"aggregate-one"=0L, "aggregate-two"=0L}
to contain only: ["aggregate-one"=3L, "aggregate-two"=7L]
```

`ConsistencyMarker`'s class Javadoc now records that a marker need not describe a single position, that an implementation may track one per key, and that the bounds combine per key over the keys of **both** markers -- including the disjoint consequence. The scalar sentences on `lowerBound` and `upperBound` are untouched, so `GlobalIndexConsistencyMarker` still reads correctly.

## Tests

| Run | Result |
|---|---|
| `AggregateBasedConsistencyMarkerTest`, `DefaultEventStoreTransactionTest` | 7 + 19 testcases, 0 failures |
| `AggregateBasedJpaEventStorageEngineIT` | 33 testcases, 0 failures |

On unfixed code the new `LowerBound` cases error with `UnsupportedOperationException: Not implemented yet` at `AggregateBasedConsistencyMarker.java:80`.

## Not in scope

Fixing this marker does not make multi-entity command handling work on the aggregate-based store. A second, by-design limitation sits behind it -- `TooManyTagsOnEventMessageException` -- described in #4815.
