### PR TITLE
[#4904] Ensure `HierarchicalStateManager` supports Entity-subtype search

### DIFF
--- a/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
@@ -85,7 +85,13 @@ public class HierarchicalStateManager implements StateManager {
      * Delegates such as {@link SimpleStateManager} complete their {@link CompletableFuture} exceptionally rather than
      * throwing {@link MissingRepositoryException} synchronously, so the parent fallback is expressed with
      * {@link CompletableFuture#exceptionallyCompose(java.util.function.Function)} rather than a
-     * {@code try}/{@code catch}. Any other exception is propagated to the caller unchanged.
+     * {@code try}/{@code catch}. The child call is nonetheless wrapped in
+     * {@link FutureUtils#runFailing(java.util.function.Supplier)} so a delegate that still throws
+     * {@link MissingRepositoryException} synchronously also triggers the fallback. Any other exception is propagated to
+     * the caller unchanged. Only {@link MissingRepositoryException} triggers the fallback; a
+     * {@link LoadedEntityNotOfExpectedTypeException}, for instance, does not, since by the time it surfaces the child's
+     * {@code loadOrCreate} may already have attached state to the {@link ProcessingContext}, making a retry against the
+     * parent unsound.
      */
     @Override
     public <I, T> CompletableFuture<ManagedEntity<I, T>> loadManagedEntity(Class<T> type,

--- a/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
@@ -22,6 +22,7 @@ import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
+import org.jspecify.annotations.Nullable;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -113,7 +114,7 @@ public class HierarchicalStateManager implements StateManager {
     }
 
     @Override
-    public <I, T> Repository<I, T> repository(Class<T> entityType, Class<I> idType) {
+    public <I, T> @Nullable Repository<I, T> repository(Class<T> entityType, Class<I> idType) {
         Repository<I, T> childRepository = child.repository(entityType, idType);
         if (childRepository != null) {
             return childRepository;

--- a/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling;
 
+import org.axonframework.common.FutureUtils;
 import org.axonframework.common.configuration.Module;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -67,17 +68,32 @@ public class HierarchicalStateManager implements StateManager {
         return this;
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Delegates directly to {@code StateManager#loadManagedEntity(Class, Object, ProcessingContext)} of the
+     * {@link #getChild() child}, falling back to the {@link #getParent() parent} when the child completes exceptionally
+     * with a {@link MissingRepositoryException}. Delegating the load itself, rather than first locating a
+     * {@link Repository} through {@link #repository(Class, Class)} and invoking it here, ensures each delegate applies
+     * its own resolution semantics for {@code type}. {@link SimpleStateManager}, for instance, resolves a
+     * {@link Repository} registered for a supertype when asked for a subtype, whereas {@link #repository(Class, Class)}
+     * only matches the exact registered type. Re-implementing that resolution here would either duplicate or diverge
+     * from the delegate's own behavior; calling {@code loadManagedEntity} avoids that entirely, and still composes
+     * correctly when the delegate is itself a {@code HierarchicalStateManager}.
+     * <p>
+     * Delegates such as {@link SimpleStateManager} complete their {@link CompletableFuture} exceptionally rather than
+     * throwing {@link MissingRepositoryException} synchronously, so the parent fallback is expressed with
+     * {@link CompletableFuture#exceptionallyCompose(java.util.function.Function)} rather than a
+     * {@code try}/{@code catch}. Any other exception is propagated to the caller unchanged.
+     */
     @Override
     public <I, T> CompletableFuture<ManagedEntity<I, T>> loadManagedEntity(Class<T> type,
                                                                            I id,
                                                                            ProcessingContext context) {
-        //noinspection unchecked
-        Class<I> idClass = (Class<I>) id.getClass();
-        Repository<I, T> repository = repository(type, idClass);
-        if (repository != null) {
-            return repository.loadOrCreate(id, context);
-        }
-        throw new MissingRepositoryException(id.getClass(), type);
+        return child.loadManagedEntity(type, id, context)
+                    .exceptionallyCompose(ex -> FutureUtils.unwrap(ex) instanceof MissingRepositoryException
+                            ? parent.loadManagedEntity(type, id, context)
+                            : CompletableFuture.failedFuture(ex));
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/HierarchicalStateManager.java
@@ -91,10 +91,10 @@ public class HierarchicalStateManager implements StateManager {
     public <I, T> CompletableFuture<ManagedEntity<I, T>> loadManagedEntity(Class<T> type,
                                                                            I id,
                                                                            ProcessingContext context) {
-        return child.loadManagedEntity(type, id, context)
-                    .exceptionallyCompose(ex -> FutureUtils.unwrap(ex) instanceof MissingRepositoryException
-                            ? parent.loadManagedEntity(type, id, context)
-                            : CompletableFuture.failedFuture(ex));
+        return FutureUtils.runFailing(() -> child.loadManagedEntity(type, id, context))
+                          .exceptionallyCompose(ex -> FutureUtils.unwrap(ex) instanceof MissingRepositoryException
+                                  ? parent.loadManagedEntity(type, id, context)
+                                  : CompletableFuture.failedFuture(ex));
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
@@ -63,31 +63,29 @@ public class SimpleStateManager implements StateManager {
         this.name = name;
     }
 
-    @SuppressWarnings({"unchecked", "DataFlowIssue", "OptionalIsPresent"})
+    @SuppressWarnings("unchecked")
     @Override
-    public <I, T> CompletableFuture<ManagedEntity<I, T>> loadManagedEntity(
-            Class<T> entityType,
-            I id,
-            ProcessingContext context
-    ) {
-        Optional<Repository<I, T>> repository = repositories
+    public <I, T> CompletableFuture<ManagedEntity<I, T>> loadManagedEntity(Class<T> entityType,
+                                                                           I id,
+                                                                           ProcessingContext context) {
+        return repositories
                 .stream()
                 .filter(r -> r.entityType().isAssignableFrom(entityType))
                 .filter(r -> r.idType().isAssignableFrom(id.getClass()))
                 .map(r -> (Repository<I, T>) r)
-                .findFirst();
-        if (repository.isEmpty()) {
-            return CompletableFuture.failedFuture(new MissingRepositoryException(id.getClass(), entityType));
-        }
-
-        return repository.get()
-                         .loadOrCreate(id, context)
-                         .thenApply(me -> {
-                             if (me.entity() != null && !entityType.isInstance(me.entity())) {
-                                 throw new LoadedEntityNotOfExpectedTypeException(me.entity().getClass(), entityType);
-                             }
-                             return me;
-                         });
+                .findFirst()
+                .map(repository -> repository.loadOrCreate(id, context)
+                                             .thenApply(me -> {
+                                                 if (me.entity() != null && !entityType.isInstance(me.entity())) {
+                                                     throw new LoadedEntityNotOfExpectedTypeException(
+                                                             me.entity().getClass(), entityType
+                                                     );
+                                                 }
+                                                 return me;
+                                             }))
+                .orElseGet(() -> CompletableFuture.failedFuture(
+                        new MissingRepositoryException(id.getClass(), entityType)
+                ));
     }
 
     @Override

--- a/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
@@ -21,6 +21,7 @@ import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
@@ -31,10 +32,12 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 /**
- * Simple implementation of the {@link StateManager}. Keeps a list of all registered {@link Repository repositories} and
- * delegates the loading of entities to the appropriate repository through the use of
- * {@link Repository#loadOrCreate(Object, ProcessingContext)}. Throws a {@link MissingRepositoryException} if no
- * repository is found for the given entity type and the provided id.
+ * Simple implementation of the {@link StateManager}.
+ * <p>
+ * Keeps a list of all registered {@link Repository repositories} and delegates the loading of entities to the
+ * appropriate repository through the use of {@link Repository#loadOrCreate(Object, ProcessingContext)}. Completes the
+ * returned {@link CompletableFuture} exceptionally with a {@link MissingRepositoryException} if no repository is found
+ * for the given entity type and the provided id.
  *
  * @author Mitchell Herrijgers
  * @see StateManager
@@ -60,7 +63,7 @@ public class SimpleStateManager implements StateManager {
         this.name = name;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "DataFlowIssue", "OptionalIsPresent"})
     @Override
     public <I, T> CompletableFuture<ManagedEntity<I, T>> loadManagedEntity(
             Class<T> entityType,
@@ -103,7 +106,7 @@ public class SimpleStateManager implements StateManager {
     }
 
     @Override
-    public <I, T> Repository<I, T> repository(Class<T> entityType, Class<I> idType) {
+    public <I, T> @Nullable Repository<I, T> repository(Class<T> entityType, Class<I> idType) {
         //noinspection unchecked
         return (Repository<I, T>) repositories.stream()
                                               .filter(r -> r.entityType().equals(entityType))

--- a/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/SimpleStateManager.java
@@ -67,14 +67,18 @@ public class SimpleStateManager implements StateManager {
             I id,
             ProcessingContext context
     ) {
-        var repository = repositories
+        Optional<Repository<I, T>> repository = repositories
                 .stream()
                 .filter(r -> r.entityType().isAssignableFrom(entityType))
                 .filter(r -> r.idType().isAssignableFrom(id.getClass()))
                 .map(r -> (Repository<I, T>) r)
-                .findFirst()
-                .orElseThrow(() -> new MissingRepositoryException(id.getClass(), entityType));
-        return repository.loadOrCreate(id, context)
+                .findFirst();
+        if (repository.isEmpty()) {
+            return CompletableFuture.failedFuture(new MissingRepositoryException(id.getClass(), entityType));
+        }
+
+        return repository.get()
+                         .loadOrCreate(id, context)
                          .thenApply(me -> {
                              if (me.entity() != null && !entityType.isInstance(me.entity())) {
                                  throw new LoadedEntityNotOfExpectedTypeException(me.entity().getClass(), entityType);

--- a/modelling/src/main/java/org/axonframework/modelling/StateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/StateManager.java
@@ -91,10 +91,9 @@ public interface StateManager extends DescribableComponent {
      * @param id      the id of the state to retrieve
      * @param context the {@link ProcessingContext context} to load the entity in
      * @param <I>     the type of the identifier of the entity
-     * @return a {@link CompletableFuture} which resolves to the entity instance
-     * @throws MissingRepositoryException contained in the resulting {@link CompletableFuture} whenever this
-     *                                    {@code StateManager} does not control the {@link Repository} to load the
-     *                                    entity from
+     * @return a {@link CompletableFuture} which resolves to the entity instance, or completes exceptionally with a
+     * {@link MissingRepositoryException} when this {@code StateManager} does not control the {@link Repository} to
+     * load the entity from
      */
     default <I, T> CompletableFuture<@Nullable T> loadEntity(Class<T> type,
                                                              I id,
@@ -111,10 +110,9 @@ public interface StateManager extends DescribableComponent {
      * @param context the {@link ProcessingContext context} to load the entity in
      * @param <ID>    the type of the identifier of the entity
      * @param <T>     the type of the entity
-     * @return a {@link CompletableFuture} which resolves to the entity instance
-     * @throws MissingRepositoryException contained in the resulting {@link CompletableFuture} whenever this
-     *                                    {@code StateManager} does not control the {@link Repository} to load the
-     *                                    {@link ManagedEntity} from
+     * @return a {@link CompletableFuture} which resolves to the entity instance, or completes exceptionally with a
+     * {@link MissingRepositoryException} when this {@code StateManager} does not control the {@link Repository} to
+     * load the {@link ManagedEntity} from
      */
     <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(Class<T> type,
                                                                       ID id,
@@ -140,6 +138,10 @@ public interface StateManager extends DescribableComponent {
      * Returns the {@link Repository} for the given {@code type}.
      * <p>
      * Returns {@code null} if no repository is registered for the given type and id.
+     * <p>
+     * Unlike {@link #loadManagedEntity(Class, Object, ProcessingContext)}, which resolves a {@link Repository}
+     * registered for a supertype when asked for a subtype, this method only matches an exactly registered
+     * {@code (entityType, idType)} pair. Hence, there is no supertype or subtype resolution.
      *
      * @param <ID>       the type of the identifier of the entity
      * @param <T>        the type of the entity

--- a/modelling/src/main/java/org/axonframework/modelling/StateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/StateManager.java
@@ -23,6 +23,7 @@ import org.axonframework.modelling.repository.Repository;
 import org.axonframework.modelling.repository.SimpleRepository;
 import org.axonframework.modelling.repository.SimpleRepositoryEntityLoader;
 import org.axonframework.modelling.repository.SimpleRepositoryEntityPersister;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -47,12 +48,12 @@ public interface StateManager extends DescribableComponent {
      * Registers an {@link Repository} for use with this {@code StateManager}. The combination of
      * {@link Repository#entityType()} and {@link Repository#idType()} must be unique for all registered repositories.
      *
-     * @param repository The {@link Repository} to use for loading state.
-     * @param <ID>       The type of id.
-     * @param <T>        The type of the entity.
-     * @return This {@code StateManager} for fluent interfacing.
+     * @param repository the {@link Repository} to use for loading state
+     * @param <ID>       the type of id
+     * @param <T>        the type of the entity
+     * @return this {@code StateManager} for fluent interfacing
      * @throws RepositoryAlreadyRegisteredException if a repository with the same entity type and id type is already
-     *                                              registered.
+     *                                              registered
      */
     <ID, T> StateManager register(Repository<ID, T> repository);
 
@@ -60,15 +61,15 @@ public interface StateManager extends DescribableComponent {
      * Registers a load and save function for state type {@code T} with id of type {@code ID}. Creates a
      * {@link SimpleRepository} for the given type with the given load and save functions.
      *
-     * @param idType     The type of the identifier.
-     * @param entityType The type of the state.
-     * @param loader     The function to load state.
-     * @param persister  The function to persist state.
-     * @param <ID>       The type of id.
-     * @param <T>        The type of state.
-     * @return This {@code StateManager} for fluent interfacing.
+     * @param idType     the type of the identifier
+     * @param entityType the type of the state
+     * @param loader     the function to load state
+     * @param persister  the function to persist state
+     * @param <ID>       the type of id
+     * @param <T>        the type of state
+     * @return this {@code StateManager} for fluent interfacing
      * @throws RepositoryAlreadyRegisteredException if a repository with the same entity type and id type is already
-     *                                              registered.
+     *                                              registered
      */
     default <ID, T> StateManager register(Class<ID> idType,
                                           Class<T> entityType,
@@ -95,11 +96,9 @@ public interface StateManager extends DescribableComponent {
      *                                    {@code StateManager} does not control the {@link Repository} to load the
      *                                    entity from
      */
-    default <I, T> CompletableFuture<T> loadEntity(
-            Class<T> type,
-            I id,
-            ProcessingContext context
-    ) {
+    default <I, T> CompletableFuture<@Nullable T> loadEntity(Class<T> type,
+                                                             I id,
+                                                             ProcessingContext context) {
         return loadManagedEntity(type, id, context).thenApply(ManagedEntity::entity);
     }
 
@@ -117,36 +116,36 @@ public interface StateManager extends DescribableComponent {
      *                                    {@code StateManager} does not control the {@link Repository} to load the
      *                                    {@link ManagedEntity} from
      */
-    <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(
-            Class<T> type,
-            ID id,
-            ProcessingContext context);
+    <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(Class<T> type,
+                                                                      ID id,
+                                                                      ProcessingContext context);
 
     /**
      * The types of entities that are registered with this {@code StateManager}.
      *
-     * @return the types of entities that are registered with this {@code StateManager}.
+     * @return the types of entities that are registered with this {@code StateManager}
      */
     Set<Class<?>> registeredEntities();
 
     /**
      * The types of identifiers that are registered with this {@code StateManager} for the given {@code entityType}.
      *
-     * @param entityType The type of the entity.
+     * @param entityType the type of the entity
      * @return the types of identifiers that are registered with this {@code StateManager} for the given
-     * {@code entityType}.
+     * {@code entityType}
      */
     Set<Class<?>> registeredIdsFor(Class<?> entityType);
 
     /**
-     * Returns the {@link Repository} for the given {@code type}. Returns {@code null} if no repository is registered
-     * for the given type and id.
+     * Returns the {@link Repository} for the given {@code type}.
+     * <p>
+     * Returns {@code null} if no repository is registered for the given type and id.
      *
-     * @param <ID>        The type of the identifier of the entity.
-     * @param <T>        The type of the entity.
-     * @param entityType The type of the entity.
-     * @param idType     The type of the identifier of the entity.
-     * @return The {@link Repository} for the given {@code idType} and {@code entityType}.
+     * @param <ID>       the type of the identifier of the entity
+     * @param <T>        the type of the entity
+     * @param entityType the type of the entity
+     * @param idType     the type of the identifier of the entity
+     * @return the {@link Repository} for the given {@code idType} and {@code entityType}
      */
-    <ID, T> Repository<ID, T> repository(Class<T> entityType, Class<ID> idType);
+    <ID, T> @Nullable Repository<ID, T> repository(Class<T> entityType, Class<ID> idType);
 }

--- a/modelling/src/main/java/org/axonframework/modelling/StateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/StateManager.java
@@ -85,12 +85,15 @@ public interface StateManager extends DescribableComponent {
      * If multiple repositories are registered for the given {@code entityType} that can handle the given {@code id}
      * (through superclass registration), the most specific repository is used.
      *
-     * @param <T>     The type of state to retrieve.
-     * @param type    The type of state to retrieve.
-     * @param id      The id of the state to retrieve.
-     * @param context The {@link ProcessingContext context} to load the entity in.
-     * @param <I>     The type of the identifier of the entity.
-     * @return a {@link CompletableFuture} which resolves to the entity instance.
+     * @param <T>     the type of state to retrieve
+     * @param type    the type of state to retrieve
+     * @param id      the id of the state to retrieve
+     * @param context the {@link ProcessingContext context} to load the entity in
+     * @param <I>     the type of the identifier of the entity
+     * @return a {@link CompletableFuture} which resolves to the entity instance
+     * @throws MissingRepositoryException contained in the resulting {@link CompletableFuture} whenever this
+     *                                    {@code StateManager} does not control the {@link Repository} to load the
+     *                                    entity from
      */
     default <I, T> CompletableFuture<T> loadEntity(
             Class<T> type,
@@ -104,12 +107,15 @@ public interface StateManager extends DescribableComponent {
      * Retrieves a {@link ManagedEntity} of the given {@code type} and {@code id}. The {@link CompletableFuture} will
      * resolve to a {@link ManagedEntity}, or complete exceptionally if it could not be resolved.
      *
-     * @param type    The type of state to retrieve.
-     * @param id      The id of the state to retrieve.
-     * @param context The {@link ProcessingContext context} to load the entity in.
-     * @param <ID>    The type of the identifier of the entity.
-     * @param <T>     The type of the entity.
-     * @return a {@link CompletableFuture} which resolves to the entity instance.
+     * @param type    the type of state to retrieve
+     * @param id      the id of the state to retrieve
+     * @param context the {@link ProcessingContext context} to load the entity in
+     * @param <ID>    the type of the identifier of the entity
+     * @param <T>     the type of the entity
+     * @return a {@link CompletableFuture} which resolves to the entity instance
+     * @throws MissingRepositoryException contained in the resulting {@link CompletableFuture} whenever this
+     *                                    {@code StateManager} does not control the {@link Repository} to load the
+     *                                    {@link ManagedEntity} from
      */
     <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(
             Class<T> type,

--- a/modelling/src/main/java/org/axonframework/modelling/tracing/TracingStateManager.java
+++ b/modelling/src/main/java/org/axonframework/modelling/tracing/TracingStateManager.java
@@ -19,13 +19,13 @@ package org.axonframework.modelling.tracing;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
-import org.axonframework.messaging.tracing.Span;
 import org.axonframework.messaging.tracing.SpanFactory;
 import org.axonframework.messaging.tracing.attributes.EntityIdSpanAttributesProvider;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
 import org.axonframework.modelling.repository.tracing.TracingRepository;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.Set;
@@ -36,17 +36,17 @@ import java.util.concurrent.CompletableFuture;
  * <p>
  * The {@code loadManagedEntity} call produces a single span named {@code StateManager.loadManagedEntity <EntityType>}
  * carrying the entity type name and the entity identifier (under
- * {@link EntityIdSpanAttributesProvider#DEFAULT_ATTRIBUTE_KEY}). The default {@code loadEntity} method
- * ultimately calls {@code loadManagedEntity}, so it is naturally traced too.
+ * {@link EntityIdSpanAttributesProvider#DEFAULT_ATTRIBUTE_KEY}). The default {@code loadEntity} method ultimately calls
+ * {@code loadManagedEntity}, so it is naturally traced too.
  * <p>
  * Repositories {@link #register(Repository) registered} on this state manager are wrapped in a
- * {@link TracingRepository} (when not traced already), so their {@code load} / {@code loadOrCreate} /
- * {@code persist} / {@code attach} operations produce spans as well. This matters for entity modules (e.g.
- * event-sourced entities), which build their {@code Repository} inside the module's own component registry - out of
- * reach of the root registry's {@code Repository} decorator - and then register it on the root {@code StateManager}:
- * this wrap is what puts the {@code Repository.load <EntityType>} span inside the entity-loading trace.
+ * {@link TracingRepository} (when not traced already), so their {@code load} / {@code loadOrCreate} / {@code persist} /
+ * {@code attach} operations produce spans as well. This matters for entity modules (e.g. event-sourced entities), which
+ * build their {@code Repository} inside the module's own component registry - out of reach of the root registry's
+ * {@code Repository} decorator - and then register it on the root {@code StateManager}: this wrap is what puts the
+ * {@code Repository.load <EntityType>} span inside the entity-loading trace.
  * <p>
- * This decorator is registered by {@link ModellingTracingConfigurationEnhancer}; it is never instantiated directly by
+ * This decorator is registered by {@code ModellingTracingConfigurationEnhancer}; it is never instantiated directly by
  * applications.
  *
  * @author Mateusz Nowak
@@ -55,10 +55,14 @@ import java.util.concurrent.CompletableFuture;
 @Internal
 public final class TracingStateManager implements StateManager {
 
-    /** Prefix for the state-manager-load-managed-entity span. */
+    /**
+     * Prefix for the state-manager-load-managed-entity span.
+     */
     private static final String LOAD_MANAGED_ENTITY_SPAN = "StateManager.loadManagedEntity";
 
-    /** Attribute key for the entity type (same convention as {@link TracingRepository}). */
+    /**
+     * Attribute key for the entity type (same convention as {@link TracingRepository}).
+     */
     private static final String ENTITY_TYPE_KEY = "axoniq.entity.type";
 
     private final StateManager delegate;
@@ -80,13 +84,13 @@ public final class TracingStateManager implements StateManager {
      * {@inheritDoc}
      * <p>
      * <b>Contract:</b> the given {@code repository} is assumed to be untraced and is wrapped in a
-     * {@link TracingRepository} before registration, unless it already <em>is</em> one (e.g. on re-registration of
-     * the same instance, or when registering a component the root registry's decorator already traced). The
-     * already-traced check looks at the <em>outermost</em> wrapper only - sound for everything the component
-     * registry builds, because the tracing decorators register at near-maximal {@code TRACING_DECORATOR_ORDER} and
-     * are therefore always the outermost layer. If you register a hand-built decorator pipeline around an
-     * already-traced repository, keep the {@link TracingRepository} as the outermost wrapper - burying it under
-     * another decorator makes it undetectable here and results in duplicate {@code Repository.*} spans.
+     * {@link TracingRepository} before registration, unless it already <em>is</em> one (e.g. on re-registration of the
+     * same instance, or when registering a component the root registry's decorator already traced). The already-traced
+     * check looks at the <em>outermost</em> wrapper only - sound for everything the component registry builds, because
+     * the tracing decorators register at near-maximal {@code TRACING_DECORATOR_ORDER} and are therefore always the
+     * outermost layer. If you register a hand-built decorator pipeline around an already-traced repository, keep the
+     * {@link TracingRepository} as the outermost wrapper - burying it under another decorator makes it undetectable
+     * here and results in duplicate {@code Repository.*} spans.
      */
     @Override
     public <ID, T> StateManager register(Repository<ID, T> repository) {
@@ -112,13 +116,10 @@ public final class TracingStateManager implements StateManager {
     public <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(Class<T> type,
                                                                              ID id,
                                                                              ProcessingContext context) {
-        Span span = spanFactory.createInternalSpan(
-                                       LOAD_MANAGED_ENTITY_SPAN + " " + type.getSimpleName(), context)
-                               .addAttribute(ENTITY_TYPE_KEY, type.getSimpleName());
-        if (id != null) {
-            span.addAttribute(EntityIdSpanAttributesProvider.DEFAULT_ATTRIBUTE_KEY, id.toString());
-        }
-        return span.branchAsync(context, scoped -> delegate.loadManagedEntity(type, id, scoped));
+        return spanFactory.createInternalSpan(LOAD_MANAGED_ENTITY_SPAN + " " + type.getSimpleName(), context)
+                          .addAttribute(ENTITY_TYPE_KEY, type.getSimpleName())
+                          .addAttribute(EntityIdSpanAttributesProvider.DEFAULT_ATTRIBUTE_KEY, id.toString())
+                          .branchAsync(context, scoped -> delegate.loadManagedEntity(type, id, scoped));
     }
 
     @Override
@@ -132,7 +133,7 @@ public final class TracingStateManager implements StateManager {
     }
 
     @Override
-    public <ID, T> Repository<ID, T> repository(Class<T> entityType, Class<ID> idType) {
+    public <ID, T> @Nullable Repository<ID, T> repository(Class<T> entityType, Class<ID> idType) {
         return delegate.repository(entityType, idType);
     }
 

--- a/modelling/src/test/java/org/axonframework/modelling/HierarchicalStateManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/HierarchicalStateManagerTest.java
@@ -17,7 +17,10 @@
 package org.axonframework.modelling;
 
 import org.axonframework.common.FutureUtils;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
@@ -100,7 +103,71 @@ class HierarchicalStateManagerTest {
     }
 
     @Test
-    void throwsExceptionIfExistsInNeither() {
+    void resolvesPolymorphicEntityFromChildWhenBothChildAndParentHaveMatchingSupertype() {
+        StateManager parent = SimpleStateManager.named("parent")
+                                                .register(String.class,
+                                                          TestEntity.class,
+                                                          (id, ctx) -> CompletableFuture.completedFuture(
+                                                                  new TestSubEntity("parent")),
+                                                          (id, state, ctx) -> FutureUtils.emptyCompletedFuture());
+        StateManager child = SimpleStateManager.named("child")
+                                               .register(String.class,
+                                                         TestEntity.class,
+                                                         (id, ctx) -> CompletableFuture.completedFuture(
+                                                                 new TestSubEntity("child")),
+                                                         (id, state, ctx) -> FutureUtils.emptyCompletedFuture());
+
+        HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
+
+        ManagedEntity<String, TestSubEntity> managedEntity =
+                stateManager.loadManagedEntity(TestSubEntity.class, "id", new StubProcessingContext()).join();
+
+        assertNotNull(managedEntity.entity());
+        assertEquals("child", managedEntity.entity().value());
+    }
+
+    @Test
+    void nonMissingRepositoryExceptionFromChildPropagatesUnchangedWithoutParentFallback() {
+        RuntimeException childFailure = new RuntimeException("child loader failure");
+        StateManager parent = createStringSimpleStateManager("parent");
+        StateManager child = SimpleStateManager.named("child")
+                                               .register(String.class,
+                                                         String.class,
+                                                         (id, ctx) -> CompletableFuture.failedFuture(childFailure),
+                                                         (id, state, ctx) -> FutureUtils.emptyCompletedFuture());
+
+        HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
+
+        CompletionException exception = assertThrows(CompletionException.class, () -> {
+            stateManager.loadEntity(String.class, "id", new StubProcessingContext())
+                        .join();
+        });
+        assertSame(childFailure, exception.getCause());
+    }
+
+    @Test
+    void synchronousMissingRepositoryExceptionThrowFromChildStillTriggersParentFallback() {
+        StateManager parent = createStringSimpleStateManager("parent");
+        StateManager child = new SynchronouslyThrowingStateManager();
+
+        HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
+
+        verifyHasAsResult(stateManager, "parent");
+    }
+
+    @Test
+    void resolvesEntityThroughNestedHierarchicalStateManagerComposition() {
+        StateManager grandparent = createStringSimpleStateManager("grandparent");
+        StateManager parent = HierarchicalStateManager.create(grandparent, SimpleStateManager.named("intermediate"));
+        StateManager child = SimpleStateManager.named("child");
+
+        HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
+
+        verifyHasAsResult(stateManager, "grandparent");
+    }
+
+    @Test
+    void completesExceptionallyIfExistsInNeither() {
         StateManager parent = SimpleStateManager.named("parent");
         StateManager child = SimpleStateManager.named("child");
 
@@ -174,5 +241,45 @@ class HierarchicalStateManagerTest {
 
     private record TestSubEntity(String value) implements TestEntity {
 
+    }
+
+    /**
+     * {@link StateManager} stub that throws {@link MissingRepositoryException} synchronously rather than completing
+     * a {@link CompletableFuture} exceptionally, exercising the {@code FutureUtils#runFailing} wrapping in
+     * {@link HierarchicalStateManager#loadManagedEntity(Class, Object, ProcessingContext)}.
+     */
+    private static final class SynchronouslyThrowingStateManager implements StateManager {
+
+        @Override
+        public <ID, T> StateManager register(Repository<ID, T> repository) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(Class<T> type,
+                                                                                  ID id,
+                                                                                  ProcessingContext context) {
+            throw new MissingRepositoryException(id.getClass(), type);
+        }
+
+        @Override
+        public Set<Class<?>> registeredEntities() {
+            return Set.of();
+        }
+
+        @Override
+        public Set<Class<?>> registeredIdsFor(Class<?> entityType) {
+            return Set.of();
+        }
+
+        @Override
+        public <ID, T> Repository<ID, T> repository(Class<T> entityType, Class<ID> idType) {
+            return null;
+        }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            // No-op - not required for testing
+        }
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/HierarchicalStateManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/HierarchicalStateManagerTest.java
@@ -24,6 +24,10 @@ import org.mockito.*;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class HierarchicalStateManagerTest {
 
@@ -58,16 +62,55 @@ class HierarchicalStateManagerTest {
     }
 
     @Test
+    void resolvesPolymorphicEntityFromChildIfRepositoryRegisteredForSupertype() {
+        StateManager parent = SimpleStateManager.named("parent");
+        StateManager child = SimpleStateManager.named("child")
+                                               .register(String.class,
+                                                         TestEntity.class,
+                                                         (id, ctx) -> CompletableFuture.completedFuture(
+                                                                 new TestSubEntity("child")),
+                                                         (id, state, ctx) -> FutureUtils.emptyCompletedFuture());
+
+        HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
+
+        TestSubEntity entity = stateManager.loadEntity(TestSubEntity.class, "id", new StubProcessingContext())
+                                           .join();
+
+        assertNotNull(entity);
+        assertEquals("child", entity.value());
+    }
+
+    @Test
+    void resolvesPolymorphicEntityFromParentIfRepositoryRegisteredForSupertypeAndNotInChild() {
+        StateManager parent = SimpleStateManager.named("parent")
+                                                .register(String.class,
+                                                          TestEntity.class,
+                                                          (id, ctx) -> CompletableFuture.completedFuture(
+                                                                  new TestSubEntity("parent")),
+                                                          (id, state, ctx) -> FutureUtils.emptyCompletedFuture());
+        StateManager child = SimpleStateManager.named("child");
+
+        HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
+
+        TestSubEntity entity = stateManager.loadEntity(TestSubEntity.class, "id", new StubProcessingContext())
+                                           .join();
+
+        assertNotNull(entity);
+        assertEquals("parent", entity.value());
+    }
+
+    @Test
     void throwsExceptionIfExistsInNeither() {
         StateManager parent = SimpleStateManager.named("parent");
         StateManager child = SimpleStateManager.named("child");
 
         HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
 
-        Assertions.assertThrows(MissingRepositoryException.class, () -> {
+        CompletionException exception = Assertions.assertThrows(CompletionException.class, () -> {
             stateManager.loadEntity(String.class, "id", new StubProcessingContext())
                         .join();
         });
+        assertInstanceOf(MissingRepositoryException.class, exception.getCause());
     }
 
     @Test
@@ -82,25 +125,26 @@ class HierarchicalStateManagerTest {
         HierarchicalStateManager stateManager = HierarchicalStateManager.create(parent, child);
 
         Set<Class<?>> classes = stateManager.registeredEntities();
-        Assertions.assertEquals(3, classes.size());
+        assertEquals(3, classes.size());
         Assertions.assertTrue(classes.contains(String.class));
         Assertions.assertTrue(classes.contains(Integer.class));
         Assertions.assertTrue(classes.contains(Boolean.class));
 
         Set<Class<?>> stringIds = stateManager.registeredIdsFor(String.class);
-        Assertions.assertEquals(2, stringIds.size());
+        assertEquals(2, stringIds.size());
         Assertions.assertTrue(stringIds.contains(Integer.class));
         Assertions.assertTrue(stringIds.contains(Boolean.class));
 
         Set<Class<?>> integerIds = stateManager.registeredIdsFor(Integer.class);
-        Assertions.assertEquals(1, integerIds.size());
+        assertEquals(1, integerIds.size());
         Assertions.assertTrue(integerIds.contains(Integer.class));
 
         Set<Class<?>> booleanIds = stateManager.registeredIdsFor(Boolean.class);
-        Assertions.assertEquals(1, booleanIds.size());
+        assertEquals(1, booleanIds.size());
         Assertions.assertTrue(booleanIds.contains(Integer.class));
     }
 
+    @SuppressWarnings("rawtypes")
     private Repository<?, ?> createMockForTypes(Class<?> entityType, Class<?> idType) {
         Repository mock = Mockito.mock(Repository.LifecycleManagement.class);
         Mockito.when(mock.idType()).thenReturn(idType);
@@ -111,18 +155,24 @@ class HierarchicalStateManagerTest {
     private static void verifyHasAsResult(HierarchicalStateManager stateManager, String child) {
         stateManager.loadEntity(String.class, "id", new StubProcessingContext())
                     .thenAccept(entity -> {
-                        Assertions.assertEquals(child, entity);
+                        assertEquals(child, entity);
                     })
                     .join();
     }
 
     private static StateManager createStringSimpleStateManager(String value) {
-        return SimpleStateManager.named(value)
-                                 .register(String.class,
-                                           String.class,
-                                           (id, ctx) -> CompletableFuture.completedFuture(value),
-                                           (id, state, ctx) -> {
-                                               return FutureUtils.emptyCompletedFuture();
-                                           });
+        return SimpleStateManager.named(value).register(
+                String.class, String.class,
+                (id, ctx) -> CompletableFuture.completedFuture(value),
+                (id, state, ctx) -> FutureUtils.emptyCompletedFuture()
+        );
+    }
+
+    private interface TestEntity {
+
+    }
+
+    private record TestSubEntity(String value) implements TestEntity {
+
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/SimpleStateManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/SimpleStateManagerTest.java
@@ -49,7 +49,7 @@ class SimpleStateManagerTest {
     }
 
     @Test
-    void throwsExceptionOnMissingModelDefinition() {
+    void completesExceptionallyOnMissingModelDefinition() {
         // given
         StateManager testSubject = SimpleStateManager.named("test");
 

--- a/modelling/src/test/java/org/axonframework/modelling/SimpleStateManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/SimpleStateManagerTest.java
@@ -54,8 +54,10 @@ class SimpleStateManagerTest {
         StateManager testSubject = SimpleStateManager.named("test");
 
         // when & then
-        assertThrows(MissingRepositoryException.class,
-                     () -> testSubject.loadEntity(Integer.class, "42", new StubProcessingContext()).join());
+        var exception = assertThrows(CompletionException.class,
+                                     () -> testSubject.loadEntity(Integer.class, "42", new StubProcessingContext())
+                                                      .join());
+        assertInstanceOf(MissingRepositoryException.class, exception.getCause());
     }
 
     @Test
@@ -173,9 +175,11 @@ class SimpleStateManagerTest {
                                                           .register(repository);
 
             // when & then
-            assertThrows(MissingRepositoryException.class,
-                         () -> stateManager.loadManagedEntity(MySuperEntity.class, "42", new StubProcessingContext())
-                                           .join());
+            var exception = assertThrows(CompletionException.class,
+                                         () -> stateManager.loadManagedEntity(MySuperEntity.class,
+                                                                              "42",
+                                                                              new StubProcessingContext()).join());
+            assertInstanceOf(MissingRepositoryException.class, exception.getCause());
         }
 
         @Test
@@ -211,10 +215,11 @@ class SimpleStateManagerTest {
                                                           .register(repository);
 
             // when & then
-            assertThrows(MissingRepositoryException.class,
-                         () -> stateManager.loadManagedEntity(MySuperEntity.class,
-                                                              new MySuperId(),
-                                                              new StubProcessingContext()).join());
+            var exception = assertThrows(CompletionException.class,
+                                         () -> stateManager.loadManagedEntity(MySuperEntity.class,
+                                                                              new MySuperId(),
+                                                                              new StubProcessingContext()).join());
+            assertInstanceOf(MissingRepositoryException.class, exception.getCause());
         }
 
         @Test

--- a/modelling/src/test/java/org/axonframework/modelling/tracing/TracingStateManagerTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/tracing/TracingStateManagerTest.java
@@ -16,24 +16,24 @@
 
 package org.axonframework.modelling.tracing;
 
-import org.axonframework.modelling.repository.tracing.TracingRepository;
-import org.axonframework.messaging.tracing.support.TestSpanFactory;
-import org.axonframework.messaging.tracing.support.TestSpanFactory.TestSpanType;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.tracing.support.TestSpanFactory;
+import org.axonframework.messaging.tracing.support.TestSpanFactory.TestSpanType;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.axonframework.modelling.repository.Repository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.axonframework.modelling.repository.tracing.TracingRepository;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.*;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.axonframework.common.FutureUtils.joinAndUnwrap;
 
 class TracingStateManagerTest {
 
@@ -72,6 +72,7 @@ class TracingStateManagerTest {
     @Nested
     class RegisterWrapsRepositories {
 
+        @SuppressWarnings("unchecked")
         @Test
         void registeringALifecycleRepositoryWrapsItSoItsOperationsAreTraced() {
             // given a plain (untraced) repository, e.g. the one an event-sourced entity module builds in its own
@@ -84,8 +85,7 @@ class TracingStateManagerTest {
             // then the delegate received a traced wrapper, and loading through it opens the repository span
             assertThat(delegate.registered).isInstanceOf(TracingRepository.class);
             joinAndUnwrap(
-                    ((Repository<String, Booking>) delegate.registered)
-                            .load("room-42", new StubProcessingContext())
+                    ((Repository<String, Booking>) delegate.registered).load("room-42", new StubProcessingContext())
             );
             spanFactory.verifySpanCompleted("Repository.load Booking");
         }
@@ -111,36 +111,41 @@ class TracingStateManagerTest {
 
         private Repository<?, ?> registered;
 
+        @NonNull
         @Override
-        public <ID, T> StateManager register(Repository<ID, T> repository) {
+        public <ID, T> StateManager register(@NonNull Repository<ID, T> repository) {
             this.registered = repository;
             return this;
         }
 
+        @NonNull
         @Override
-        public <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(Class<T> type,
-                                                                                 ID id,
-                                                                                 ProcessingContext context) {
+        public <ID, T> CompletableFuture<ManagedEntity<ID, T>> loadManagedEntity(@NonNull Class<T> type,
+                                                                                 @NonNull ID id,
+                                                                                 @NonNull ProcessingContext context) {
             return CompletableFuture.completedFuture(null);
         }
 
+        @NonNull
         @Override
         public Set<Class<?>> registeredEntities() {
             return Set.of();
         }
 
+        @NonNull
         @Override
-        public Set<Class<?>> registeredIdsFor(Class<?> entityType) {
+        public Set<Class<?>> registeredIdsFor(@NonNull Class<?> entityType) {
             return Set.of();
         }
 
+        @Nullable
         @Override
-        public <ID, T> Repository<ID, T> repository(Class<T> entityType, Class<ID> idType) {
+        public <ID, T> Repository<ID, T> repository(@NonNull Class<T> entityType, @NonNull Class<ID> idType) {
             return null;
         }
 
         @Override
-        public void describeTo(ComponentDescriptor descriptor) {
+        public void describeTo(@NonNull ComponentDescriptor descriptor) {
             // No-op - not required for testing
         }
     }
@@ -150,43 +155,50 @@ class TracingStateManagerTest {
      */
     private static final class RecordingRepository implements Repository.LifecycleManagement<String, Booking> {
 
+        @NonNull
         @Override
         public Class<Booking> entityType() {
             return Booking.class;
         }
 
+        @NonNull
         @Override
         public Class<String> idType() {
             return String.class;
         }
 
+        @NonNull
         @Override
         public CompletableFuture<ManagedEntity<String, Booking>> load(String identifier,
-                                                                      ProcessingContext processingContext) {
+                                                                      @NonNull ProcessingContext processingContext) {
             return CompletableFuture.completedFuture(null);
         }
 
+        @NonNull
         @Override
         public CompletableFuture<ManagedEntity<String, Booking>> loadOrCreate(String identifier,
-                                                                              ProcessingContext processingContext) {
+                                                                              @NonNull ProcessingContext processingContext) {
             return CompletableFuture.completedFuture(null);
         }
 
+        @SuppressWarnings("DataFlowIssue")
+        @NonNull
         @Override
         public ManagedEntity<String, Booking> persist(String identifier,
                                                       Booking entity,
-                                                      ProcessingContext processingContext) {
+                                                      @NonNull ProcessingContext processingContext) {
             return null;
         }
 
+        @NonNull
         @Override
-        public ManagedEntity<String, Booking> attach(ManagedEntity<String, Booking> entity,
-                                                     ProcessingContext processingContext) {
+        public ManagedEntity<String, Booking> attach(@NonNull ManagedEntity<String, Booking> entity,
+                                                     @NonNull ProcessingContext processingContext) {
             return entity;
         }
 
         @Override
-        public void describeTo(ComponentDescriptor descriptor) {
+        public void describeTo(@NonNull ComponentDescriptor descriptor) {
         }
     }
 


### PR DESCRIPTION
This pull request ensures the `HierarchicalStateManager` allows for Entity-subtype search, as is important when searching based on a polymorphic type.
It does so by simply delegating the request through to the `StateManager` child and parent the `HierarchicalStateManager` contains in the `StateManager#loadManagedEntity` method.
This led to some clean-up on the `StateManager` JavaDoc to clarify it's intent. If it doesn't hold a `Repository`, it should throw a `MissingRepositoryException`.

This ensures that the `HierarchicalStateManager` can, when the `child` doesn't have a working `Repository` for the given (sub)type, that it results in a `MissingRepositoryException`.
That allows a similar check on the `parent`. Although this could also lead to a `MissingRepositoryException` is fine, as if both the child and parent don't have a `Repository` for a subtype, that it will fail.
In other words, the `HierarchicalStateManager` gives the decision to the implementations.

In the meantime, I've cleaned up the `StateManager` and it's implementations as per boy scouting.

In doing the above, this PR resolves #4904.