### PR TITLE
[#4924] Release the token claim after the segment release listeners

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -1514,12 +1514,12 @@ class Coordinator {
                            }
                        })
                        .thenCompose(unused -> unitOfWorkFactory.create().executeWithResult(
-                               // Persist the final safe token (strategy onSegmentReleased -> store) WHILE the claim is
-                               // still held, then release the claim LAST so no other node can resume past durable
-                               // progress.
+                               // Persist the final safe token (strategy onSegmentReleased -> store) and let the release
+                               // listeners wind down WHILE the claim is still held, then release the claim LAST so no
+                               // other node can resume past durable progress or pick up work still running here.
                                context -> work.onSegmentReleased(context)
+                                              .thenCompose(r -> notifyReleaseListeners(work.segment()))
                                               .thenCompose(r -> tokenStore.releaseClaim(name, segmentId, context))
-                                              .thenCompose(r -> segmentChangeListener.onSegmentReleased(work.segment()))
                        ))
                        .exceptionally(throwable -> {
                            Throwable unwrapped = throwable instanceof CompletionException ce ? ce.getCause() : throwable;
@@ -1534,6 +1534,42 @@ class Coordinator {
                                    unwrapped);
                            return null;
                        });
+        }
+
+        /**
+         * Invokes the {@link SegmentChangeListener#onSegmentReleased(Segment) release listeners} for the given
+         * {@code segment} and waits for them to finish, giving them the chance to wind down their work before the claim
+         * is handed over.
+         * <p>
+         * The wait is bounded by the
+         * {@link PooledStreamingEventProcessorConfiguration#claimExtensionThreshold(long) claim extension threshold},
+         * since the claim of an aborted work package is no longer extended and would go stale beyond it anyhow.
+         * Listeners that time out or fail do not keep the claim held: the returned {@link CompletableFuture} completes
+         * normally regardless, so the claim is always released afterwards.
+         *
+         * @param segment the released {@link Segment} to notify the listeners of
+         * @return a {@link CompletableFuture} completing once the listeners are done, timed out, or failed
+         */
+        private CompletableFuture<Void> notifyReleaseListeners(Segment segment) {
+            return segmentChangeListener.onSegmentReleased(segment)
+                                        // Copied, as orTimeout completes the future it is invoked on.
+                                        .copy()
+                                        .orTimeout(claimExtensionThreshold, TimeUnit.MILLISECONDS)
+                                        .exceptionally(throwable -> {
+                                            Throwable unwrapped = throwable instanceof CompletionException ce
+                                                    ? ce.getCause() : throwable;
+                                            if (unwrapped instanceof Error error) {
+                                                throw error;
+                                            }
+                                            logger.warn(
+                                                    "Processor [{}] (Coordination Task [{}]). Release listeners for [{}] failed or exceeded the claim extension threshold of [{}]ms; releasing the claim regardless.",
+                                                    name,
+                                                    generation,
+                                                    segment,
+                                                    claimExtensionThreshold,
+                                                    unwrapped);
+                                            return null;
+                                        });
         }
 
         private void advanceReleaseDeadlineFor(int segmentId) {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentChangeListener.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/segmenting/SegmentChangeListener.java
@@ -99,6 +99,11 @@ public interface SegmentChangeListener {
 
     /**
      * Invoked when a segment has been released.
+     * <p>
+     * Invoked while the claim on the {@code segment} is still held, so a listener can wind down the work it runs for
+     * that segment before another node can pick it up. The claim is released once the returned
+     * {@link CompletableFuture} completes, or once the processor's claim extension threshold has passed, whichever
+     * comes first.
      *
      * @param segment released {@link Segment}
      * @return {@link CompletableFuture} that completes when handling has finished

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -833,6 +833,72 @@ class CoordinatorTest {
         }
 
         @Test
+        void holdsTokenClaimUntilOnSegmentReleasedCompleted() throws NoSuchFieldException {
+            // given - a release listener recording whether the claim was still held when it was invoked
+            AtomicBoolean claimReleased = new AtomicBoolean(false);
+            AtomicReference<Boolean> claimHeldWhileReleasing = new AtomicReference<>();
+            Coordinator coordinator = buildCoordinatorWith(
+                    builder -> builder.segmentChangeListener(SegmentChangeListener.onRelease(segment -> {
+                        claimHeldWhileReleasing.set(!claimReleased.get());
+                        return emptyCompletedFuture();
+                    }))
+            );
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
+                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
+            doAnswer(invocation -> {
+                claimReleased.set(true);
+                return emptyCompletedFuture();
+            }).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            Map<Integer, WorkPackage> workPackages =
+                    ReflectionUtils.getFieldValue(Coordinator.class.getDeclaredField("workPackages"), coordinator);
+            workPackages.put(SEGMENT_ID, workPackage);
+
+            // when
+            awaitStart(coordinator);
+
+            // then - the claim is only released once the release listener has finished winding down
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any()));
+            assertThat(claimHeldWhileReleasing).hasValue(true);
+        }
+
+        @Test
+        void releasesTokenClaimWhenOnSegmentReleasedNeverCompletes() throws NoSuchFieldException {
+            // given - a release listener that never completes, and a short claim extension threshold to bound the wait
+            Coordinator coordinator = buildCoordinatorWith(
+                    builder -> builder.claimExtensionThreshold(100)
+                                      .segmentChangeListener(SegmentChangeListener.onRelease(
+                                              segment -> new CompletableFuture<>()
+                                      ))
+            );
+
+            doReturn(completedFuture(SEGMENTS)).when(tokenStore).fetchSegments(eq(PROCESSOR_NAME), any());
+            doReturn(completedFuture(Collections.emptyList())).when(tokenStore)
+                                                              .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
+            doReturn(SEGMENT_ZERO).when(workPackage).segment();
+            doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
+            doReturn(emptyCompletedFuture()).when(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
+            doAnswer(runTaskSync()).when(executorService).submit(any(Runnable.class));
+
+            Map<Integer, WorkPackage> workPackages =
+                    ReflectionUtils.getFieldValue(Coordinator.class.getDeclaredField("workPackages"), coordinator);
+            workPackages.put(SEGMENT_ID, workPackage);
+
+            // when
+            awaitStart(coordinator);
+
+            // then - the hanging listener does not hold on to the claim indefinitely
+            await().atMost(5, TimeUnit.SECONDS)
+                   .untilAsserted(() -> verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any()));
+        }
+
+        @Test
         void onSegmentReleasedFailureIsHandledGracefully() throws NoSuchFieldException {
             // given - coordinator with a release listener that always fails
             Coordinator coordinator = Coordinator.builder()
@@ -864,7 +930,8 @@ class CoordinatorTest {
             // when
             awaitStart(coordinator);
 
-            // then - the failure is swallowed by the exceptionally handler and a retry is still scheduled
+            // then - the failure does not keep the claim held, and a retry is still scheduled
+            verify(tokenStore).releaseClaim(eq(PROCESSOR_NAME), anyInt(), any());
             verify(executorService).schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
         }
     }


### PR DESCRIPTION
Relates to #4924, found in the same sharding work.

### Problem

`Coordinator.abortWorkPackage` releases the token claim *before* it invokes
`SegmentChangeListener#onSegmentReleased`:

```java
context -> work.onSegmentReleased(context)
               .thenCompose(r -> tokenStore.releaseClaim(name, segmentId, context))
               .thenCompose(r -> segmentChangeListener.onSegmentReleased(work.segment()))
```

By the time a listener runs, the claim row names nobody and a peer may already own the
segment. The `CompletableFuture` the callback returns is awaited after the hand-off it was
meant to precede, which makes it useless for draining.

Measured on a multi-JVM rig (forked JVM nodes, shared Postgres `JdbcTokenStore`, real Axon
Server): a planned rebalance moved segment 0 to node B, the claim row named B 565 ms into a
step body still running on node A, node B restored the same state, and node A wrote that
steps side effect 44 560 ms after the row named B. Both nodes ran the same work.

### Fix

Invoke the release listeners while the claim is still held, release the claim once they
complete. The wait is bounded by the existing `claimExtensionThreshold`, since the claim of
an aborted work package is no longer extended past it and would go stale anyway; on timeout
or failure a warning names the segment and the claim is released regardless.

`abortWorkPackage` is the only place in the coordinator that releases a claim, so all paths
(shutdown, error, rebalance, split/merge abort) get the ordering.

### Test

`CoordinatorTest.holdsTokenClaimUntilOnSegmentReleasedCompleted` records the claim state from
inside the listener; it fails on the unfixed ordering. Plus a hanging-listener test covering
the timeout, and `onSegmentReleasedFailureIsHandledGracefully` now also asserts the claim is
released.