### PR TITLE
[#4874] Preserve assignable payloads without a converter

### DIFF
--- a/common/src/main/java/org/axonframework/common/TypeReference.java
+++ b/common/src/main/java/org/axonframework/common/TypeReference.java
@@ -71,20 +71,18 @@ public abstract class TypeReference<E> {
 
     /**
      * Returns the class of the type of the component represented by this {@code TypeReference}.
+     * <p>
+     * The class is the erasure of the represented type, following the erasure rules of the Java Language
+     * Specification. A {@link Class} erases to itself, a {@link ParameterizedType} to its raw type, a
+     * {@link java.lang.reflect.TypeVariable} to the erasure of its first bound, and a
+     * {@link java.lang.reflect.GenericArrayType} to an array of the erasure of its component type. Any other
+     * {@link Type} erases to {@link Object}.
      *
-     * @return The class of the component.
+     * @return the class of the component
      */
     @SuppressWarnings("unchecked")
     public Class<E> getTypeAsClass() {
-        if (type instanceof Class<?> clazz) {
-            return (Class<E>) clazz;
-        }
-        if (type instanceof ParameterizedType parameterizedType) {
-            return (Class<E>) parameterizedType.getRawType();
-        }
-        throw new IllegalArgumentException(
-                "Internal error: TypeReference constructed with unsupported type: %s".formatted(type)
-        );
+        return (Class<E>) TypeReflectionUtils.erase(type);
     }
 
     /**

--- a/common/src/main/java/org/axonframework/common/TypeReflectionUtils.java
+++ b/common/src/main/java/org/axonframework/common/TypeReflectionUtils.java
@@ -94,9 +94,18 @@ public final class TypeReflectionUtils {
     }
 
     /**
-     * Returns the erasure of the given type.
+     * Returns the erasure of the given {@code type}, following the erasure rules of the Java Language Specification.
+     * <p>
+     * A {@link Class} erases to itself, a {@link ParameterizedType} to its raw type, a {@link TypeVariable} to the
+     * erasure of its first bound, and a {@link GenericArrayType} to an array of the erasure of its component type. Any
+     * other {@link Type} erases to {@link Object}.
+     * <p>
+     * This method is package-private because it exposes the framework's implementation-specific type-erasure handling.
+     *
+     * @param type the type to return the erasure for
+     * @return the erasure of the given {@code type}
      */
-    private static Class<?> erase(Type type) {
+    static Class<?> erase(Type type) {
         if (type instanceof Class) {
             return (Class<?>) type;
         } else if (type instanceof ParameterizedType) {

--- a/common/src/test/java/org/axonframework/common/TypeReferenceTest.java
+++ b/common/src/test/java/org/axonframework/common/TypeReferenceTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test class validating the {@link TypeReference}.
+ *
+ * @author Mateusz Nowak
+ */
+class TypeReferenceTest {
+
+    @Nested
+    class GetTypeAsClass {
+
+        @Test
+        void returnsClassItselfForNonGenericType() {
+            // given
+            TypeReference<String> testSubject = new TypeReference<>() {
+            };
+
+            // when
+            Class<String> result = testSubject.getTypeAsClass();
+
+            // then
+            assertThat(result).isEqualTo(String.class);
+        }
+
+        @Test
+        void returnsRawTypeForParameterizedType() {
+            // given
+            TypeReference<Map<String, Object>> testSubject = new TypeReference<>() {
+            };
+
+            // when
+            Class<Map<String, Object>> result = testSubject.getTypeAsClass();
+
+            // then
+            assertThat(result).isEqualTo(Map.class);
+        }
+
+        @Test
+        void returnsArrayOfErasedComponentTypeForGenericArrayType() {
+            // given
+            TypeReference<List<String>[]> testSubject = new TypeReference<>() {
+            };
+
+            // when
+            Class<List<String>[]> result = testSubject.getTypeAsClass();
+
+            // then
+            assertThat(result).isEqualTo(List[].class);
+        }
+
+        @Test
+        void returnsFirstBoundForBoundedTypeVariable() {
+            // given
+            TypeReference<CharSequence> testSubject = boundedTypeVariableTypeReference();
+
+            // when
+            Class<CharSequence> result = testSubject.getTypeAsClass();
+
+            // then
+            assertThat(result).isEqualTo(CharSequence.class);
+        }
+
+        @Test
+        void returnsObjectForUnboundedTypeVariable() {
+            // given
+            TypeReference<Object> testSubject = unboundedTypeVariableTypeReference();
+
+            // when
+            Class<Object> result = testSubject.getTypeAsClass();
+
+            // then
+            assertThat(result).isEqualTo(Object.class);
+        }
+
+        private static <X extends CharSequence> TypeReference<X> boundedTypeVariableTypeReference() {
+            return new TypeReference<>() {
+            };
+        }
+
+        private static <X> TypeReference<X> unboundedTypeVariableTypeReference() {
+            return new TypeReference<>() {
+            };
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/GenericMessage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/GenericMessage.java
@@ -191,6 +191,12 @@ public class GenericMessage extends AbstractMessage {
         }
 
         if (converter == null) {
+            if (TypeReference.fromType(type).getTypeAsClass().isAssignableFrom(payloadType())) {
+                // Without a converter the type arguments cannot be converted or validated. As the payload is already
+                // assignable to the requested type's erasure, return it as is instead of failing.
+                //noinspection unchecked
+                return (T) payload();
+            }
             throw new ConversionException("Cannot convert " + payloadType() + " to " + type + " without a converter.");
         }
         return convertedPayloads.convertIfAbsent(type, converter);

--- a/messaging/src/test/java/org/axonframework/messaging/core/MessageTestSuite.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/MessageTestSuite.java
@@ -54,6 +54,10 @@ public abstract class MessageTestSuite<M extends Message> {
     };
     private static final TypeReference<List<Integer>> PARAMETERIZED_LIST_TYPE_REF = new TypeReference<>() {
     };
+    private static final TypeReference<Map<String, Object>> PARAMETERIZED_MAP_TYPE_REF = new TypeReference<>() {
+    };
+    private static final TypeReference<List<String>[]> PARAMETERIZED_ARRAY_TYPE_REF = new TypeReference<>() {
+    };
 
     /**
      * Builds a default {@link Message} used by this test suite.
@@ -246,11 +250,102 @@ public abstract class MessageTestSuite<M extends Message> {
     }
 
     @Test
-    void payloadAsWithParameterizedTypeReferencePreservesGenericTypeInsteadOfRawClass() {
-        M testSubject = buildMessage(List.of("a", "b"));
+    void payloadAsWithParameterizedTypeReferencePassesFullGenericTypeToConverter() {
+        // given
+        List<String> testPayload = List.of("a", "b");
+        List<Integer> convertedPayload = List.of(1, 2);
+        Converter stubbedConverter = spy(CONVERTER);
+        // Only a converter invocation with the full generic type returns the converted payload.
+        doReturn(convertedPayload).when(stubbedConverter).convert(testPayload, PARAMETERIZED_LIST_TYPE_REF.getType());
 
-        assertThatThrownBy(() -> testSubject.payloadAs(PARAMETERIZED_LIST_TYPE_REF))
+        M testSubject = buildMessage(testPayload);
+
+        // when
+        List<Integer> result = testSubject.payloadAs(PARAMETERIZED_LIST_TYPE_REF, stubbedConverter);
+
+        // then
+        assertThat(result).isSameAs(convertedPayload);
+    }
+
+    @Test
+    void payloadAsWithParameterizedTypeReferenceWithoutConverterReturnsPayloadWhenRawTypeIsAssignable() {
+        // given
+        Map<String, Object> testPayload = Map.of("key", "value");
+
+        M testSubject = buildMessage(testPayload);
+
+        // when
+        Map<String, Object> result = testSubject.payloadAs(PARAMETERIZED_MAP_TYPE_REF, null);
+
+        // then
+        assertThat(result).isSameAs(testPayload);
+    }
+
+    @Test
+    void payloadAsWithParameterizedTypeReferenceOnMessageWithoutConverterReturnsPayloadWhenRawTypeIsAssignable() {
+        // given
+        Map<String, Object> testPayload = Map.of("key", "value");
+
+        M testSubject = buildMessage(testPayload);
+
+        // when
+        Map<String, Object> result = testSubject.payloadAs(PARAMETERIZED_MAP_TYPE_REF);
+
+        // then
+        assertThat(result).isSameAs(testPayload);
+    }
+
+    @Test
+    void payloadAsWithParameterizedTypeReferenceWithoutConverterThrowsWhenRawTypeIsNotAssignable() {
+        // given
+        M testSubject = buildMessage(STRING_PAYLOAD);
+
+        // when / then
+        assertThatThrownBy(() -> testSubject.payloadAs(PARAMETERIZED_LIST_TYPE_REF, null))
                 .isExactlyInstanceOf(ConversionException.class);
+    }
+
+    @Test
+    void payloadAsWithGenericArrayTypeReferenceWithoutConverterReturnsPayloadWhenErasedTypeIsAssignable() {
+        // given
+        @SuppressWarnings("unchecked")
+        List<String>[] testPayload = new List[]{List.of("a")};
+
+        M testSubject = buildMessage(testPayload);
+
+        // when
+        List<String>[] result = testSubject.payloadAs(PARAMETERIZED_ARRAY_TYPE_REF, null);
+
+        // then
+        assertThat(result).isSameAs(testPayload);
+    }
+
+    @Test
+    void payloadAsWithGenericArrayTypeReferenceWithoutConverterThrowsWhenErasedTypeIsNotAssignable() {
+        // given
+        M testSubject = buildMessage(STRING_PAYLOAD);
+
+        // when / then
+        assertThatThrownBy(() -> testSubject.payloadAs(PARAMETERIZED_ARRAY_TYPE_REF, null))
+                .isExactlyInstanceOf(ConversionException.class);
+    }
+
+    @Test
+    void payloadAsWithTypeVariableTypeReferenceWithoutConverterReturnsPayloadAsIs() {
+        // given
+        // A type variable erases to its bound, Object in this case, to which any payload is assignable.
+        M testSubject = buildMessage(STRING_PAYLOAD);
+
+        // when
+        String result = testSubject.payloadAs(MessageTestSuite.<String>typeVariableTypeReference(), null);
+
+        // then
+        assertThat(result).isSameAs(STRING_PAYLOAD);
+    }
+
+    private static <X> TypeReference<X> typeVariableTypeReference() {
+        return new TypeReference<>() {
+        };
     }
 
     @Test


### PR DESCRIPTION
## Summary

This change restores pass-through behavior for payloads that are already assignable to a requested parameterized type when a `GenericMessage` has no `Converter`.

It:

- checks the erasure of a requested `Type` before failing due to a missing converter
- returns the original payload only when its declared payload type is assignable to that erasure
- keeps converter-backed requests generic-aware and continues passing the complete parameterized `Type` to the converter
- makes `TypeReference#getTypeAsClass()` consistently derive an erased runtime class for classes, parameterized types, type variables, and generic arrays
- keeps the shared erasure helper package-private
- adds regression coverage for parameterized maps and lists, generic arrays, bounded and unbounded type variables, converter-backed conversion, and incompatible payloads

## Background

Issue #4874 corrected `Message#payloadAs(TypeReference)` so that generic type information is no longer discarded. Before that correction, a request such as `TypeReference<List<Integer>>` was reduced to `List.class`, preventing a converter from seeing the element type.

The correction routes a `TypeReference` through the `Type`-based payload conversion path. That preserves generic information, but it also exposed a follow-on regression for messages without a converter.

## Root cause

`GenericMessage#payloadAs(Type, Converter)` has a direct pass-through shortcut for assignable `Class` targets. A parameterized target such as `Map<String, Object>`, however, is represented by a `ParameterizedType`, not a `Class`. It therefore bypasses that shortcut.

For an in-memory message:

```java
Map<String, Object> payload = Map.of("orderId", "123");
Message message = new GenericMessage(new MessageType("example"), payload);

Map<String, Object> result = message.payloadAs(
        new TypeReference<Map<String, Object>>() {
        }
);
```

the payload is already a `Map`, but the parameterized target reaches the missing-converter branch and throws a `ConversionException`. This affects locally created messages, test fixtures, and locally applied events, where no serialization boundary introduced a converter.

## Fix

When no converter is available, the method now derives the requested type's erasure and applies the same assignability rule used by the existing `Class` shortcut.

For example:

- `Map<String, Object>` erases to `Map.class`
- `List<String>[]` erases to `List[].class`
- `T extends CharSequence` erases to `CharSequence.class`
- an unbounded `T` erases to `Object.class`

If the declared payload type is assignable to the erased target, the original payload is returned. Otherwise, the existing `ConversionException` is still raised.

This fallback is intentionally limited to the no-converter case. Without a converter, the generic arguments cannot be converted or validated at runtime anyway, so checking erasure is no less safe than the existing `payloadAs(Class)` pass-through. When a converter is present, the implementation still delegates using the complete `Type`; the generic-awareness introduced for #4874 remains intact.

## Type-erasure utility

`TypeReference#getTypeAsClass()` now delegates to the existing reflection-based erasure logic in `TypeReflectionUtils`. This removes duplicated handling for `Class` and `ParameterizedType` and also supports legal `TypeReference` shapes that previously caused `getTypeAsClass()` to throw, notably type variables and generic arrays.

The `erase(Type)` helper remains package-private and is documented as framework implementation detail rather than public API. It intentionally does not use the cross-package `@Internal` annotation, because importing `org.axonframework.common.annotation` from the parent `org.axonframework.common` package would introduce a package dependency cycle.

## Compatibility and impact

- Existing `Class`-based pass-through behavior is unchanged.
- Null/`Void` payload behavior is unchanged.
- Converter-backed parameterized conversion remains unchanged and retains full generic type information.
- Incompatible payloads without a converter continue to fail with `ConversionException`.
- Assignable in-memory payloads no longer require a converter solely because the requested type is parameterized.

## Verification

- `./mvnw -pl common -Dtest=ArchitectureTest,TypeReferenceTest test`
  - architecture rules and 5 type-erasure tests passed
- focused inherited `MessageTestSuite` coverage across generic command, event, query, result, reset-context, and subscription-update message implementations
  - 342 tests passed
- `git diff --check` passed

Follow-up to #4874.
