### PR TITLE
Return `ManagedEntity` from `Repository` and provided to `@InjectEntity` annotated parameters at all times

### DIFF
--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/CardIssued.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/CardIssued.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+record CardIssued(String cardId, double amount) {
+}

--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/CardRedeemed.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/CardRedeemed.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+record CardRedeemed(String cardId, double amount) {
+}

--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/GiftCard.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/GiftCard.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+// tag::giftcard-entity[]
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+
+@EventSourcedEntity(tagKey = "cardId")
+public class GiftCard {
+
+    private String cardId;
+    private double amount;
+
+    @EntityCreator
+    public GiftCard() {}
+
+    @EventSourcingHandler
+    void on(CardIssued event) {
+        this.cardId = event.cardId();
+        this.amount = event.amount();
+    }
+
+    @EventSourcingHandler
+    void on(CardRedeemed event) {
+        this.amount -= event.amount();
+    }
+
+    String cardId() { return cardId; }
+    double amount() { return amount; }
+}
+// end::giftcard-entity[]

--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/GiftCardCommands.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/GiftCardCommands.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+import org.axonframework.modelling.annotation.TargetEntityId;
+
+class GiftCardCommands {
+
+    public record IssueCard(@TargetEntityId String cardId, double amount) {}
+
+    public record IssueCardWithInitialRedemption(
+            @TargetEntityId String cardId, double amount, double initialRedemption
+    ) {}
+}

--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/GiftCardCreateIfMissingHandler.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/GiftCardCreateIfMissingHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+import commands.entities.statefulcommandhandler.GiftCardCommands.IssueCardWithInitialRedemption;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.InjectEntity;
+import org.axonframework.modelling.repository.ManagedEntity;
+
+public class GiftCardCreateIfMissingHandler {
+
+    // tag::managed-entity-create-if-missing-handler[]
+    @CommandHandler
+    public void handle(IssueCardWithInitialRedemption command,
+                       @InjectEntity ManagedEntity<String, GiftCard> card,
+                       EventAppender appender) {
+        if (card.entity() != null) {
+            throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
+        }
+        appender.append(new CardIssued(command.cardId(), command.amount()));
+
+        // card.entity() now reflects the CardIssued event appended above.
+        GiftCard issued = card.entity();
+        if (issued.amount() - command.initialRedemption() < 0) {
+            throw new IllegalStateException("Insufficient funds");
+        }
+        appender.append(new CardRedeemed(command.cardId(), command.initialRedemption()));
+    }
+    // end::managed-entity-create-if-missing-handler[]
+}

--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/ManagedEntityGiftCardHandler.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/ManagedEntityGiftCardHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+import commands.entities.statefulcommandhandler.GiftCardCommands.IssueCard;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.InjectEntity;
+import org.axonframework.modelling.repository.ManagedEntity;
+
+public class ManagedEntityGiftCardHandler {
+
+    // tag::managed-entity-handler[]
+    @CommandHandler
+    public void handle(IssueCard command,
+                       @InjectEntity ManagedEntity<String, GiftCard> card,
+                       EventAppender appender) {
+        if (card.entity() == null) {
+            appender.append(new CardIssued(command.cardId(), command.amount()));
+        } else {
+            throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
+        }
+    }
+    // end::managed-entity-handler[]
+}

--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/NullableGiftCardHandler.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/NullableGiftCardHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+import commands.entities.statefulcommandhandler.GiftCardCommands.IssueCard;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.InjectEntity;
+import org.jspecify.annotations.Nullable;
+
+public class NullableGiftCardHandler {
+
+    // tag::nullable-entity-handler[]
+    @CommandHandler
+    public void handle(IssueCard command,
+                       @InjectEntity @Nullable GiftCard card,
+                       EventAppender appender) {
+        if (card == null) {
+            appender.append(new CardIssued(command.cardId(), command.amount()));
+        } else {
+            throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
+        }
+    }
+    // end::nullable-entity-handler[]
+}

--- a/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/OptionalGiftCardHandler.java
+++ b/docs/reference-guide/modules/commands/examples/commands/entities/statefulcommandhandler/OptionalGiftCardHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package commands.entities.statefulcommandhandler;
+
+import commands.entities.statefulcommandhandler.GiftCardCommands.IssueCard;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.InjectEntity;
+
+import java.util.Optional;
+
+public class OptionalGiftCardHandler {
+
+    // tag::optional-entity-handler[]
+    @CommandHandler
+    public void handle(IssueCard command,
+                       @InjectEntity Optional<GiftCard> card,
+                       EventAppender appender) {
+        if (card.isEmpty()) {
+            appender.append(new CardIssued(command.cardId(), command.amount()));
+        } else {
+            throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
+        }
+    }
+    // end::optional-entity-handler[]
+}

--- a/docs/reference-guide/modules/commands/pages/entities/stateful-command-handler.adoc
+++ b/docs/reference-guide/modules/commands/pages/entities/stateful-command-handler.adoc
@@ -66,43 +66,34 @@ Without either attribute set, Axon falls back to the default resolver, which rea
 By default, an `@InjectEntity` parameter requires the entity to exist.
 If no entity can be found for the resolved identifier, Axon throws an `EntityNotFoundException`, failing the command instead of invoking the handler.
 
-Annotate the parameter with **any** annotation matching `@Nullable` to opt into create-or-update semantics instead.
+Note that this existence check applies regardless of how the entity's `@EntityCreator` (applicable to event-sourced entities **only**, as detailed further link:entity-creator.adoc[here]) constructs it.
+Even a no-arg or identifier-based creator, which do not need a preceding event to produce an instance, only create said entity if that instance actually exists.
+The same holds for `ManagedEntity.entity()`, for which the behavior is further explained xref:inject_a_managed_entity[here].
+
+Annotate the parameter with **any** annotation matching `@Nullable` to opt out having the `EntityNotFoundException` thrown whenever the entity does not exist.
+In doing so, you can effectively opt **into** create-or-update semantics instead.
 A `@Nullable @InjectEntity` parameter resolves to `null` when the entity does not exist yet, allowing the handler to decide whether to create it:
 
 [source,java]
 ----
-@CommandHandler
-public void handle(IssueCard command, @InjectEntity @Nullable GiftCard card, EventAppender appender) {
-    if (card == null) {
-        appender.append(new CardIssued(command.cardId(), command.amount()));
-    } else {
-        throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
-    }
-}
+include::example$commands/entities/statefulcommandhandler/NullableGiftCardHandler.java[tag=nullable-entity-handler,indent=0]
 ----
 
 Declaring the parameter as `Optional<GiftCard>` achieves the same outcome without needing a `@Nullable` annotation:
 
 [source,java]
 ----
-@CommandHandler
-public void handle(IssueCard command, @InjectEntity Optional<GiftCard> card, EventAppender appender) {
-    if (card.isEmpty()) {
-        appender.append(new CardIssued(command.cardId(), command.amount()));
-    } else {
-        throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
-    }
-}
+include::example$commands/entities/statefulcommandhandler/OptionalGiftCardHandler.java[tag=optional-entity-handler,indent=0]
 ----
-
-The same works for a `ManagedEntity` parameter which can be injected with the `@InjectEntity` annotation. Either mark it `@Nullable` to allow receiving it as a `null`, or declare it as `Optional<ManagedEntity<ID, GiftCard>>` instead.
 
 In Kotlin, the nullable type carries this information on its own, so no annotation is required:
 
 [source,kotlin]
 ----
 @CommandHandler
-fun handle(command: IssueCard, @InjectEntity card: GiftCard?, appender: EventAppender) {
+fun handle(command: IssueCard,
+           @InjectEntity card: GiftCard?,
+           appender: EventAppender) {
     if (card == null) {
         appender.append(CardIssued(command.cardId, command.amount))
     } else {
@@ -122,8 +113,28 @@ A parameter declared as a non-null `GiftCard` fails even when annotated `@Nullab
 Write `GiftCard?` to accept a missing entity.
 ====
 
-This existence check applies regardless of how the entity's `@EntityCreator` constructs it.
-Even a no-arg or identifier-based creator, which does not need a preceding event to produce an instance, only does so once that instance actually exists; before that, both a no-arg-created and an identifier-created entity behave the same as one that requires an event to construct.
+[#inject_a_managed_entity]
+=== Working with a ManagedEntity instead
+
+Everything above concerns the entity type itself.
+Declare the parameter as `ManagedEntity<ID, GiftCard>` instead, and none of it applies: Axon always gives you the wrapper exactly as resolved, whether or not it carries a `@Nullable` annotation.
+Only `ManagedEntity.entity()` can be `null`.The wrapper itself never is:
+
+[source,java]
+----
+include::example$commands/entities/statefulcommandhandler/ManagedEntityGiftCardHandler.java[tag=managed-entity-handler,indent=0]
+----
+
+Because the wrapper itself is never replaced, it keeps working after the handler appends an event.
+An event-sourced entity stays subscribed to live updates, so appending an event evolves that same `ManagedEntity` in place.
+That lets a handler make a second decision, later in the same method, based on state an event earlier in that method just established:
+
+[source,java]
+----
+include::example$commands/entities/statefulcommandhandler/GiftCardCreateIfMissingHandler.java[tag=managed-entity-create-if-missing-handler,indent=0]
+----
+
+`Optional<ManagedEntity<ID, GiftCard>>` is not a valid parameter type: since the wrapper is never `null`, wrapping it in an `Optional` would never be empty, so Axon rejects such a parameter when configuring the handler.
 
 [#_injecting_multiple_entities]
 == Injecting multiple entities

--- a/docs/reference-guide/modules/commands/pages/entities/stateful-command-handler.adoc
+++ b/docs/reference-guide/modules/commands/pages/entities/stateful-command-handler.adoc
@@ -34,7 +34,7 @@ include::example$commands/entities/statefulcommandhandler/CourseCommandHandler.j
 <1> Creational handlers do not receive an entity parameter; the course does not yet exist and is created when `CourseCreated` is published.
 
 <2> `@InjectEntity` tells Axon to load the `Course` entity before invoking this handler.
-By default, the entity ID is read from the `@TargetEntityId`-annotated field on the command payload; see <<_resolving_the_entity_identifier>> for the other options.
+By default, the entity ID is read from the `@TargetEntityId`-annotated field on the command payload; see <<resolve_entity_id>> for the other options.
 
 <3> The handler reads entity state to make a decision.
 No event is appended if the name has not changed; an idempotent pattern common in this style.
@@ -48,19 +48,19 @@ include::example$commands/entities/statefulcommandhandler/CourseCommands.java[ta
 
 For how to define the entity itself (state fields, event sourcing handlers, and configuration), see xref:commands:entities/event-sourced-entity.adoc[Event-sourced entities].
 
-[#_resolving_the_entity_identifier]
+[#resolve_entity_id]
 == Resolving the entity identifier
 
 `@InjectEntity` needs an identifier to look up the entity.
 The annotation offers two attributes for controlling how that identifier is resolved from the incoming command:
 
 * **`idProperty`**: name a field on the command payload directly: `@InjectEntity(idProperty = "courseId")`.
-Useful when the command targets multiple entities (see <<_injecting_multiple_entities>>) or when the relevant field is not marked with `@TargetEntityId`.
+Useful when the command targets multiple entities (see <<inject_multiple_entities>>) or when the relevant field is not marked with `@TargetEntityId`.
 * **`idResolver`**: supply a class implementing `EntityIdResolver` for custom extraction logic, useful when the identifier is computed from multiple fields or requires lookup logic.
 
 Without either attribute set, Axon falls back to the default resolver, which reads the field marked with `@TargetEntityId` on the command payload (the form used in the example above).
 
-[#_handling_a_missing_entity]
+[#missing_injected_entity]
 == Handling a missing entity
 
 By default, an `@InjectEntity` parameter requires the entity to exist.
@@ -68,7 +68,7 @@ If no entity can be found for the resolved identifier, Axon throws an `EntityNot
 
 Note that this existence check applies regardless of how the entity's `@EntityCreator` (applicable to event-sourced entities **only**, as detailed further link:entity-creator.adoc[here]) constructs it.
 Even a no-arg or identifier-based creator, which do not need a preceding event to produce an instance, only create said entity if that instance actually exists.
-The same holds for `ManagedEntity.entity()`, for which the behavior is further explained xref:inject_a_managed_entity[here].
+The same holds for `ManagedEntity.entity()`, for which the behavior is further explained xref:inject_managed_entity[here].
 
 Annotate the parameter with **any** annotation matching `@Nullable` to opt out having the `EntityNotFoundException` thrown whenever the entity does not exist.
 In doing so, you can effectively opt **into** create-or-update semantics instead.
@@ -113,7 +113,7 @@ A parameter declared as a non-null `GiftCard` fails even when annotated `@Nullab
 Write `GiftCard?` to accept a missing entity.
 ====
 
-[#inject_a_managed_entity]
+[#inject_managed_entity]
 === Working with a ManagedEntity instead
 
 Everything above concerns the entity type itself.
@@ -136,7 +136,7 @@ include::example$commands/entities/statefulcommandhandler/GiftCardCreateIfMissin
 
 `Optional<ManagedEntity<ID, GiftCard>>` is not a valid parameter type: since the wrapper is never `null`, wrapping it in an `Optional` would never be empty, so Axon rejects such a parameter when configuring the handler.
 
-[#_injecting_multiple_entities]
+[#inject_multiple_entities]
 == Injecting multiple entities
 
 A single handler method can receive more than one entity.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -215,7 +215,8 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
     private void initializeIfAbsent(ID identifier,
                                     ProcessingContext context,
                                     EventSourcedEntity<ID, E> entity) {
-        entity.applyStateChange(current -> current != null ? current : initializeQuietly(identifier, context));
+        E initialized = initializeQuietly(identifier, context);
+        entity.applyStateChange(current -> current != null ? current : initialized);
     }
 
     /**
@@ -235,7 +236,8 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      * @return the initialized entity, or {@code null} when the {@code lifecycleHandler} reports the entity does not
      * exist yet
      */
-    private @Nullable E initializeQuietly(ID identifier, ProcessingContext context) {
+    @Nullable
+    private E initializeQuietly(ID identifier, ProcessingContext context) {
         try {
             return lifecycleHandler.initialize(identifier, context);
         } catch (EntityNotFoundException e) {
@@ -259,7 +261,8 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
     private void updateActiveEntity(EventSourcedEntity<ID, E> entity, ProcessingContext processingContext,
                                     Throwable exception) {
         if (exception == null) {
-            updateActiveEntity(entity, processingContext);}
+            updateActiveEntity(entity, processingContext);
+        }
     }
 
     /**

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -312,8 +312,9 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
             return currentState.get();
         }
 
+        @Nullable
         @Override
-        public M applyStateChange(UnaryOperator<M> change) {
+        public M applyStateChange(UnaryOperator<@Nullable M> change) {
             return currentState.updateAndGet(change);
         }
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/EventSourcingRepository.java
@@ -177,7 +177,6 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
     private CompletableFuture<ManagedEntity<ID, E>> doLoad(ID identifier,
                                                            boolean create,
                                                            ProcessingContext context) {
-        AtomicReference<EntityNotFoundException> failureRef = new AtomicReference<>();
         var managedEntities = context.computeResourceIfAbsent(managedEntitiesKey, ConcurrentHashMap::new);
 
         return managedEntities.computeIfAbsent(
@@ -185,7 +184,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
                 id -> lifecycleHandler.source(identifier, context)
                                       .thenApply(
                                               entity -> create && entity == null
-                                                      ? catchAndAllowForEntityNotFound(identifier, context, failureRef)
+                                                      ? initializeQuietly(identifier, context)
                                                       : entity
                                       )
                                       .thenApply(e -> new EventSourcedEntity<>(identifier, e))
@@ -195,10 +194,6 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
         ).thenApply(
                 entity -> {
                     if (create && entity.entity() == null) {
-                        EntityNotFoundException failure = failureRef.get();
-                        if (failure != null) {
-                            throw failure;
-                        }
                         initializeIfAbsent(identifier, context, entity);
                     }
                     return entity;
@@ -207,8 +202,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
     }
 
     /**
-     * Initializes the state of the given {@code entity} through the
-     * {@link EntityLifecycleHandler#initialize(Object, ProcessingContext) lifecycle handler}, unless it already holds
+     * Initializes the state of the given {@code entity} through {@link #initializeQuietly}, unless it already holds
      * state.
      * <p>
      * The given {@link EventSourcedEntity} instance is kept, so callers already holding a reference to it observe the
@@ -217,13 +211,11 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      * @param identifier the identifier of the entity to initialize
      * @param context    the {@link ProcessingContext} to initialize the entity in
      * @param entity     the managed entity to initialize the state of
-     * @throws EntityNotFoundException when the entity cannot be constructed from its identifier alone
      */
     private void initializeIfAbsent(ID identifier,
                                     ProcessingContext context,
                                     EventSourcedEntity<ID, E> entity) {
-        E initialized = lifecycleHandler.initialize(identifier, context);
-        entity.applyStateChange(current -> current != null ? current : initialized);
+        entity.applyStateChange(current -> current != null ? current : initializeQuietly(identifier, context));
     }
 
     /**
@@ -234,25 +226,19 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
      * subscribed} for live updates even though the entity does not exist yet: if the caller (e.g. a command handler
      * resolving an {@code @InjectEntity} parameter with create-or-update semantics) subsequently appends creation
      * events for the same identifier within the same {@link ProcessingContext}, those events are applied to this
-     * entity via its subscription, so a later {@link #doLoad} call for the same identifier observes the created
-     * entity instead of a permanently poisoned not-found result. The caught exception is captured in
-     * {@code failureRef} so the caller whose invocation actually triggered it can still see the original
-     * exception instance.
+     * entity via its subscription. Since {@link #doLoad} never lets this exception escape, the caller always
+     * receives the {@link ManagedEntity} wrapper itself - whether the entity could be constructed or not is
+     * reflected solely by {@link ManagedEntity#entity()} being {@code null}.
      *
-     * @param identifier    the identifier of the entity to initialize
-     * @param context       the {@link ProcessingContext} to initialize the entity in
-     * @param failureRef captures the original {@link EntityNotFoundException}, if any, thrown by the
-     *                      {@code lifecycleHandler}
+     * @param identifier the identifier of the entity to initialize
+     * @param context    the {@link ProcessingContext} to initialize the entity in
      * @return the initialized entity, or {@code null} when the {@code lifecycleHandler} reports the entity does not
      * exist yet
      */
-    private @Nullable E catchAndAllowForEntityNotFound(ID identifier,
-                                                       ProcessingContext context,
-                                                       AtomicReference<EntityNotFoundException> failureRef) {
+    private @Nullable E initializeQuietly(ID identifier, ProcessingContext context) {
         try {
             return lifecycleHandler.initialize(identifier, context);
         } catch (EntityNotFoundException e) {
-            failureRef.set(e);
             return null;
         }
     }
@@ -273,8 +259,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
     private void updateActiveEntity(EventSourcedEntity<ID, E> entity, ProcessingContext processingContext,
                                     Throwable exception) {
         if (exception == null) {
-            updateActiveEntity(entity, processingContext);
-        }
+            updateActiveEntity(entity, processingContext);}
     }
 
     /**
@@ -304,7 +289,7 @@ public class EventSourcingRepository<ID, E> implements Repository.LifecycleManag
     private static class EventSourcedEntity<ID, M> implements ManagedEntity<ID, M> {
 
         private final ID identifier;
-        private final AtomicReference<M> currentState;
+        private final AtomicReference<@Nullable M> currentState;
 
         private EventSourcedEntity(ID identifier, @Nullable M currentState) {
             this.identifier = identifier;

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIT.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIT.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 
@@ -56,6 +57,7 @@ import static org.mockito.Mockito.*;
  */
 @ExtendWith(MockitoExtension.class)
 class EventSourcingRepositoryIT {
+
     private EventStore eventStore = mock();
     private EventStoreTransaction eventStoreTransaction = mock();
     private EventSourcedEntityFactory<String, String> factory;
@@ -75,17 +77,17 @@ class EventSourcingRepositoryIT {
         };
 
         testSubject = new EventSourcingRepository<>(
-            String.class,
-            String.class,
-            new SimpleEntityLifecycleHandler<>(
-                eventStore,
-                (id, context) -> EventCriteria.havingAnyTag(),
-                new AnnotationBasedTagResolver(),
-                new InitializingEntityEvolver<>(
-                    (id, event, context) -> factory.create(id, event, context),
-                    (entity, event, context) -> entity + "-" + event.payload()
+                String.class,
+                String.class,
+                new SimpleEntityLifecycleHandler<>(
+                        eventStore,
+                        (id, context) -> EventCriteria.havingAnyTag(),
+                        new AnnotationBasedTagResolver(),
+                        new InitializingEntityEvolver<>(
+                                (id, event, context) -> factory.create(id, event, context),
+                                (entity, event, context) -> entity + "-" + event.payload()
+                        )
                 )
-            )
         );
 
         MessageStream<? extends EventMessage> stream = MessageStream.fromIterable(eventsToLoad);
@@ -97,7 +99,9 @@ class EventSourcingRepositoryIT {
     void loadEventSourcedEntity() {
         ProcessingContext processingContext = new StubProcessingContext();
 
-        ManagedEntity<String, String> result = testSubject.load("test", processingContext).join();
+        ManagedEntity<String, String> result = testSubject.load("test", processingContext)
+                                                          .orTimeout(2, TimeUnit.SECONDS)
+                                                          .join();
 
         assertEquals("test(0)-0-1", result.entity());
 
@@ -175,7 +179,9 @@ class EventSourcingRepositoryIT {
     void updateLoadedEventSourcedEntity() {
         ProcessingContext processingContext = new StubProcessingContext();
 
-        ManagedEntity<String, String> result = testSubject.load("test", processingContext).join();
+        ManagedEntity<String, String> result = testSubject.load("test", processingContext)
+                                                          .orTimeout(2, TimeUnit.SECONDS)
+                                                          .join();
 
         assertEquals("test(0)-0-1", result.entity());
 
@@ -194,8 +200,8 @@ class EventSourcingRepositoryIT {
     void loadOrCreateShouldLoadWhenEventsAreReturned() {
         ProcessingContext processingContext = new StubProcessingContext();
 
-        CompletableFuture<ManagedEntity<String, String>> result =
-                testSubject.load("test", processingContext);
+        CompletableFuture<ManagedEntity<String, String>> result = testSubject.load("test", processingContext)
+                                                                             .orTimeout(2, TimeUnit.SECONDS);
 
         assertEquals("test(0)-0-1", result.join().entity());
     }
@@ -213,7 +219,9 @@ class EventSourcingRepositoryIT {
             return null; // Simulating a null entity creation
         };
 
-        ManagedEntity<String, String> loaded = testSubject.loadOrCreate("test", processingContext).join();
+        ManagedEntity<String, String> loaded = testSubject.loadOrCreate("test", processingContext)
+                                                          .orTimeout(2, TimeUnit.SECONDS)
+                                                          .join();
 
         assertNull(loaded.entity());
     }
@@ -225,10 +233,13 @@ class EventSourcingRepositoryIT {
             return null; // Simulating a null entity creation
         };
 
-        assertThatThrownBy(() -> testSubject.load("test", processingContext).join())
-            .isInstanceOf(CompletionException.class)
-            .cause()
-            .isInstanceOf(EntityMissingAfterFirstEventException.class);
+        assertThatThrownBy(
+                () -> testSubject.load("test", processingContext)
+                                 .orTimeout(2, TimeUnit.SECONDS)
+                                 .join()
+        ).isInstanceOf(CompletionException.class)
+         .cause()
+         .isInstanceOf(EntityMissingAfterFirstEventException.class);
     }
 
     @Test
@@ -237,7 +248,9 @@ class EventSourcingRepositoryIT {
 
         eventsToLoad.clear();
 
-        ManagedEntity<String, String> loaded = testSubject.load("test", processingContext).join();
+        ManagedEntity<String, String> loaded = testSubject.load("test", processingContext)
+                                                          .orTimeout(2, TimeUnit.SECONDS)
+                                                          .join();
 
         assertNull(loaded.entity());
 
@@ -251,7 +264,9 @@ class EventSourcingRepositoryIT {
 
         eventsToLoad.clear();
 
-        ManagedEntity<String, String> loaded = testSubject.loadOrCreate("test", processingContext).join();
+        ManagedEntity<String, String> loaded = testSubject.loadOrCreate("test", processingContext)
+                                                          .orTimeout(2, TimeUnit.SECONDS)
+                                                          .join();
 
         assertEquals("test()", loaded.entity());
 

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIT.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryIT.java
@@ -28,14 +28,12 @@ import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
-import org.axonframework.modelling.repository.EntityNotFoundException;
 import org.axonframework.modelling.repository.ManagedEntity;
 import org.jspecify.annotations.NonNull;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.*;
+import org.mockito.*;
+import org.mockito.junit.jupiter.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,16 +44,9 @@ import java.util.function.UnaryOperator;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class validating the {@link EventSourcingRepository}.
@@ -210,7 +201,7 @@ class EventSourcingRepositoryIT {
     }
 
     @Test
-    void loadOrCreateThrowsExceptionWhenEventStreamIsEmptyAndNullEntityIsCreated() {
+    void loadOrCreateReturnsNullStateWhenEventStreamIsEmptyAndNullEntityIsCreated() {
         ProcessingContext processingContext = new StubProcessingContext();
 
         eventsToLoad.clear();
@@ -222,10 +213,9 @@ class EventSourcingRepositoryIT {
             return null; // Simulating a null entity creation
         };
 
-        assertThatThrownBy(() -> testSubject.loadOrCreate("test", processingContext).join())
-            .isInstanceOf(CompletionException.class)
-            .cause()
-            .isInstanceOf(EntityNotFoundException.class);
+        ManagedEntity<String, String> loaded = testSubject.loadOrCreate("test", processingContext).join();
+
+        assertNull(loaded.entity());
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/EventSourcingRepositoryTest.java
@@ -32,18 +32,16 @@ import org.axonframework.modelling.repository.ManagedEntity;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.*;
-import org.mockito.*;
 import org.mockito.junit.jupiter.*;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -240,25 +238,23 @@ class EventSourcingRepositoryTest {
 
         when(handler.initialize("test", processingContext)).thenThrow(new EntityNotFoundException("test"));
 
-        CompletableFuture<ManagedEntity<String, String>> firstResult =
-                testSubject.loadOrCreate("test", processingContext);
+        // Even though initialize() failed, loadOrCreate resolves normally to a ManagedEntity wrapping a null
+        // entity - the wrapper itself is still subscribed for live updates, which is what allows a
+        // same-unit-of-work creation to be observed by a later resolution instead of a poisoned result.
+        ManagedEntity<String, String> firstResult = testSubject.loadOrCreate("test", processingContext)
+                                                               .orTimeout(2, TimeUnit.SECONDS)
+                                                               .join();
 
-        ExecutionException firstException = assertThrows(ExecutionException.class, firstResult::get);
-        assertInstanceOf(EntityNotFoundException.class, firstException.getCause());
-
-        // Even though initialize() failed, the entity must still be subscribed for live updates - this is what
-        // allows a same-unit-of-work creation to be observed by a later resolution instead of a poisoned result.
-        @SuppressWarnings("unchecked")
-        ArgumentCaptor<ManagedEntity<String, String>> entityCaptor = ArgumentCaptor.forClass(ManagedEntity.class);
-        verify(handler).subscribe(entityCaptor.capture(), eq(processingContext));
-        ManagedEntity<String, String> subscribedEntity = entityCaptor.getValue();
+        assertNull(firstResult.entity());
+        verify(handler).subscribe(firstResult, processingContext);
 
         // Simulate a creation event being appended and applied via the onAppend callback a real
         // EntityLifecycleHandler would have registered through subscribe(...).
-        subscribedEntity.applyStateChange(current -> "test(created)");
+        firstResult.applyStateChange(current -> "test(created)");
 
         ManagedEntity<String, String> secondResult = testSubject.loadOrCreate("test", processingContext).join();
 
+        assertSame(firstResult, secondResult);
         assertEquals("test(created)", secondResult.entity());
     }
 
@@ -290,7 +286,7 @@ class EventSourcingRepositoryTest {
         }
 
         @Test
-        void loadOrCreateAfterNotFoundLoadFailsWhenTheEntityRequiresAFirstEvent() {
+        void loadOrCreateAfterNotFoundLoadReturnsSameInstanceWithNullStateWhenEntityRequiresAFirstEvent() {
             // given an entity that cannot be constructed from its identifier alone
             when(handler.initialize("test", processingContext)).thenThrow(new EntityNotFoundException("test"));
 
@@ -298,12 +294,14 @@ class EventSourcingRepositoryTest {
             assertThat(loaded.entity()).isNull();
 
             // when loadOrCreate follows for the same identifier in the same context
-            CompletableFuture<ManagedEntity<String, String>> result =
-                    testSubject.loadOrCreate("test", processingContext);
+            ManagedEntity<String, String> result = testSubject.loadOrCreate("test", processingContext)
+                                                              .orTimeout(2, TimeUnit.SECONDS)
+                                                              .join();
 
-            // then it fails, leaving the managed instance available for the first appended event to evolve
-            assertThatThrownBy(result::join).hasCauseInstanceOf(EntityNotFoundException.class);
-            assertThat(loaded.entity()).isNull();
+            // then it resolves normally, on the same managed instance, still available for the first appended
+            // event to evolve
+            assertThat(result).isSameAs(loaded);
+            assertThat(result.entity()).isNull();
         }
 
         @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SimpleEntityLifecycleHandlerTest.java
@@ -29,6 +29,7 @@ import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
 import org.axonframework.modelling.repository.ManagedEntity;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -143,7 +144,7 @@ class SimpleEntityLifecycleHandlerTest {
             }
 
             @Override
-            public Bike applyStateChange(UnaryOperator<Bike> change) {
+            public Bike applyStateChange(UnaryOperator<@Nullable Bike> change) {
                 return stateRef.updateAndGet(change);
             }
         };

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/handler/SnapshottingEntityLifecycleHandlerTest.java
@@ -44,6 +44,7 @@ import org.axonframework.messaging.eventhandling.SimpleEventBus;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
 import org.axonframework.modelling.repository.ManagedEntity;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -407,7 +408,7 @@ class SnapshottingEntityLifecycleHandlerTest {
             }
 
             @Override
-            public Account applyStateChange(UnaryOperator<Account> change) {
+            public Account applyStateChange(UnaryOperator<@Nullable Account> change) {
                 return stateRef.updateAndGet(change);
             }
         };

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/EntityCreationTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/EntityCreationTest.java
@@ -20,6 +20,7 @@ import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
 import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
 import org.axonframework.integrationtests.testsuite.giftcard.commands.IssueCardCommand;
+import org.axonframework.integrationtests.testsuite.giftcard.commands.IssueCardWithInitialRedemptionCommand;
 import org.axonframework.integrationtests.testsuite.giftcard.commands.RedeemCardCommand;
 import org.axonframework.integrationtests.testsuite.giftcard.state.GiftCardEventCreator;
 import org.axonframework.integrationtests.testsuite.giftcard.state.GiftCardEventCreatorStateful;
@@ -110,6 +111,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * regardless of the creator style: a non-{@code @Nullable}, non-{@code Optional} {@code @InjectEntity} parameter
  * always propagates an {@link EntityNotFoundException} instead of receiving an entity that was implicitly
  * constructed without a preceding event.
+ * <p>
+ * {@link IdentifierNullableEntityCreationStatefulCommandHandler} additionally validates a create-if-missing flow
+ * within a single command handling: a first event is appended for an entity that does not exist yet, after which a
+ * second, dependent event is appended based on the state the first event just established on the injected
+ * {@link org.axonframework.modelling.repository.ManagedEntity}.
  *
  * @author Steven van Beelen
  */
@@ -462,6 +468,31 @@ class EntityCreationTest {
             CompletableFuture<Void> result = commandGateway.send(new RedeemCardCommand("cardId", 1337), Void.class);
 
             assertThat(result).succeedsWithin(Duration.ofSeconds(2));
+        }
+
+        @Test
+        void createIfMissingSecondEventSucceedsWhenItRespectsStateEstablishedByTheFirstEvent() {
+            CompletableFuture<Void> result = commandGateway.send(
+                    new IssueCardWithInitialRedemptionCommand("cardId", 100, 40), Void.class
+            );
+
+            assertThat(result).succeedsWithin(Duration.ofSeconds(2));
+        }
+
+        @Test
+        void createIfMissingSecondEventFailsWhenItViolatesStateEstablishedByTheFirstEvent() {
+            // The initial redemption (100) exceeds the amount the card was just issued for (50): this only fails
+            // correctly if the injected ManagedEntity reflects the CardIssuedEvent's effect (amount=50) by the time
+            // the second event is decided upon, rather than the null it was originally resolved with, or the
+            // constructor's unrelated default of 9001.
+            CompletableFuture<Void> result = commandGateway.send(
+                    new IssueCardWithInitialRedemptionCommand("cardId", 50, 100), Void.class
+            );
+
+            assertThat(result).failsWithin(Duration.ofSeconds(2))
+                              .withThrowableOfType(ExecutionException.class)
+                              .havingCause()
+                              .withMessageContaining("Insufficient funds");
         }
     }
 

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/commands/IssueCardWithInitialRedemptionCommand.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/commands/IssueCardWithInitialRedemptionCommand.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.giftcard.commands;
+
+import org.axonframework.modelling.annotation.TargetEntityId;
+
+public record IssueCardWithInitialRedemptionCommand(
+        @TargetEntityId String cardId,
+        double amount,
+        double initialRedemption
+) {
+
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/state/NullableGiftCardIdCreatorStateful.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/state/NullableGiftCardIdCreatorStateful.java
@@ -21,6 +21,7 @@ import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
 import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
 import org.axonframework.eventsourcing.annotation.reflection.InjectEntityId;
 import org.axonframework.integrationtests.testsuite.giftcard.commands.IssueCardCommand;
+import org.axonframework.integrationtests.testsuite.giftcard.commands.IssueCardWithInitialRedemptionCommand;
 import org.axonframework.integrationtests.testsuite.giftcard.commands.RedeemCardCommand;
 import org.axonframework.integrationtests.testsuite.giftcard.events.CardIssuedEvent;
 import org.axonframework.integrationtests.testsuite.giftcard.events.CardRedeemedEvent;
@@ -32,12 +33,14 @@ import org.jspecify.annotations.Nullable;
 
 /**
  * A stateful command handler for which the entity is created based on the identifier, will succeed for instance command
- * handlers because the handler lives outside the entity and receives a {@code null} entity when it does not exist yet.
- * The type is deliberately wrapped in a {@link ManagedEntity} to validate nullability support for those as well.
+ * handlers because the handler lives outside the entity and receives an entity with a {@code null} state when it does
+ * not exist yet. The type is deliberately wrapped in a {@link ManagedEntity} to validate nullability support on said
+ * {@code ManagedEntity} as well.
  * <p>
- * Although the command defines the identifier and the constructor could produce an entity without any preceding event,
- * the {@code @InjectEntity} parameter is annotated {@code @Nullable} here, so it consistently resolves to {@code null}
- * when there is no event to source the entity from, just as the no-arg and event-based creator styles do.
+ * {@link #handle(IssueCardWithInitialRedemptionCommand, ManagedEntity, EventAppender)} additionally validates a
+ * create-if-missing flow: it appends a creation event, then relies on the injected {@link ManagedEntity} having
+ * observed that same event's effect - through its live subscription - before deciding on and appending a second,
+ * dependent event within the same command handling.
  *
  * @author Steven van Beelen
  */
@@ -45,9 +48,9 @@ public class NullableGiftCardIdCreatorStateful {
 
     @CommandHandler
     public void handle(IssueCardCommand command,
-                       @InjectEntity @Nullable ManagedEntity<String, GiftCard> entity,
+                       @InjectEntity ManagedEntity<String, GiftCard> entity,
                        EventAppender appender) {
-        if (entity == null) {
+        if (entity.entity() == null) {
             appender.append(new CardIssuedEvent(command.cardId(), command.amount()));
         } else {
             throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
@@ -65,6 +68,36 @@ public class NullableGiftCardIdCreatorStateful {
             throw new IllegalStateException("Insufficient funds");
         }
         appender.append(new CardRedeemedEvent(command.cardId(), command.amount()));
+    }
+
+    /**
+     * Create-if-missing in a single command handler invocation: issues the card, then redeems part of it right away.
+     * <p>
+     * The insufficient-funds check for the redemption reads {@code entity.entity()} again after appending the
+     * {@link CardIssuedEvent}. This only works because the injected {@code entity} is subscribed to live updates: the
+     * first {@code appender.append(...)} call evolves this very {@link ManagedEntity} in place before this method
+     * continues, so the second event's decision is based on the state the first event just established, rather than on
+     * the (already stale) {@code null} the parameter was originally resolved with.
+     */
+    @CommandHandler
+    public void handle(IssueCardWithInitialRedemptionCommand command,
+                       @InjectEntity ManagedEntity<String, GiftCard> entity,
+                       EventAppender appender) {
+        if (entity.entity() != null) {
+            throw new IllegalStateException("GiftCard for id [" + command.cardId() + "] already exists");
+        }
+        appender.append(new CardIssuedEvent(command.cardId(), command.amount()));
+
+        GiftCard issued = entity.entity();
+        if (issued == null) {
+            throw new IllegalStateException(
+                    "GiftCard for id [" + command.cardId() + "] was not created as expected"
+            );
+        }
+        if (issued.amount - command.initialRedemption() < 0) {
+            throw new IllegalStateException("Insufficient funds");
+        }
+        appender.append(new CardRedeemedEvent(command.cardId(), command.initialRedemption()));
     }
 
     @EventSourcedEntity(tagKey = "cardId")

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntity.java
@@ -18,6 +18,7 @@ package org.axonframework.modelling.annotation;
 
 import org.axonframework.messaging.core.annotation.MessageHandler;
 import org.axonframework.modelling.EntityIdResolver;
+import org.axonframework.modelling.repository.ManagedEntity;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -29,10 +30,12 @@ import java.lang.annotation.Target;
  * Annotation to be placed on a parameter of a {@link MessageHandler} annotated method that should receive an entity
  * loaded from the {@link org.axonframework.modelling.StateManager}.
  * <p>
- * The parameter should be of the type of the entity to inject, or of a
- * {@link org.axonframework.modelling.repository.ManagedEntity} with the generic of the entity to inject. Either can
- * also be wrapped in an {@link java.util.Optional}, for example {@code Optional<MyEntity>} or
- * {@code Optional<ManagedEntity<ID, MyEntity>>}.
+ * The parameter should be one of the following three options:
+ * <ol>
+ *     <li>The exact entity type to inject, marked nullable if null can be expected.</li>
+ *     <li>An {@link java.util.Optional} of the entity type to inject.</li>
+ *     <li>A {@link org.axonframework.modelling.repository.ManagedEntity} of the entity identifier and entity type to inject.</li>
+ * </ol>
  * <p>
  * The {@code idProperty} attribute can be used to specify the property of the message payload that contains the
  * identifier of the entity to inject. If not specified, the {@code idResolver} is used to resolve the identifier of the
@@ -49,14 +52,23 @@ import java.lang.annotation.Target;
  *     <li>From the {@link TargetEntityId} annotation on the message payload.</li>
  * </ol>
  * <p>
- * When no entity can be found for the resolved identifier, the parameter's type and nullability determine the
- * outcome. By default, an {@link org.axonframework.modelling.repository.EntityNotFoundException} is propagated,
- * failing the message being handled. A parameter annotated with an annotation resembling {@code "nullable"} will
- * instead resolve to {@code null}, allowing the handler to deal with a missing entity itself, for example to support
- * create-or-update semantics. Declaring the parameter as {@code Optional<MyEntity>} (or
- * {@code Optional<ManagedEntity<ID, MyEntity>>}) achieves the same outcome without needing a {@code "nullable"}
- * annotation: the parameter resolves to {@link java.util.Optional#empty()} instead of {@code null}. Kotlin
- * nullability, as in {@code MyEntity?}, is supported as well.
+ * When the parameter is typed as the entity itself, and no entity can be found for the resolved identifier, the
+ * parameter's nullability determines the outcome. By default, an
+ * {@link org.axonframework.modelling.repository.EntityNotFoundException} is propagated, failing the message being
+ * handled. A parameter annotated with an annotation resembling {@code "nullable"} will instead resolve to {@code null},
+ * allowing the handler to deal with a missing entity itself. This nullability support is in place to support a
+ * create-if-missing flow. A handler can check whether the injected entity is {@code null}, create the entity, and then
+ * proceed with subsequent tasks.
+ * <p>
+ * Declaring the parameter as {@code Optional<MyEntity>} achieves the same outcome without needing a {@code "nullable"}
+ * annotation: the parameter resolves to {@link java.util.Optional#empty()} instead of {@code null}. Kotlin nullability,
+ * as in {@code MyEntity?}, is supported as well.
+ * <p>
+ * A {@link org.axonframework.modelling.repository.ManagedEntity}-typed parameter is unaffected by nullability. Whether
+ * or not it is annotated {@code "nullable"}, it is always passed through exactly as resolved by the
+ * {@link org.axonframework.modelling.StateManager} backing this annotation. Note that the
+ * {@link ManagedEntity#entity()} <b>is</b> marked as nullable, thus supporting similar create-if-missing behavior as
+ * through the entity type or {@code Optional} path.
  *
  * @author Mitchell Herrijgers
  * @since 5.0.0

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntityParameterResolver.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntityParameterResolver.java
@@ -25,6 +25,7 @@ import org.axonframework.modelling.EntityIdResolutionException;
 import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.repository.EntityNotFoundException;
+import org.axonframework.modelling.repository.ManagedEntity;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
@@ -39,11 +40,19 @@ import static java.util.Objects.requireNonNullElseGet;
  * {@link Configuration}.
  * <p>
  * The entity is loaded based on the identifier resolved from the message using the given {@link EntityIdResolver}. Can
- * either load the {@link org.axonframework.modelling.repository.ManagedEntity} or just the entity itself. The given
- * {@link MissingEntityStrategy} determines what happens when the entity could not be found: it either propagates the
- * {@link EntityNotFoundException}, resolves to {@code null}, or resolves to an {@link Optional}.
+ * either load the {@link org.axonframework.modelling.repository.ManagedEntity} or just the entity itself.
+ * <p>
+ * For the entity itself, the {@link MissingEntityStrategy} determines what happens when it could not be found. It
+ * either propagates an {@link EntityNotFoundException}, resolves to {@code null}, or resolves to an {@link Optional},
+ * depending on whether the {@code MissingEntityStrategy} equals {@link MissingEntityStrategy#FAIL},
+ * {@link MissingEntityStrategy#RESOLVE_NULL}, or {@link MissingEntityStrategy#RESOLVE_OPTIONAL} respectively.
+ * <p>
+ * A {@link org.axonframework.modelling.repository.ManagedEntity}-typed parameter is unaffected by this. It is always
+ * passed through exactly as the {@link StateManager} resolved it leaving the interpretation entirely up to the
+ * handler.
  *
  * @author Mitchell Herrijgers
+ * @author Steven van Beelen
  * @since 5.0.0
  */
 class InjectEntityParameterResolver implements ParameterResolver<Object> {
@@ -63,8 +72,8 @@ class InjectEntityParameterResolver implements ParameterResolver<Object> {
      * state applier, it would construct methods, which would then require the {@link StateManager} to be created during
      * the construction of the parameter resolvers. This would lead to a circular dependency.
      *
-     * @param configuration         the {@link Configuration} from which a {@link StateManager} can be retrieved to
-     *                              load the entity
+     * @param configuration         the {@link Configuration} from which a {@link StateManager} can be retrieved to load
+     *                              the entity
      * @param type                  the type of the entity to load
      * @param identifierResolver    the {@link EntityIdResolver} to resolve the id of the entity
      * @param managedEntity         whether the parameter is a
@@ -94,41 +103,49 @@ class InjectEntityParameterResolver implements ParameterResolver<Object> {
             Object resolvedId = identifierResolver.resolve(message, context);
             StateManager stateManager = configuration.getComponent(StateManager.class);
 
-            CompletableFuture<Object> entityFuture;
-            if (managedEntity) {
-                // Safe cast: widening from CompletableFuture<T> to CompletableFuture<Object>
-                // Double cast through wildcard avoids unchecked cast warnings
-                @SuppressWarnings("unchecked")
-                CompletableFuture<Object> castCompletableFuture =
-                        (CompletableFuture<Object>) (CompletableFuture<?>) stateManager.loadManagedEntity(
-                                type, resolvedId, context
-                        );
-                entityFuture = castCompletableFuture;
-            } else {
-                @SuppressWarnings("unchecked")
-                CompletableFuture<Object> castCompletableFuture =
-                        (CompletableFuture<Object>) stateManager.loadEntity(type, resolvedId, context);
-                entityFuture = castCompletableFuture;
-            }
-
-            return switch (missingEntityStrategy) {
-                case FAIL -> entityFuture;
-                case RESOLVE_NULL -> entityFuture.exceptionally(e -> resolveOnEntityNotFound(e, null));
-                // The ManagedEntity wrapper itself is never null on a successful load (only its wrapped entity may
-                // be), so Optional.of is used there instead of Optional.ofNullable.
-                case RESOLVE_OPTIONAL -> entityFuture.handle((value, e) -> e != null
-                        ? resolveOnEntityNotFound(e, Optional.empty())
-                        : (managedEntity ? Optional.of(value) : Optional.ofNullable(value)));
-            };
+            return managedEntity
+                    ? resolveManagedEntity(stateManager, resolvedId, context)
+                    : resolveEntity(stateManager, resolvedId, context);
         } catch (EntityIdResolutionException e) {
-            return CompletableFuture.failedFuture(
-                    new IllegalStateException(
-                            "Unable to inject entity parameter of type [%s] because [%s] was unable to resolve an entity id from [%s]"
-                                    .formatted(type, identifierResolver, message),
-                            e
-                    )
-            );
+            return CompletableFuture.failedFuture(new IllegalStateException(
+                    "Unable to inject entity parameter of type [%s] because [%s] was unable to resolve an entity id from [%s]"
+                            .formatted(type, identifierResolver, message),
+                    e
+            ));
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<Object> resolveManagedEntity(StateManager stateManager, Object resolvedId,
+                                                           ProcessingContext context) {
+        // Safe cast: widening from CompletableFuture<T> to CompletableFuture<Object>
+        // Double cast through wildcard avoids unchecked cast warnings
+        return (CompletableFuture<Object>) (CompletableFuture<?>) stateManager.loadManagedEntity(
+                type, resolvedId, context
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private CompletableFuture<Object> resolveEntity(StateManager stateManager,
+                                                    Object entityId,
+                                                    ProcessingContext context) {
+        CompletableFuture<Object> entityFuture =
+                (CompletableFuture<Object>) stateManager.loadEntity(type, entityId, context);
+
+        return switch (missingEntityStrategy) {
+            case FAIL -> entityFuture.thenApply(value -> requireEntityFound(value, entityId));
+            case RESOLVE_NULL -> entityFuture.exceptionally(e -> resolveOnEntityNotFound(e, null));
+            case RESOLVE_OPTIONAL -> entityFuture.handle((value, e) -> e != null
+                    ? resolveOnEntityNotFound(e, Optional.empty())
+                    : Optional.ofNullable(value));
+        };
+    }
+
+    private Object requireEntityFound(@Nullable Object entity, Object entityId) {
+        if (entity == null) {
+            throw new EntityNotFoundException(entityId);
+        }
+        return entity;
     }
 
     @Nullable
@@ -149,13 +166,18 @@ class InjectEntityParameterResolver implements ParameterResolver<Object> {
     }
 
     /**
-     * Determines how {@link #resolveParameterValue(ProcessingContext)} reacts when the entity to inject cannot be
-     * found.
+     * Determines how {@link #resolveEntity(StateManager, Object, ProcessingContext)} reacts when the entity to inject
+     * cannot be found.
+     * <p>
+     * This strategy only applies to resolving the entity itself. A {@link ManagedEntity}-typed parameter is always
+     * passed through unconditionally by {@link #resolveManagedEntity(StateManager, Object, ProcessingContext)},
+     * regardless of this strategy.
      */
     enum MissingEntityStrategy {
 
         /**
-         * Propagate the {@link EntityNotFoundException}, failing the message being handled.
+         * Propagate the {@link EntityNotFoundException} raised while resolving the entity, failing the message being
+         * handled.
          */
         FAIL,
 
@@ -165,8 +187,8 @@ class InjectEntityParameterResolver implements ParameterResolver<Object> {
         RESOLVE_NULL,
 
         /**
-         * Resolve the parameter to {@link Optional#empty()}, or to {@link Optional#of(Object)} of the loaded value
-         * when the entity is found.
+         * Resolve the parameter to {@link Optional#empty()}, or to {@link Optional#of(Object)} of the loaded value when
+         * the entity is found.
          */
         RESOLVE_OPTIONAL
     }

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntityParameterResolverFactory.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/InjectEntityParameterResolverFactory.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.modelling.annotation;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ReflectionUtils;
 import org.axonframework.common.configuration.Configuration;
@@ -27,6 +26,7 @@ import org.axonframework.modelling.EntityIdResolver;
 import org.axonframework.modelling.PropertyBasedEntityIdResolver;
 import org.axonframework.modelling.StateManager;
 import org.axonframework.modelling.repository.ManagedEntity;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Parameter;
@@ -41,11 +41,12 @@ import static org.axonframework.common.ConstructorUtils.getConstructorFunctionWi
  * {@link ParameterResolverFactory} implementation that provides {@link ParameterResolver ParameterResolvers} for
  * parameters annotated with {@link InjectEntity}.
  * <p>
- * The parameter can either be a {@link ManagedEntity} or the entity itself, optionally wrapped in an
- * {@link Optional} (for example {@code Optional<MyEntity>} or {@code Optional<ManagedEntity<ID, MyEntity>>}). The
- * order of resolving the identity id is as specified on the {@link InjectEntity} annotation.
+ * The parameter can either be a {@link ManagedEntity} or the entity itself, and the latter may optionally be wrapped in
+ * an {@link Optional} (for example {@code Optional<MyEntity>}). The order of resolving the identity id is as specified
+ * on the {@link InjectEntity} annotation.
  *
  * @author Mitchell Herrijgers
+ * @author Steven van Beelen
  * @see InjectEntity
  * @since 5.0.0
  */
@@ -100,6 +101,10 @@ public class InjectEntityParameterResolverFactory implements ParameterResolverFa
      * {@code null} resolves to {@code null}, and anything else fails the message being handled. Nullability is
      * determined through the {@link NullabilityResolver} chain, so languages that do not express it through a
      * runtime-visible annotation, such as Kotlin, are honored as well.
+     * <p>
+     * This only applies when resolving the entity itself. For a {@link ManagedEntity}-typed parameter,
+     * {@link InjectEntityParameterResolver} always passes the wrapper through exactly as resolved, regardless of
+     * nullability.
      *
      * @param isOptional whether the parameter is declared as an {@link Optional}
      * @param parameter  the {@link InjectEntity} annotated parameter being resolved
@@ -120,6 +125,14 @@ public class InjectEntityParameterResolverFactory implements ParameterResolverFa
         if (entityType instanceof ParameterizedType parameterizedType
                 && parameterizedType.getRawType() instanceof Class<?> rawType
                 && ManagedEntity.class.isAssignableFrom(rawType)) {
+            if (isOptional) {
+                throw new AxonConfigurationException(
+                        ("Cannot inject entity for parameter [%s] of [%s]: Optional<ManagedEntity<ID, MyEntity>> is "
+                                + "not supported, since a ManagedEntity is always passed through as-is and never "
+                                + "null. Use ManagedEntity<ID, MyEntity> instead.")
+                                .formatted(parameter.getName(), executable)
+                );
+            }
             return new EntityTypeInfo((Class<?>) parameterizedType.getActualTypeArguments()[1], true);
         }
         if (entityType instanceof Class<?> entityClass) {
@@ -145,8 +158,8 @@ public class InjectEntityParameterResolverFactory implements ParameterResolverFa
             if (!(parameterizedType instanceof ParameterizedType)) {
                 throw new AxonConfigurationException(
                         ("Cannot inject entity for parameter [%s] of [%s]: a raw Optional does not specify the "
-                                + "entity type. Use Optional<MyEntity> or Optional<ManagedEntity<ID, MyEntity>> "
-                                + "instead.").formatted(parameter.getName(), executable)
+                                + "entity type. Use Optional<MyEntity> instead.")
+                                .formatted(parameter.getName(), executable)
                 );
             }
             type = ReflectionUtils.unwrapIfType(parameterizedType, Optional.class);

--- a/modelling/src/main/java/org/axonframework/modelling/entity/EntityMissingForInstanceCommandHandlerException.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/EntityMissingForInstanceCommandHandlerException.java
@@ -17,17 +17,22 @@
 package org.axonframework.modelling.entity;
 
 import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.modelling.repository.EntityNotFoundException;
 
 /**
  * Exception indicating that an instance command handler was invoked for an entity that does not exist.
  * <p>
  * If this command is valid for the creation of an entity, as well as instance commands, a creational command can be
  * defined for the same {@link CommandMessage#type()}.
+ * <p>
+ * This is a specialization of {@link EntityNotFoundException}: no business identifier is available at this level, so
+ * {@link EntityNotFoundException#identifier()} returns the {@link CommandMessage#type()} of the command being handled
+ * instead.
  *
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
-public class EntityMissingForInstanceCommandHandlerException extends RuntimeException {
+public class EntityMissingForInstanceCommandHandlerException extends EntityNotFoundException {
 
     /**
      * Creates a new exception with the given {@code command}.
@@ -35,7 +40,7 @@ public class EntityMissingForInstanceCommandHandlerException extends RuntimeExce
      * @param command The {@link CommandMessage} that was handled.
      */
     public EntityMissingForInstanceCommandHandlerException(CommandMessage command) {
-        super(String.format(
+        super(command.type(), String.format(
                 "Entity was missing for instance command handler for command [%s]",
                 command.type()
         ));

--- a/modelling/src/main/java/org/axonframework/modelling/repository/ManagedEntity.java
+++ b/modelling/src/main/java/org/axonframework/modelling/repository/ManagedEntity.java
@@ -38,9 +38,14 @@ public interface ManagedEntity<ID, E> {
     ID identifier();
 
     /**
-     * The current state of the entity, {@code null} when nothing was loaded from the repository.
+     * The current state of the entity.
+     * <p>
+     * This is {@code null} when no entity was found for, or could be constructed from. For example while resolving a
+     * create-if-missing flow. In that case, the {@code ManagedEntity} wrapper itself is still returned by the
+     * {@link Repository}, and may still be live-tracked (e.g. for event-sourced entities), so it reflects a creation
+     * event appended later in the same {@link org.axonframework.messaging.core.unitofwork.ProcessingContext}.
      *
-     * @return the current state of the entity
+     * @return the current state of the entity, or {@code null} when it could not be found or constructed
      */
     @Nullable
     E entity();
@@ -51,5 +56,6 @@ public interface ManagedEntity<ID, E> {
      * @param change The function applying the requested change.
      * @return The state of the entity after the change.
      */
-    E applyStateChange(UnaryOperator<E> change);
+    @Nullable
+    E applyStateChange(UnaryOperator<@Nullable E> change);
 }

--- a/modelling/src/main/java/org/axonframework/modelling/repository/Repository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/repository/Repository.java
@@ -54,22 +54,31 @@ public sealed interface Repository<ID, E>
     /**
      * Load the entity with the given unique identifier. No version checks are done when loading an entity, meaning that
      * concurrent access will not be checked for.
+     * <p>
+     * The returned {@link CompletableFuture} always resolves to a {@link ManagedEntity} for the given
+     * {@code identifier}. The {@link ManagedEntity#entity() entity} managed by it may be {@code null} when none
+     * could be found. Implementations without an autonomous construction step (e.g. one driven entirely by a
+     * user-supplied loader) remain free to let the future complete exceptionally instead, if that loader does so.
      *
-     * @param identifier        The identifier of the entity to load.
-     * @param processingContext The processing context in which to manage the lifecycle of the entity.
-     * @return A {@link CompletableFuture} resolving to the {@link ManagedEntity} with the given identifier, or
-     * {@code null} if it can't be found.
+     * @param identifier        the identifier of the entity to load
+     * @param processingContext the processing context in which to manage the lifecycle of the entity
+     * @return a {@link CompletableFuture} resolving to the {@link ManagedEntity} with the given identifier
      */
     CompletableFuture<ManagedEntity<ID, E>> load(ID identifier,
                                                  ProcessingContext processingContext);
 
     /**
-     * Loads an entity from the repository.
+     * Loads an entity from the repository, constructing a new instance when none exists yet.
+     * <p>
+     * The returned {@link CompletableFuture} always resolves to a {@link ManagedEntity} for the given
+     * {@code identifier}. The {@link ManagedEntity#entity() entity} managed by it may be {@code null} when none
+     * could be found. Implementations without an autonomous construction step (e.g. one driven entirely by a
+     * user-supplied loader) remain free to let the future complete exceptionally instead, if that loader does so.
      *
-     * @param identifier        The identifier of the entity to load.
-     * @param processingContext The processing context in which to manage the lifecycle of the entity.
-     * @return A {@link CompletableFuture} resolving to the {@link ManagedEntity} with the given identifier, or a newly
-     * constructed entity instance based on the {@code factoryMethod}.
+     * @param identifier        the identifier of the entity to load
+     * @param processingContext the processing context in which to manage the lifecycle of the entity
+     * @return a {@link CompletableFuture} resolving to the {@link ManagedEntity} with the given identifier, backed by
+     * a newly constructed entity instance when none existed yet
      */
     CompletableFuture<ManagedEntity<ID, E>> loadOrCreate(ID identifier,
                                                          ProcessingContext processingContext);

--- a/modelling/src/main/java/org/axonframework/modelling/repository/SimpleRepository.java
+++ b/modelling/src/main/java/org/axonframework/modelling/repository/SimpleRepository.java
@@ -19,6 +19,7 @@ package org.axonframework.modelling.repository;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.Context.ResourceKey;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -184,8 +185,9 @@ public class SimpleRepository<ID, E> implements Repository.LifecycleManagement<I
             return state.get();
         }
 
+        @Nullable
         @Override
-        public T applyStateChange(UnaryOperator<T> change) {
+        public T applyStateChange(UnaryOperator<@Nullable T> change) {
             return state.updateAndGet(change);
         }
     }

--- a/modelling/src/test/java/org/axonframework/modelling/annotation/InjectEntityParameterResolverFactoryTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/annotation/InjectEntityParameterResolverFactoryTest.java
@@ -131,6 +131,20 @@ class InjectEntityParameterResolverFactoryTest {
             // then
             assertThat(result).isNull();
         }
+
+        @Test
+        void propagatesExceptionWhenLoaderReturnsNullAndNotNullable() throws NoSuchMethodException {
+            // given: a repository resolving successfully to a null entity is treated the same as one whose future
+            // fails with an EntityNotFoundException - both are "missing" for a non-nullable parameter
+            Method method = Handlers.class.getDeclaredMethod("plainEntity", GiftCard.class);
+            StateManager stateManager = stateManagerLoading((id, context) -> CompletableFuture.completedFuture(null));
+
+            // when & then
+            assertThatThrownBy(() -> resolve(method, stateManager))
+                    .isInstanceOf(CompletionException.class)
+                    .cause()
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
     }
 
     @Nested
@@ -153,8 +167,9 @@ class InjectEntityParameterResolverFactoryTest {
         }
 
         @Test
-        void propagatesExceptionWhenMissingAndNotNullable() throws NoSuchMethodException {
-            // given
+        void propagatesExceptionWhenLoaderFailsAndNotNullable() throws NoSuchMethodException {
+            // given: a ManagedEntity-typed parameter is always passed through exactly as the Repository resolved
+            // it - a failure is never swallowed
             Method method = Handlers.class.getDeclaredMethod("managedEntity", ManagedEntity.class);
             StateManager stateManager = stateManagerLoading(
                     (id, context) -> CompletableFuture.failedFuture(new EntityNotFoundException(id))
@@ -168,19 +183,49 @@ class InjectEntityParameterResolverFactoryTest {
         }
 
         @Test
-        void resolvesToNullWhenMissingAndNullable() throws NoSuchMethodException {
-            // given: this used to be ignored entirely - a @Nullable ManagedEntity parameter always propagated the
-            // EntityNotFoundException regardless of nullability
+        void propagatesExceptionWhenLoaderFailsEvenWhenNullable() throws NoSuchMethodException {
+            // given: nullability is a plain-entity concern; a ManagedEntity-typed parameter is passed through
+            // unfiltered regardless of @Nullable
             Method method = Handlers.class.getDeclaredMethod("managedEntityNullable", ManagedEntity.class);
             StateManager stateManager = stateManagerLoading(
                     (id, context) -> CompletableFuture.failedFuture(new EntityNotFoundException(id))
             );
 
+            // when & then
+            assertThatThrownBy(() -> resolve(method, stateManager))
+                    .isInstanceOf(CompletionException.class)
+                    .cause()
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+
+        @Test
+        void resolvesToManagedEntityWithNullStateWhenLoaderReturnsNullAndNotNullable() throws NoSuchMethodException {
+            // given: the create-or-update pattern relies on the ManagedEntity wrapper itself never being null, only
+            // its wrapped state, so the handler can still call applyStateChange(...) on it - this holds regardless
+            // of @Nullable, since nullability no longer affects a ManagedEntity-typed parameter
+            Method method = Handlers.class.getDeclaredMethod("managedEntity", ManagedEntity.class);
+            StateManager stateManager = stateManagerLoading((id, context) -> CompletableFuture.completedFuture(null));
+
             // when
-            Object result = resolve(method, stateManager);
+            ManagedEntity<?, ?> result = (ManagedEntity<?, ?>) resolve(method, stateManager);
 
             // then
-            assertThat(result).isNull();
+            assertThat(result).isNotNull();
+            assertThat(result.entity()).isNull();
+        }
+
+        @Test
+        void resolvesToManagedEntityWithNullStateWhenLoaderReturnsNullAndNullable() throws NoSuchMethodException {
+            // given
+            Method method = Handlers.class.getDeclaredMethod("managedEntityNullable", ManagedEntity.class);
+            StateManager stateManager = stateManagerLoading((id, context) -> CompletableFuture.completedFuture(null));
+
+            // when
+            ManagedEntity<?, ?> result = (ManagedEntity<?, ?>) resolve(method, stateManager);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.entity()).isNull();
         }
     }
 
@@ -229,59 +274,6 @@ class InjectEntityParameterResolverFactoryTest {
 
             // then
             assertThat(result).isEqualTo(Optional.empty());
-        }
-    }
-
-    @Nested
-    class OptionalManagedEntityParameter {
-
-        @Test
-        void resolvesToOptionalOfManagedEntityWhenFound() throws NoSuchMethodException {
-            // given
-            GiftCard entity = new GiftCard();
-            Method method = Handlers.class.getDeclaredMethod("optionalManagedEntity", Optional.class);
-            StateManager stateManager = stateManagerLoading(
-                    (id, context) -> CompletableFuture.completedFuture(entity)
-            );
-
-            // when
-            @SuppressWarnings("unchecked")
-            Optional<ManagedEntity<?, ?>> result = (Optional<ManagedEntity<?, ?>>) resolve(method, stateManager);
-
-            // then
-            assertThat(result).isPresent();
-            assertThat(result.get().entity()).isSameAs(entity);
-        }
-
-        @Test
-        void resolvesToEmptyOptionalWhenNotFound() throws NoSuchMethodException {
-            // given
-            Method method = Handlers.class.getDeclaredMethod("optionalManagedEntity", Optional.class);
-            StateManager stateManager = stateManagerLoading(
-                    (id, context) -> CompletableFuture.failedFuture(new EntityNotFoundException(id))
-            );
-
-            // when
-            Object result = resolve(method, stateManager);
-
-            // then
-            assertThat(result).isEqualTo(Optional.empty());
-        }
-
-        @Test
-        void resolvesToOptionalOfManagedEntityWithNullStateWhenLoaderReturnsNull() throws NoSuchMethodException {
-            // given: the create-or-update pattern relies on the ManagedEntity wrapper itself never being empty, only
-            // its wrapped state, so the handler can still call applyStateChange(...) on it
-            Method method = Handlers.class.getDeclaredMethod("optionalManagedEntity", Optional.class);
-            StateManager stateManager = stateManagerLoading((id, context) -> CompletableFuture.completedFuture(null));
-
-            // when
-            @SuppressWarnings("unchecked")
-            Optional<ManagedEntity<?, ?>> result = (Optional<ManagedEntity<?, ?>>) resolve(method, stateManager);
-
-            // then
-            assertThat(result).isPresent();
-            assertThat(result.get().entity()).isNull();
         }
     }
 
@@ -381,6 +373,19 @@ class InjectEntityParameterResolverFactoryTest {
         void rejectsRawManagedEntityParameter() throws NoSuchMethodException {
             // given
             Method method = Handlers.class.getDeclaredMethod("rawManagedEntity", ManagedEntity.class);
+            Configuration configuration = configurationWithStateManager(SimpleStateManager.named("unused"));
+
+            // when & then
+            assertThatThrownBy(() -> new InjectEntityParameterResolverFactory(configuration)
+                    .createInstance(method, method.getParameters(), 0))
+                    .isInstanceOf(AxonConfigurationException.class);
+        }
+
+        @Test
+        void rejectsOptionalManagedEntityParameter() throws NoSuchMethodException {
+            // given: a ManagedEntity is always passed through as-is and never null, so wrapping it in an Optional
+            // would never be empty, making it pointless
+            Method method = Handlers.class.getDeclaredMethod("optionalManagedEntity", Optional.class);
             Configuration configuration = configurationWithStateManager(SimpleStateManager.named("unused"));
 
             // when & then


### PR DESCRIPTION
The `Repository` should return a `ManagedEntity` at all times. 
In doing so, we leave the choice to the user on how to react to a `null` entity. 
This can be done through retrieving the nullable marked `ManagedEntity#entity` output, giving the choice to the invoker how to react. 
This requires slight documentation and implementation changes around the `Repository`, `EventSourcingRepository`, and `ManagedEntity`. 

On top of that, the `InjectEntityParameterResolver` should always pass through a `ManagedEntity` **as is** when requested. 
This is inline with invoking the `Repository` or `StateManager` directly, so the user gets to choose how to react. 

Lastly, we should add a test validating that when a `ManagedEntity` is returned, that subsequent event publication adjust the entity contained in it, allowing for a create-if-missing style with subsequent event publications able to impact further decision making logic.

These changes can be seen as an addendum to #4609, to further clean-up the create-if-missing flow for users.