### PR TITLE
[#4906] Correctly support `@EventSourced` annotation for polymorphic entities

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/InfrastructureAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/InfrastructureAutoConfiguration.java
@@ -50,14 +50,14 @@ public class InfrastructureAutoConfiguration {
     }
 
     /**
-     * Provides a Spring aggregate lookup.
+     * Provides a Spring entity lookup.
      * <p>
      * Besides the regular bean-registry-based entity discovery, this scans the auto-configuration base packages (see
      * {@link AutoConfigurationPackages}) for abstract polymorphic entity roots, since those are never registered as a
      * bean by Spring's own component scan.
      *
-     * @param beanFactory The bean factory to resolve the auto-configuration base packages from.
-     * @return The lookup scanning for annotations for later entity registrations.
+     * @param beanFactory the bean factory to resolve the auto-configuration base packages from
+     * @return the lookup scanning for annotations for later entity registrations
      */
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Bean

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/InfrastructureAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/InfrastructureAutoConfiguration.java
@@ -19,9 +19,13 @@ package org.axonframework.extension.springboot.autoconfig;
 import org.axonframework.extension.spring.config.MessageHandlerLookup;
 import org.axonframework.extension.spring.config.SpringEventSourcedEntityLookup;
 import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Role;
+
+import java.util.List;
 
 /**
  * Infrastructure autoconfiguration class for Axon Framework application. Constructs the look-up components, like the
@@ -47,12 +51,22 @@ public class InfrastructureAutoConfiguration {
 
     /**
      * Provides a Spring aggregate lookup.
+     * <p>
+     * Besides the regular bean-registry-based entity discovery, this scans the auto-configuration base packages (see
+     * {@link AutoConfigurationPackages}) for abstract polymorphic entity roots, since those are never registered as a
+     * bean by Spring's own component scan.
      *
+     * @param beanFactory The bean factory to resolve the auto-configuration base packages from.
      * @return The lookup scanning for annotations for later entity registrations.
      */
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     @Bean
-    public static SpringEventSourcedEntityLookup springEventSourcedEntityLookup() {
-        return new SpringEventSourcedEntityLookup();
+    public static SpringEventSourcedEntityLookup springEventSourcedEntityLookup(
+            ConfigurableListableBeanFactory beanFactory
+    ) {
+        List<String> basePackages = AutoConfigurationPackages.has(beanFactory)
+                ? AutoConfigurationPackages.get(beanFactory)
+                : List.of();
+        return new SpringEventSourcedEntityLookup(basePackages);
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/InfrastructureAutoConfigurationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/InfrastructureAutoConfigurationTest.java
@@ -16,17 +16,23 @@
 
 package org.axonframework.extension.springboot.autoconfig;
 
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine;
+import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
 import org.axonframework.extension.spring.config.MessageHandlerLookup;
 import org.axonframework.extension.spring.config.SpringEventSourcedEntityLookup;
+import org.axonframework.extension.springboot.polymorphicentity.AbstractCourse;
+import org.axonframework.modelling.StateManager;
 import org.junit.jupiter.api.*;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableMBeanExport;
 import org.springframework.jmx.support.RegistrationPolicy;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 
 /**
  * Test class validating the behavior of the {@link InfrastructureAutoConfiguration}.
@@ -57,11 +63,37 @@ class InfrastructureAutoConfigurationTest {
         );
     }
 
+    @Test
+    void registersRepositoryForAbstractPolymorphicEntityWithoutAnnotatingSubtypes() {
+        testApplicationContext.withUserConfiguration(PolymorphicEntityContext.class).run(context -> {
+            org.axonframework.common.configuration.Configuration configuration =
+                    context.getBean(org.axonframework.common.configuration.Configuration.class);
+            StateManager stateManager = configuration.getComponent(StateManager.class);
+
+            assertThat(stateManager.repository(AbstractCourse.class, String.class)).isNotNull();
+        });
+    }
+
 
     @ContextConfiguration
     @EnableAutoConfiguration
     @EnableMBeanExport(registration = RegistrationPolicy.IGNORE_EXISTING)
     static class DefaultContext {
 
+    }
+
+    /**
+     * Scoped to {@link AbstractCourse}'s own package (rather than this test's package) so
+     * {@code AutoConfigurationPackages}-based scanning, and thus the {@link AbstractCourse} discovery under test,
+     * stays isolated to this test and doesn't affect other tests sharing this class's package.
+     */
+    @Configuration
+    @AutoConfigurationPackage(basePackageClasses = AbstractCourse.class)
+    static class PolymorphicEntityContext {
+
+        @Bean
+        public EventStorageEngine eventStorageEngine() {
+            return new InMemoryEventStorageEngine();
+        }
     }
 }

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/polymorphicentity/AbstractCourse.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/polymorphicentity/AbstractCourse.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.polymorphicentity;
+
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.extension.spring.stereotype.EventSourced;
+
+/**
+ * Abstract polymorphic entity root used by {@link org.axonframework.extension.springboot.autoconfig.InfrastructureAutoConfigurationTest}
+ * to verify {@code SpringEventSourcedEntityLookup} discovers it without {@link OnlineCourse} carrying its own
+ * {@link EventSourced} annotation. Lives in its own package (rather than nested in the test class) so that
+ * {@code AutoConfigurationPackages}-based scanning only picks it up for tests that explicitly opt in, instead of
+ * every other test in the shared {@code org.axonframework.extension.springboot.autoconfig} package.
+ */
+@EventSourced(idType = String.class, concreteTypes = OnlineCourse.class)
+public abstract class AbstractCourse {
+
+    @EntityCreator
+    public static AbstractCourse create() {
+        return new OnlineCourse();
+    }
+}

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/polymorphicentity/OnlineCourse.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/polymorphicentity/OnlineCourse.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.polymorphicentity;
+
+/**
+ * Concrete subtype of {@link AbstractCourse}. Deliberately carries no
+ * {@link org.axonframework.extension.spring.stereotype.EventSourced} annotation of its own, matching the documented
+ * Spring Boot polymorphism pattern where only the abstract parent is annotated.
+ */
+public class OnlineCourse extends AbstractCourse {
+
+}

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.util.ClassUtils;
 
 import java.lang.reflect.Modifier;
 import java.util.HashMap;
@@ -194,7 +195,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
             }
         }
 
-        for (Class<?> abstractRoot : findAbstractEntityRoots()) {
+        for (Class<?> abstractRoot : findAbstractEntityRoots(beanFactory.getBeanClassLoader())) {
             if (registeredEntityTypes.contains(abstractRoot)) {
                 continue;
             }
@@ -227,9 +228,10 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
      * it finds those roots regardless. Concrete classes are deliberately excluded here, since those are already
      * discoverable as beans and handled by the {@link #buildEntityHierarchy(ListableBeanFactory, String[])} path.
      *
-     * @return the abstract or interface types annotated with {@link EventSourced}, found in {@link #basePackages}
+     * @param classLoader the class loader to resolve scanned candidate class names with
+     * @return the abstract types annotated with {@link EventSourced}, found in {@link #basePackages}
      */
-    private Set<Class<?>> findAbstractEntityRoots() {
+    private Set<Class<?>> findAbstractEntityRoots(ClassLoader classLoader) {
         if (basePackages.isEmpty()) {
             return Set.of();
         }
@@ -251,7 +253,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
                     continue;
                 }
                 try {
-                    Class<?> candidateType = Class.forName(beanClassName);
+                    Class<?> candidateType = ClassUtils.forName(beanClassName, classLoader);
                     if (Modifier.isAbstract(candidateType.getModifiers())) {
                         abstractRoots.add(candidateType);
                     }

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -65,6 +65,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
     private static final Logger logger = LoggerFactory.getLogger(SpringEventSourcedEntityLookup.class);
 
     private static final String ID_TYPE_CLASS = "idType";
+    private static final String REGISTRAR_BEAN_NAME_SUFFIX = "$$Registrar";
 
     private final List<String> basePackages;
 
@@ -172,7 +173,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
             Map<Class<?>, String> entitySubtypes = entity.getValue();
             String entityPrototype = entity.getKey().getBeanName();
 
-            String registrarBeanName = entityPrototype + "$$Registrar";
+            String registrarBeanName = entityPrototype + REGISTRAR_BEAN_NAME_SUFFIX;
             if (beanFactory.containsBeanDefinition(registrarBeanName)) {
                 logger.info("Registrar for {} already available. Skipping configuration", entityPrototype);
                 break;
@@ -197,7 +198,8 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
             if (registeredEntityTypes.contains(abstractRoot)) {
                 continue;
             }
-            String registrarBeanName = lowerCaseFirstCharacterOf(abstractRoot.getSimpleName()) + "$$Registrar";
+            String registrarBeanName =
+                    lowerCaseFirstCharacterOf(abstractRoot.getSimpleName()) + REGISTRAR_BEAN_NAME_SUFFIX;
             if (beanFactory.containsBeanDefinition(registrarBeanName)) {
                 logger.info("Registrar for {} already available. Skipping configuration", abstractRoot.getName());
                 continue;

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -52,7 +52,7 @@ import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
  * Polymorphic entity hierarchies whose abstract parent lists its subtypes through {@link EventSourced#concreteTypes()}
  * are never registered as a {@link BeanDefinition} by Spring's own component scan (abstract classes are not candidate
  * components), so they cannot be found through {@link ListableBeanFactory#getBeanNamesForAnnotation(Class)}. To support
- * that documented pattern, this class additionally runs its own classpath scan (see {@link #findAbstractEntityRoots()})
+ * that documented pattern, this class additionally runs its own classpath scan (see {@code #findAbstractEntityRoots()})
  * across the given {@code basePackages}, independent of Spring's bean registry, to locate those abstract roots
  * directly.
  *
@@ -80,7 +80,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
     /**
      * Constructs a {@code SpringEventSourcedEntityLookup} that, in addition to the regular bean-registry-based
      * discovery, scans the given {@code basePackages} for abstract polymorphic entity roots (see
-     * {@link #findAbstractEntityRoots()}).
+     * {@code #findAbstractEntityRoots()}).
      *
      * @param basePackages the packages to scan for abstract classes annotated with {@link EventSourced}
      */

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -246,6 +246,10 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
         for (String basePackage : basePackages) {
             for (BeanDefinition candidate : scanner.findCandidateComponents(basePackage)) {
                 String beanClassName = candidate.getBeanClassName();
+                if (beanClassName == null) {
+                    logger.warn("Cannot determine bean class name for candidate [{}], hence ignoring.", candidate);
+                    continue;
+                }
                 try {
                     Class<?> candidateType = Class.forName(beanClassName);
                     if (Modifier.isAbstract(candidateType.getModifiers())) {

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -177,6 +177,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
             if (beanFactory.containsBeanDefinition(registrarBeanName)) {
                 logger.info("Registrar for {} already available. Skipping configuration", entityPrototype);
                 break;
+                logger.info("Registrar bean [{}] already available. Skipping configuration", registrarBeanName);
             }
 
             if (hasSubtypesOrIsPrototype(entitySubtypes, beanFactory, entityPrototype) && entityType != null) {
@@ -201,7 +202,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
             String registrarBeanName =
                     lowerCaseFirstCharacterOf(abstractRoot.getSimpleName()) + REGISTRAR_BEAN_NAME_SUFFIX;
             if (beanFactory.containsBeanDefinition(registrarBeanName)) {
-                logger.info("Registrar for {} already available. Skipping configuration", abstractRoot.getName());
+                logger.info("Registrar bean [{}] already available. Skipping configuration", registrarBeanName);
                 continue;
             }
             AnnotationUtils.findAnnotationAttributes(abstractRoot, EventSourced.class)

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -105,7 +105,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
             Class<E> entityType = (Class<E>) beanFactory.getType(prototype);
             if (entityType == null) {
                 logger.info("Cannot find Entity class for type [{}], hence ignoring.", prototype);
-                break;
+                continue;
             }
 
             SpringEntity<E> springEntity = new SpringEntity<>(prototype, entityType);
@@ -175,9 +175,8 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
 
             String registrarBeanName = entityPrototype + REGISTRAR_BEAN_NAME_SUFFIX;
             if (beanFactory.containsBeanDefinition(registrarBeanName)) {
-                logger.info("Registrar for {} already available. Skipping configuration", entityPrototype);
-                break;
                 logger.info("Registrar bean [{}] already available. Skipping configuration", registrarBeanName);
+                continue;
             }
 
             if (hasSubtypesOrIsPrototype(entitySubtypes, beanFactory, entityPrototype) && entityType != null) {

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -45,8 +45,8 @@ import static java.lang.String.format;
 import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
 
 /**
- * A {@link BeanDefinitionRegistryPostProcessor} implementation that scans for Aggregate types and registers a
- * {@link SpringEventSourcedEntityConfigurer configurer} for each Aggregate found.
+ * A {@link BeanDefinitionRegistryPostProcessor} implementation that scans for Entity types and registers a
+ * {@link SpringEventSourcedEntityConfigurer configurer} for each Entity found.
  * <p>
  * Polymorphic entity hierarchies whose abstract parent lists its subtypes through {@link EventSourced#concreteTypes()}
  * are never registered as a {@link BeanDefinition} by Spring's own component scan (abstract classes are not candidate

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -24,15 +24,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
 
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static java.lang.String.format;
 import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
@@ -40,6 +47,13 @@ import static org.axonframework.common.StringUtils.lowerCaseFirstCharacterOf;
 /**
  * A {@link BeanDefinitionRegistryPostProcessor} implementation that scans for Aggregate types and registers a
  * {@link SpringEventSourcedEntityConfigurer configurer} for each Aggregate found.
+ * <p>
+ * Polymorphic entity hierarchies whose abstract parent lists its subtypes through {@link EventSourced#concreteTypes()}
+ * are never registered as a {@link BeanDefinition} by Spring's own component scan (abstract classes are not candidate
+ * components), so they cannot be found through {@link ListableBeanFactory#getBeanNamesForAnnotation(Class)}. To support
+ * that documented pattern, this class additionally runs its own classpath scan (see {@link #findAbstractEntityRoots()})
+ * across the given {@code basePackages}, independent of Spring's bean registry, to locate those abstract roots
+ * directly.
  *
  * @author Allard Buijze
  * @author Simon Zambrovski
@@ -51,6 +65,26 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
     private static final Logger logger = LoggerFactory.getLogger(SpringEventSourcedEntityLookup.class);
 
     private static final String ID_TYPE_CLASS = "idType";
+
+    private final List<String> basePackages;
+
+    /**
+     * Constructs a {@code SpringEventSourcedEntityLookup} discovering entities through Spring's bean registry.
+     */
+    public SpringEventSourcedEntityLookup() {
+        this(List.of());
+    }
+
+    /**
+     * Constructs a {@code SpringEventSourcedEntityLookup} that, in addition to the regular bean-registry-based
+     * discovery, scans the given {@code basePackages} for abstract polymorphic entity roots (see
+     * {@link #findAbstractEntityRoots()}).
+     *
+     * @param basePackages the packages to scan for abstract classes annotated with {@link EventSourced}
+     */
+    public SpringEventSourcedEntityLookup(List<String> basePackages) {
+        this.basePackages = Objects.requireNonNull(basePackages, "The basePackages must not be null.");
+    }
 
     /**
      * Builds a hierarchy model from the given {@code entityPrototypes} found in the given {@code beanFactory}.
@@ -131,7 +165,8 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
         Map<SpringEntity<? super Object>, Map<Class<?>, String>> hierarchy =
                 buildEntityHierarchy(beanFactory, entitiesBeans);
 
-        //noinspection TypeParameterExplicitlyExtendsObject
+        Set<Class<?>> registeredEntityTypes = new HashSet<>();
+
         for (Map.Entry<SpringEntity<? super Object>, Map<Class<? extends Object>, String>> entity : hierarchy.entrySet()) {
             Class<?> entityType = entity.getKey().getClassType();
             Map<Class<?>, String> entitySubtypes = entity.getValue();
@@ -151,11 +186,75 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
                                                                          "Id type must be provided for "
                                                                                  + entityPrototype)
                                ))
-                               .ifPresent(registrarBeanDefinition -> bdRegistry.registerBeanDefinition(
-                                       registrarBeanName, registrarBeanDefinition
-                               ));
+                               .ifPresent(registrarBeanDefinition -> {
+                                   bdRegistry.registerBeanDefinition(registrarBeanName, registrarBeanDefinition);
+                                   registeredEntityTypes.add(entityType);
+                               });
             }
         }
+
+        for (Class<?> abstractRoot : findAbstractEntityRoots()) {
+            if (registeredEntityTypes.contains(abstractRoot)) {
+                continue;
+            }
+            String registrarBeanName = lowerCaseFirstCharacterOf(abstractRoot.getSimpleName()) + "$$Registrar";
+            if (beanFactory.containsBeanDefinition(registrarBeanName)) {
+                logger.info("Registrar for {} already available. Skipping configuration", abstractRoot.getName());
+                continue;
+            }
+            AnnotationUtils.findAnnotationAttributes(abstractRoot, EventSourced.class)
+                           .map(props -> buildEntityBeanDefinition(
+                                   abstractRoot,
+                                   (Class<?>) Objects.requireNonNull(props.get(ID_TYPE_CLASS),
+                                                                     "Id type must be provided for "
+                                                                             + abstractRoot.getName())
+                           ))
+                           .ifPresent(registrarBeanDefinition -> bdRegistry.registerBeanDefinition(
+                                   registrarBeanName, registrarBeanDefinition
+                           ));
+        }
+    }
+
+    /**
+     * Scans {@link #basePackages} for abstract classes (or interfaces) annotated with {@link EventSourced}.
+     * <p>
+     * Spring's own component scan never registers a {@link BeanDefinition} for an abstract type, so a polymorphic
+     * entity hierarchy whose parent lists its subtypes through {@link EventSourced#concreteTypes()} (rather than having
+     * every subtype individually annotated) is otherwise invisible to
+     * {@link ListableBeanFactory#getBeanNamesForAnnotation(Class)}. This scan is independent of the bean registry, so
+     * it finds those roots regardless. Concrete classes are deliberately excluded here, since those are already
+     * discoverable as beans and handled by the {@link #buildEntityHierarchy(ListableBeanFactory, String[])} path.
+     *
+     * @return the abstract or interface types annotated with {@link EventSourced}, found in {@link #basePackages}
+     */
+    private Set<Class<?>> findAbstractEntityRoots() {
+        if (basePackages.isEmpty()) {
+            return Set.of();
+        }
+
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false) {
+            @Override
+            protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+                return beanDefinition.getMetadata().isIndependent();
+            }
+        };
+        scanner.addIncludeFilter(new AnnotationTypeFilter(EventSourced.class, true, false));
+
+        Set<Class<?>> abstractRoots = new HashSet<>();
+        for (String basePackage : basePackages) {
+            for (BeanDefinition candidate : scanner.findCandidateComponents(basePackage)) {
+                String beanClassName = candidate.getBeanClassName();
+                try {
+                    Class<?> candidateType = Class.forName(beanClassName);
+                    if (Modifier.isAbstract(candidateType.getModifiers())) {
+                        abstractRoots.add(candidateType);
+                    }
+                } catch (ClassNotFoundException | LinkageError e) {
+                    logger.warn("Cannot load candidate Entity class [{}], hence ignoring.", beanClassName, e);
+                }
+            }
+        }
+        return abstractRoots;
     }
 
     /**

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookup.java
@@ -219,7 +219,7 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
     }
 
     /**
-     * Scans {@link #basePackages} for abstract classes (or interfaces) annotated with {@link EventSourced}.
+     * Scans {@link #basePackages} for abstract classes annotated with {@link EventSourced}.
      * <p>
      * Spring's own component scan never registers a {@link BeanDefinition} for an abstract type, so a polymorphic
      * entity hierarchy whose parent lists its subtypes through {@link EventSourced#concreteTypes()} (rather than having
@@ -227,6 +227,10 @@ public class SpringEventSourcedEntityLookup implements BeanDefinitionRegistryPos
      * {@link ListableBeanFactory#getBeanNamesForAnnotation(Class)}. This scan is independent of the bean registry, so
      * it finds those roots regardless. Concrete classes are deliberately excluded here, since those are already
      * discoverable as beans and handled by the {@link #buildEntityHierarchy(ListableBeanFactory, String[])} path.
+     * <p>
+     * The resulting registrar bean name is derived from the root's simple class name, so two abstract roots sharing a
+     * simple name in different packages would collide on a single registrar. This is a known limitation of this
+     * scan-based path, unlike the bean-registry-based path where Spring's own bean naming already guards against it.
      *
      * @param classLoader the class loader to resolve scanned candidate class names with
      * @return the abstract types annotated with {@link EventSourced}, found in {@link #basePackages}

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookupTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookupTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.spring.config;
+
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.Module;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.extension.spring.stereotype.EventSourced;
+import org.junit.jupiter.api.*;
+import org.mockito.*;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.annotation.AnnotatedBeanDefinitionReader;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link SpringEventSourcedEntityLookup}.
+ *
+ * @author Steven van Beelen
+ */
+class SpringEventSourcedEntityLookupTest {
+
+    @Test
+    void registersConfigurerForRootDiscoveredByWalkingUpFromIndividuallyAnnotatedSubtypeBean() {
+        // given
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        new AnnotatedBeanDefinitionReader(beanFactory).register(IndividuallyAnnotatedSubtype.class);
+
+        // when
+        new SpringEventSourcedEntityLookup().postProcessBeanFactory(beanFactory);
+
+        // then
+        String[] registrarBeanNames = beanFactory.getBeanNamesForType(SpringEventSourcedEntityConfigurer.class);
+        assertThat(registrarBeanNames).hasSize(1);
+        assertConfigurerTargets(beanFactory, registrarBeanNames[0], IndividuallyAnnotatedRoot.class, String.class);
+    }
+
+    @Test
+    void registersConfigurerForAbstractRootDiscoveredByClasspathScanWithoutAnnotatedSubtypes() {
+        // given
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        var lookup = new SpringEventSourcedEntityLookup(List.of(getClass().getPackageName()));
+
+        // when
+        lookup.postProcessBeanFactory(beanFactory);
+
+        // then
+        assertThat(beanFactory.containsBeanDefinition("abstractRootWithConcreteTypes$$Registrar")).isTrue();
+        assertConfigurerTargets(beanFactory,
+                                "abstractRootWithConcreteTypes$$Registrar",
+                                AbstractRootWithConcreteTypes.class,
+                                String.class);
+    }
+
+    @Test
+    void doesNotScanForAbstractRootsWhenNoBasePackagesAreConfigured() {
+        // given
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+
+        // when
+        new SpringEventSourcedEntityLookup().postProcessBeanFactory(beanFactory);
+
+        // then
+        assertThat(beanFactory.containsBeanDefinition("abstractRootWithConcreteTypes$$Registrar")).isFalse();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void assertConfigurerTargets(DefaultListableBeanFactory beanFactory,
+                                                String registrarBeanName,
+                                                Class<?> expectedEntityType,
+                                                Class<?> expectedIdType) {
+        var configurer = (SpringEventSourcedEntityConfigurer<Object, Object>) beanFactory.getBean(registrarBeanName);
+
+        ComponentRegistry registry = mock();
+        configurer.enhance(registry);
+
+        var moduleCaptor = ArgumentCaptor.forClass(Module.class);
+        verify(registry).registerModule(moduleCaptor.capture());
+        assertThat(moduleCaptor.getValue()).isInstanceOf(EventSourcedEntityModule.class);
+        assertThat(moduleCaptor.getValue().name())
+                .isEqualTo("AnnotatedEventSourcedEntityModule<"
+                                   + expectedIdType.getName() + ", " + expectedEntityType.getName() + ">");
+    }
+
+    @EventSourced(idType = String.class)
+    abstract static class IndividuallyAnnotatedRoot {
+
+    }
+
+    @EventSourced(idType = String.class)
+    static class IndividuallyAnnotatedSubtype extends IndividuallyAnnotatedRoot {
+
+    }
+
+    @EventSourced(idType = String.class, concreteTypes = ConcreteWithoutOwnAnnotation.class)
+    abstract static class AbstractRootWithConcreteTypes {
+
+    }
+
+    static class ConcreteWithoutOwnAnnotation extends AbstractRootWithConcreteTypes {
+
+    }
+}

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookupTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringEventSourcedEntityLookupTest.java
@@ -25,6 +25,7 @@ import org.mockito.*;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.annotation.AnnotatedBeanDefinitionReader;
 
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +71,25 @@ class SpringEventSourcedEntityLookupTest {
     }
 
     @Test
+    void doesNotDoubleRegisterAbstractRootReachableByBothDiscoveryPaths() {
+        // given
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        new AnnotatedBeanDefinitionReader(beanFactory).register(IndividuallyAnnotatedSubtype.class);
+        var lookup = new SpringEventSourcedEntityLookup(List.of(getClass().getPackageName()));
+
+        // when
+        lookup.postProcessBeanFactory(beanFactory);
+
+        // then
+        // The classpath scan also finds AbstractRootWithConcreteTypes (a sibling nested test class in this same
+        // package), so we count registrars targeting IndividuallyAnnotatedRoot specifically, rather than the total.
+        long registrarsTargetingRoot = countConfigurersTargeting(beanFactory,
+                                                                 IndividuallyAnnotatedRoot.class,
+                                                                 String.class);
+        assertThat(registrarsTargetingRoot).isEqualTo(1);
+    }
+
+    @Test
     void doesNotScanForAbstractRootsWhenNoBasePackagesAreConfigured() {
         // given
         DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
@@ -81,11 +101,36 @@ class SpringEventSourcedEntityLookupTest {
         assertThat(beanFactory.containsBeanDefinition("abstractRootWithConcreteTypes$$Registrar")).isFalse();
     }
 
-    @SuppressWarnings("unchecked")
     private static void assertConfigurerTargets(DefaultListableBeanFactory beanFactory,
                                                 String registrarBeanName,
                                                 Class<?> expectedEntityType,
                                                 Class<?> expectedIdType) {
+        assertThat(moduleNameOf(beanFactory, registrarBeanName))
+                .isEqualTo(expectedModuleName(expectedEntityType, expectedIdType));
+    }
+
+    private static long countConfigurersTargeting(DefaultListableBeanFactory beanFactory,
+                                                  Class<?> expectedEntityType,
+                                                  Class<?> expectedIdType) {
+        String expectedModuleName = expectedModuleName(expectedEntityType, expectedIdType);
+        return Arrays.stream(beanFactory.getBeanNamesForType(SpringEventSourcedEntityConfigurer.class))
+                     .filter(registrarBeanName -> expectedModuleName.equals(
+                             moduleNameOf(beanFactory, registrarBeanName)
+                     ))
+                     .count();
+    }
+
+    private static String expectedModuleName(Class<?> expectedEntityType,
+                                             Class<?> expectedIdType) {
+        return "AnnotatedEventSourcedEntityModule<"
+                + expectedIdType.getName()
+                + ", "
+                + expectedEntityType.getName()
+                + ">";
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String moduleNameOf(DefaultListableBeanFactory beanFactory, String registrarBeanName) {
         var configurer = (SpringEventSourcedEntityConfigurer<Object, Object>) beanFactory.getBean(registrarBeanName);
 
         ComponentRegistry registry = mock();
@@ -94,9 +139,7 @@ class SpringEventSourcedEntityLookupTest {
         var moduleCaptor = ArgumentCaptor.forClass(Module.class);
         verify(registry).registerModule(moduleCaptor.capture());
         assertThat(moduleCaptor.getValue()).isInstanceOf(EventSourcedEntityModule.class);
-        assertThat(moduleCaptor.getValue().name())
-                .isEqualTo("AnnotatedEventSourcedEntityModule<"
-                                   + expectedIdType.getName() + ", " + expectedEntityType.getName() + ">");
+        return moduleCaptor.getValue().name();
     }
 
     @EventSourced(idType = String.class)


### PR DESCRIPTION
This PR ensures that the documented contract, that a user only is required to annotated the parent/root entity with `@EventSourced`, as adhered to.
To that end, we scan for abstract classes containing the `@EventSourced` ourselves by allowing the `SpringEventSourcedEntityLookup` to set the base packages to scan for `@EventSourced` annotated abstract classes on. 
This adds a second path to the overall event-sourced entity scan flow, specific for polymorphic entities.
To have this work in combination with Spring Boot, the `InfrastructureAutoConfiguration` now constructs a `SpringEventSourcedEntityLookup` using the base packages retrieved from the `ConfigurableListableBeanFactory`
Lastly, tests were added to validate all the behavior.

In doing the above, this PR resolves #4906.
Note that it's based on #4904, as that also resolves polymoprhic-entity-specific issues.