### PR TITLE
[#4797] Match segments against pre-resolved sequence identifiers

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -194,8 +194,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
         if (SequencingPolicy.BROADCAST.equals(sequenceIdentifier)) {
             return true;
         }
-        return new SegmentMatcher((e, ctx) -> Optional.of(sequenceIdentifier))
-                .matches(segment, event, context);
+        return SegmentMatcher.matches(segment, sequenceIdentifier);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/ProcessorEventHandlingComponents.java
@@ -196,8 +196,7 @@ public class ProcessorEventHandlingComponents implements DescribableComponent {
         if (sequenceIdentifier == SequencingPolicy.BROADCAST) {
             return true;
         }
-        return new SegmentMatcher((e, ctx) -> Optional.of(sequenceIdentifier))
-                .matches(segment, event, context);
+        return SegmentMatcher.matches(segment, sequenceIdentifier);
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilter.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Default implementation of a {@link WorkPackage.EventFilter} that filters events based on the
@@ -111,9 +110,7 @@ class DefaultWorkPackageEventFilter implements WorkPackage.EventFilter {
             if (sequenceIdentifiers.contains(SequencingPolicy.BROADCAST)) {
                 return true;
             }
-            return sequenceIdentifiers.stream().anyMatch(identifier -> new SegmentMatcher(
-                    (e, ctx) -> Optional.of(identifier)).matches(segment, eventMessage, context)
-            );
+            return sequenceIdentifiers.stream().anyMatch(identifier -> SegmentMatcher.matches(segment, identifier));
         } catch (Exception e) {
             errorHandler.handleError(
                     new ErrorContext(eventProcessor, e, Collections.singletonList(eventMessage), context)

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilter.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/DefaultWorkPackageEventFilter.java
@@ -33,7 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Default implementation of a {@link WorkPackage.EventFilter} that filters events based on the
@@ -115,9 +114,7 @@ class DefaultWorkPackageEventFilter implements WorkPackage.EventFilter {
             if (sequenceIdentifiers.contains(SequencingPolicy.BROADCAST)) {
                 return true;
             }
-            return sequenceIdentifiers.stream().anyMatch(identifier -> new SegmentMatcher(
-                    (e, ctx) -> Optional.of(identifier)).matches(segment, eventMessage, context)
-            );
+            return sequenceIdentifiers.stream().anyMatch(identifier -> SegmentMatcher.matches(segment, identifier));
         } catch (Exception e) {
             errorHandler.handleError(
                     new ErrorContext(eventProcessor, e, Collections.singletonList(eventMessage), context)

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentMatcher.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentMatcher.java
@@ -17,64 +17,39 @@
 package org.axonframework.messaging.eventhandling.processing.streaming.segmenting;
 
 import org.axonframework.common.annotation.Internal;
-import org.axonframework.messaging.core.sequencing.SequencingPolicy;
-import org.axonframework.messaging.core.unitofwork.ProcessingContext;
-import org.axonframework.messaging.eventhandling.EventMessage;
 
 import java.util.Objects;
 
 /**
- * Utility class that matches {@link EventMessage EventMessages} against a {@link Segment} based on a
- * {@link SequencingPolicy}.
+ * Utility class that matches a resolved sequence identifier against a {@link Segment}.
  * <p>
- * This class uses the sequencing policy to determine the sequence identifier for a message, and then checks if that
- * identifier matches the given segment.
+ * The sequence identifier is expected to be resolved through
+ * {@link org.axonframework.messaging.eventhandling.EventHandlingComponent#sequenceIdentifierFor(org.axonframework.messaging.eventhandling.EventMessage,
+ * org.axonframework.messaging.core.unitofwork.ProcessingContext)} before matching, so any fallback for a
+ * {@link org.axonframework.messaging.core.sequencing.SequencingPolicy} that resolves no identifier is applied in a
+ * single place. This guarantees that scheduling and handling route an event to the same segment.
  *
  * @author Mateusz Nowak
  * @since 5.0.0
  */
 @Internal
-public class SegmentMatcher {
+public final class SegmentMatcher {
 
-    private final SequencingPolicy<? super EventMessage> sequencingPolicy;
-
-    /**
-     * Initialize a SegmentMatcher with the given {@code sequencingPolicy}. This policy is used to extract the sequence
-     * identifier from messages, which is then used to match against segments.
-     *
-     * @param sequencingPolicy A policy that provides the sequence identifier for a given event message.
-     */
-    public SegmentMatcher(SequencingPolicy<? super EventMessage> sequencingPolicy) {
-        Objects.requireNonNull(sequencingPolicy, "SequencingPolicy may not be null");
-        this.sequencingPolicy = sequencingPolicy;
+    private SegmentMatcher() {
+        // Utility class
     }
 
     /**
-     * Checks whether the given {@code segment} matches the given {@code event}, based on the configured sequencing
-     * policy.
+     * Checks whether the given {@code segment} matches the given {@code sequenceIdentifier}, based on the
+     * {@link Objects#hashCode(Object) hash code} of the identifier.
      *
-     * @param segment The segment to match against.
-     * @param event The event to check.
-     * @param context The processing context in which the event is being handled.
-
-     * @return {@code true} if the event matches the segment, {@code false} otherwise.
+     * @param segment            the segment to match against
+     * @param sequenceIdentifier the resolved sequence identifier of the event to match
+     * @return {@code true} if the sequence identifier matches the segment, {@code false} otherwise
      */
-    public boolean matches(Segment segment, EventMessage event, ProcessingContext context) {
+    public static boolean matches(Segment segment, Object sequenceIdentifier) {
         Objects.requireNonNull(segment, "Segment may not be null");
-        Objects.requireNonNull(event, "EventMessage may not be null");
-        return segment.matches(Objects.hashCode(sequenceIdentifier(event, context)));
-    }
-
-    /**
-     * Returns the sequence identifier for the given {@code event}, as defined by the configured sequencing policy. If
-     * the policy returns {@code null}, the event's identifier is used as a fallback.
-     *
-     * @param event The event to get the sequence identifier for.
-     * @param context The processing context in which the event is being handled.
-     * @return The sequence identifier for the event, never {@code null}.
-     */
-    public Object sequenceIdentifier(EventMessage event, ProcessingContext context) {
-        Objects.requireNonNull(event, "EventMessage may not be null");
-        return sequencingPolicy.sequenceIdentifierFor(event, context).orElseGet(event::identifier);
+        Objects.requireNonNull(sequenceIdentifier, "Sequence identifier may not be null");
+        return segment.matches(Objects.hashCode(sequenceIdentifier));
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentMatcherTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentMatcherTest.java
@@ -16,20 +16,10 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.segmenting;
 
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.EventTestUtils;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
-import org.axonframework.messaging.core.MessageType;
-import org.axonframework.messaging.core.Metadata;
-import org.axonframework.messaging.core.QualifiedName;
-import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.junit.jupiter.api.*;
 
-import java.time.Instant;
-import java.util.Optional;
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test class for {@link SegmentMatcher}.
@@ -39,52 +29,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 class SegmentMatcherTest {
 
     @Test
-    void matchesReturnsTrueWhenSegmentMatchesEventBasedOnSequenceIdentifier() {
-        //given
-        SegmentMatcher testSubject = new SegmentMatcher((message, context) -> Optional.of("sample-identifier"));
-        EventMessage testMessage = EventTestUtils.asEventMessage("test-payload");
-        Segment segment = new Segment(0, 0); // Root segment matches everything
+    void matchesReturnsTrueWhenSegmentMatchesSequenceIdentifier() {
+        // given the root segment, which matches every sequence identifier
+        Segment rootSegment = Segment.ROOT_SEGMENT;
 
-        //when
-        boolean result = testSubject.matches(segment, testMessage, new StubProcessingContext());
+        // when
+        boolean result = SegmentMatcher.matches(rootSegment, "sample-identifier");
 
-        //then
+        // then
         assertThat(result).isTrue();
     }
 
     @Test
-    void usesEventMessageIdentifierAsSequenceIdentifierWhenPolicyReturnsNull() {
-        //given
-        SegmentMatcher testSubject = new SegmentMatcher((message, context) -> Optional.empty());
-        String messageId = UUID.randomUUID().toString();
-        MessageType messageType = new MessageType(new QualifiedName(String.class));
-        EventMessage testMessage = EventTestUtils.asEventMessage(
-                new GenericEventMessage(messageId,
-                                          messageType,
-                                          "test-payload",
-                                          Metadata.emptyInstance(),
-                                          Instant.now()));
-        Segment segment = Segment.ROOT_SEGMENT; // Matches everything
+    void matchesReturnsFalseWhenSegmentDoesNotMatchSequenceIdentifier() {
+        // given a segment that matches identifiers with an odd hash
+        Segment oddSegment = new Segment(1, 1);
+        String evenIdentifier = "even"; // "even" has a hash code of 3021508, which is even
 
-        //when
-        boolean result = testSubject.matches(segment, testMessage, new StubProcessingContext());
+        // when
+        boolean result = SegmentMatcher.matches(oddSegment, evenIdentifier);
 
-        //then
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void matchesReturnsFalseWhenSegmentDoesNotMatchEventBasedOnSequenceIdentifier() {
-        //given
-        Segment segmentEven = new Segment(1, 1); // Will match events with odd hash
-        String sequenceId = "even"; // "even" has a hash code of 3021508, which is even
-        SegmentMatcher testSubject = new SegmentMatcher((message, context) -> Optional.of(sequenceId));
-        EventMessage oddMessage = EventTestUtils.asEventMessage("test-payload");
-
-        //when
-        boolean result = testSubject.matches(segmentEven, oddMessage, new StubProcessingContext());
-
-        //then
+        // then
         assertThat(result).isFalse();
+    }
+
+    @Test
+    void matchesRejectsNullSegmentAndNullSequenceIdentifier() {
+        // given the resolved sequence identifier contract: callers apply any fallback before matching
+        // when / then
+        assertThatThrownBy(() -> SegmentMatcher.matches(null, "sample-identifier"))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> SegmentMatcher.matches(Segment.ROOT_SEGMENT, null))
+                .isInstanceOf(NullPointerException.class);
     }
 }


### PR DESCRIPTION
Builds on top of #4818 (targets its branch, so only the refactor shows in the diff). Relates to #4797 and #4803.

## What changed

`SegmentMatcher` carried its own silent empty-Optional fallback (`orElseGet(event::identifier)`), duplicating the fallback that #4818 introduces -- with a warning -- in `SimpleEventHandlingComponent`. The duplicate was dead in production: both call sites (`ProcessorEventHandlingComponents.canHandleInSegment` and `DefaultWorkPackageEventFilter.canHandle`) first resolve the identifier through `EventHandlingComponent#sequenceIdentifierFor` and wrapped the already-resolved value in a constant `(e, ctx) -> Optional.of(identifier)` lambda, so the matcher's policy path was only reachable from its own test.

`SegmentMatcher` is now reduced to the one invariant it actually encodes: matching a segment against the hash of an already-resolved, never-null sequence identifier (`static boolean matches(Segment, Object)`). The policy-based constructor, the dead fallback, and the per-event `new SegmentMatcher(...)` allocation at both call sites are gone.

## Why

Keeping two definitions of what an unresolved sequence identifier means invites drift: a future caller passing a real policy to `SegmentMatcher` would fall back silently while the component path warns, and if either fallback changed independently, an event could be admitted to a segment under one identifier but sequenced under another. After this change, resolution (including the fallback and its warning) lives only in `EventHandlingComponent` implementations, and `SegmentMatcher` guarantees scheduling and handling route an event to the same segment.

Historical note: the policy-holding shape was justified when the class was extracted from `SimpleEventHandlerInvoker` during #3098 (it carried the AF4-style null-to-event-identifier fallback for the invoker). Sequencing ownership has since moved to `EventHandlingComponent#sequenceIdentifierFor`, which left the policy path vestigial.

## Compatibility

`SegmentMatcher` is `@Internal`. Verified no other constructor usage in this repository (including `stash/`) nor in Axoniq Framework, so the signature change is contained.

## Tests

66 tests, 0 failures: `SegmentMatcherTest` (rewritten for the new shape, incl. null-rejection), `DefaultWorkPackageEventFilterTest`, `ProcessorEventHandlingComponentsTest`, `WorkPackageTest`, and the full `SimpleEventHandlingComponentSequencingPolicyTest`. The old "empty Optional falls back to event identifier" test was deleted deliberately: that behavior no longer exists in `SegmentMatcher`; it lives (warned and tested) in `SimpleEventHandlingComponent`.

## Merge note

Merge #4818 first; this PR targets its branch and contains only the one refactor commit on top.