### PR TITLE
Cache `AnnotationMessageTypeResolver` annotation look-ups | Pre-compute entity event routing

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
@@ -85,7 +85,9 @@ public class AnnotatedCommandHandlingComponent<T> implements CommandHandlingComp
         );
         @SuppressWarnings("unchecked")
         Class<T> clazz = (Class<T>) annotatedCommandHandler.getClass();
-        this.model = AnnotatedHandlerInspector.inspectType(clazz, parameterResolverFactory, handlerDefinition);
+        this.model = AnnotatedHandlerInspector.inspectType(
+                clazz, messageTypeResolver, parameterResolverFactory, handlerDefinition
+        );
         this.messageTypeResolver = requireNonNull(messageTypeResolver, "The MessageTypeResolver may not be null.");
         this.converter = requireNonNull(converter, "The MessageConverter may not be null.");
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.core.annotation;
 
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.interception.annotation.ChainedMessageHandlerInterceptorMember;
 import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.interception.annotation.MessageInterceptingMember;
@@ -205,12 +206,13 @@ public class AnnotatedHandlerInspector<T> {
     @SuppressWarnings("unchecked")
     private void initializeMessageHandlers(ParameterResolverFactory parameterResolverFactory,
                                            HandlerDefinition handlerDefinition) {
+        MessageTypeResolver resultMessageTypeResolver = new AnnotationMessageTypeResolver();
         handlers.put(inspectedType, new TreeSet<>(HandlerComparator.instance()));
         for (Method method : inspectedType.getDeclaredMethods()) {
             handlerDefinition.createHandler(inspectedType,
                                             method,
                                             parameterResolverFactory,
-                                            result -> resolveToStream(result, new AnnotationMessageTypeResolver()))
+                                            result -> resolveToStream(result, resultMessageTypeResolver))
                              .ifPresent(h -> registerHandler(inspectedType, h));
         }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
@@ -59,20 +59,20 @@ public class AnnotatedHandlerInspector<T> {
     private final Class<T> inspectedType;
     private final List<AnnotatedHandlerInspector<? super T>> superClassInspectors;
     private final List<AnnotatedHandlerInspector<? extends T>> subClassInspectors;
+    private final MessageTypeResolver messageTypeResolver;
     private final Map<Class<?>, SortedSet<MessageHandlingMember<? super T>>> handlers;
     private final Map<Class<?>, MessageHandlerInterceptorMemberChain<T>> interceptorChains;
     private final Map<Class<?>, SortedSet<MessageHandlingMember<? super T>>> interceptors;
 
     private AnnotatedHandlerInspector(Class<T> inspectedType,
                                       List<AnnotatedHandlerInspector<? super T>> superClassInspectors,
-                                      ParameterResolverFactory parameterResolverFactory,
-                                      HandlerDefinition handlerDefinition,
-                                      Map<Class<?>, AnnotatedHandlerInspector<?>> registry,
-                                      List<AnnotatedHandlerInspector<? extends T>> subClassInspectors) {
+                                      List<AnnotatedHandlerInspector<? extends T>> subClassInspectors,
+                                      MessageTypeResolver messageTypeResolver) {
         this.inspectedType = inspectedType;
         this.superClassInspectors = new ArrayList<>(superClassInspectors);
-        this.handlers = new HashMap<>();
         this.subClassInspectors = subClassInspectors;
+        this.messageTypeResolver = messageTypeResolver;
+        this.handlers = new HashMap<>();
         this.interceptorChains = new ConcurrentHashMap<>();
         this.interceptors = new ConcurrentHashMap<>();
     }
@@ -86,39 +86,54 @@ public class AnnotatedHandlerInspector<T> {
      * @return a new inspector instance for the inspected class
      */
     public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType) {
-        return inspectType(handlerType, ClasspathParameterResolverFactory.forClass(handlerType));
+        return inspectType(handlerType,
+                           new AnnotationMessageTypeResolver(),
+                           ClasspathParameterResolverFactory.forClass(handlerType));
     }
 
     /**
      * Create an inspector for given {@code handlerType} that uses given {@code parameterResolverFactory} to resolve
      * method parameters.
      *
-     * @param handlerType              the target handler type
-     * @param parameterResolverFactory the resolver factory to use during detection
      * @param <T>                      the handler's type
+     * @param handlerType              the target handler type
+     * @param messageTypeResolver      the message type resolver used to derive the return type of the message returned
+     *                                 by the {@link org.axonframework.messaging.core.MessageStream} returned from
+     *                                 uncovered
+     *                                 {@link org.axonframework.messaging.core.MessageHandler MessageHandlers}
+     * @param parameterResolverFactory the resolver factory to use during detection
      * @return a new inspector instance for the inspected class
      */
     public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType,
+                                                               MessageTypeResolver messageTypeResolver,
                                                                ParameterResolverFactory parameterResolverFactory) {
-        return inspectType(handlerType,
-                           parameterResolverFactory,
-                           ClasspathHandlerDefinition.forClass(handlerType));
+        return inspectType(
+                handlerType,
+                messageTypeResolver,
+                parameterResolverFactory,
+                ClasspathHandlerDefinition.forClass(handlerType)
+        );
     }
 
     /**
      * Create an inspector for given {@code handlerType} that uses given {@code parameterResolverFactory} to resolve
      * method parameters and given {@code handlerDefinition} to create handlers.
      *
+     * @param <T>                      the handler's type
      * @param handlerType              the target handler type
+     * @param messageTypeResolver      the message type resolver used to derive the return type of the message returned
+     *                                 by the {@link org.axonframework.messaging.core.MessageStream} returned from
+     *                                 uncovered
+     *                                 {@link org.axonframework.messaging.core.MessageHandler MessageHandlers}
      * @param parameterResolverFactory the resolver factory to use during detection
      * @param handlerDefinition        the handler definition used to create concrete handlers
-     * @param <T>                      the handler's type
      * @return a new inspector instance for the inspected class
      */
     public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType,
+                                                               MessageTypeResolver messageTypeResolver,
                                                                ParameterResolverFactory parameterResolverFactory,
                                                                HandlerDefinition handlerDefinition) {
-        return inspectType(handlerType, parameterResolverFactory, handlerDefinition, emptySet());
+        return inspectType(handlerType, messageTypeResolver, parameterResolverFactory, handlerDefinition, emptySet());
     }
 
     /**
@@ -126,43 +141,57 @@ public class AnnotatedHandlerInspector<T> {
      * {@code parameterResolverFactory} to resolve method parameters and given {@code handlerDefinition} to create
      * handlers.
      *
+     * @param <T>                      the handler's type
      * @param handlerType              the target handler type
+     * @param messageTypeResolver      the message type resolver used to derive the return type of the message returned
+     *                                 by the {@link org.axonframework.messaging.core.MessageStream} returned from
+     *                                 uncovered
+     *                                 {@link org.axonframework.messaging.core.MessageHandler MessageHandlers}
      * @param parameterResolverFactory the resolver factory to use during detection
      * @param handlerDefinition        the handler definition used to create concrete handlers
      * @param declaredSubtypes         the declared subtypes of this {@code handlerType}
-     * @param <T>                      the handler's type
      * @return a new inspector instance for the inspected class
      */
     public static <T> AnnotatedHandlerInspector<T> inspectType(Class<T> handlerType,
+                                                               MessageTypeResolver messageTypeResolver,
                                                                ParameterResolverFactory parameterResolverFactory,
                                                                HandlerDefinition handlerDefinition,
                                                                Set<Class<? extends T>> declaredSubtypes) {
-        return createInspector(handlerType,
-                               parameterResolverFactory,
-                               handlerDefinition,
-                               new HashMap<>(),
-                               declaredSubtypes);
+        return createInspector(
+                handlerType,
+                messageTypeResolver,
+                parameterResolverFactory,
+                handlerDefinition,
+                new HashMap<>(),
+                declaredSubtypes
+        );
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> AnnotatedHandlerInspector<T> createInspector(Class<T> inspectedType,
-                                                                    ParameterResolverFactory parameterResolverFactory,
-                                                                    HandlerDefinition handlerDefinition,
-                                                                    Map<Class<?>, AnnotatedHandlerInspector<?>> registry,
-                                                                    Set<Class<? extends T>> declaredSubtypes) {
+    private static <T> AnnotatedHandlerInspector<T> createInspector(
+            Class<T> inspectedType,
+            MessageTypeResolver messageTypeResolver,
+            ParameterResolverFactory parameterResolverFactory,
+            HandlerDefinition handlerDefinition,
+            Map<Class<?>, AnnotatedHandlerInspector<?>> registry,
+            Set<Class<? extends T>> declaredSubtypes
+    ) {
         if (!registry.containsKey(inspectedType)) {
-            registry.put(inspectedType,
-                         AnnotatedHandlerInspector.initialize(inspectedType,
-                                                              parameterResolverFactory,
-                                                              handlerDefinition,
-                                                              registry,
-                                                              declaredSubtypes));
+            registry.put(inspectedType, AnnotatedHandlerInspector.initialize(
+                    inspectedType,
+                    messageTypeResolver,
+                    parameterResolverFactory,
+                    handlerDefinition,
+                    registry,
+                    declaredSubtypes
+            ));
         }
 
         return (AnnotatedHandlerInspector<T>) registry.get(inspectedType);
     }
 
     private static <T> AnnotatedHandlerInspector<T> initialize(Class<T> inspectedType,
+                                                               MessageTypeResolver messageTypeResolver,
                                                                ParameterResolverFactory parameterResolverFactory,
                                                                HandlerDefinition handlerDefinition,
                                                                Map<Class<?>, AnnotatedHandlerInspector<?>> registry,
@@ -171,34 +200,36 @@ public class AnnotatedHandlerInspector<T> {
         for (Class<?> iFace : inspectedType.getInterfaces()) {
             @SuppressWarnings("unchecked")  // Safe cast: all interfaces of T are guaranteed to be supertypes of T
             Class<? super T> castIF = (Class<? super T>) iFace;
-
-            parents.add(createInspector(castIF,
-                                        parameterResolverFactory,
-                                        handlerDefinition,
-                                        registry,
-                                        emptySet()));
+            parents.add(createInspector(
+                    castIF,
+                    messageTypeResolver,
+                    parameterResolverFactory,
+                    handlerDefinition,
+                    registry,
+                    emptySet()
+            ));
         }
+
         if (inspectedType.getSuperclass() != null && !Object.class.equals(inspectedType.getSuperclass())) {
-            parents.add(createInspector(inspectedType.getSuperclass(),
+            parents.add(createInspector(inspectedType.getSuperclass(), messageTypeResolver,
                                         parameterResolverFactory,
                                         handlerDefinition,
-                                        registry,
-                                        emptySet()));
+                                        registry, emptySet()));
         }
         List<AnnotatedHandlerInspector<? extends T>> children =
                 declaredSubtypes.stream()
-                                .map(subclass -> createInspector(subclass,
-                                                                 parameterResolverFactory,
-                                                                 handlerDefinition,
-                                                                 registry,
-                                                                 emptySet()))
+                                .map(subclass -> createInspector(
+                                        subclass,
+                                        messageTypeResolver,
+                                        parameterResolverFactory,
+                                        handlerDefinition,
+                                        registry,
+                                        emptySet()
+                                ))
                                 .collect(Collectors.toList());
-        AnnotatedHandlerInspector<T> inspector = new AnnotatedHandlerInspector<>(inspectedType,
-                                                                                 parents,
-                                                                                 parameterResolverFactory,
-                                                                                 handlerDefinition,
-                                                                                 registry,
-                                                                                 children);
+
+        AnnotatedHandlerInspector<T> inspector =
+                new AnnotatedHandlerInspector<>(inspectedType, parents, children, messageTypeResolver);
         inspector.initializeMessageHandlers(parameterResolverFactory, handlerDefinition);
         return inspector;
     }
@@ -206,14 +237,14 @@ public class AnnotatedHandlerInspector<T> {
     @SuppressWarnings("unchecked")
     private void initializeMessageHandlers(ParameterResolverFactory parameterResolverFactory,
                                            HandlerDefinition handlerDefinition) {
-        MessageTypeResolver resultMessageTypeResolver = new AnnotationMessageTypeResolver();
         handlers.put(inspectedType, new TreeSet<>(HandlerComparator.instance()));
         for (Method method : inspectedType.getDeclaredMethods()) {
-            handlerDefinition.createHandler(inspectedType,
-                                            method,
-                                            parameterResolverFactory,
-                                            result -> resolveToStream(result, resultMessageTypeResolver))
-                             .ifPresent(h -> registerHandler(inspectedType, h));
+            handlerDefinition.createHandler(
+                    inspectedType,
+                    method,
+                    parameterResolverFactory,
+                    result -> resolveToStream(result, messageTypeResolver)
+            ).ifPresent(h -> registerHandler(inspectedType, h));
         }
 
         // we need to consider handlers from parent/subclasses as well

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolver.java
@@ -44,6 +44,10 @@ import java.util.Optional;
  * meta-annotated with the namespace annotation as a fallback.
  * <p>
  * Allows for defining a fallback {@code MessageTypeResolver}, for when the defined annotations are not present.
+ * <p>
+ * As annotations are static class metadata, the annotation-based resolution result is cached per payload type without
+ * preventing that type from being unloaded. Only when the configured annotations do not yield a {@link MessageType}
+ * is the fallback consulted, on every invocation.
  *
  * @author Steven van Beelen
  * @since 5.0.0
@@ -52,6 +56,12 @@ public class AnnotationMessageTypeResolver implements MessageTypeResolver {
 
     private final MessageTypeResolver fallback;
     private final AnnotationSpecification specification;
+    private final ClassValue<Optional<MessageType>> annotationCache = new ClassValue<>() {
+        @Override
+        protected Optional<MessageType> computeValue(Class<?> type) {
+            return resolveFromAnnotations(type);
+        }
+    };
 
     /**
      * Constructs a default {@code AnnotationMessageTypeResolver}, using the {@link ClassBasedMessageTypeResolver} as
@@ -95,10 +105,18 @@ public class AnnotationMessageTypeResolver implements MessageTypeResolver {
 
     @Override
     public Optional<MessageType> resolve(Class<?> payloadType) {
+        Optional<MessageType> resolved = annotationCache.get(payloadType);
+        if (resolved.isPresent()) {
+            return resolved;
+        }
+        return fallback != null ? fallback.resolve(payloadType) : Optional.empty();
+    }
+
+    private Optional<MessageType> resolveFromAnnotations(Class<?> payloadType) {
         Map<String, Object> nameAttributes = attributesFor(payloadType, specification.nameAnnotation());
         Map<String, Object> versionAttributes = attributesFor(payloadType, specification.versionAnnotation());
         if (nameAttributes.isEmpty() || versionAttributes.isEmpty()) {
-            return fallback != null ? fallback.resolve(payloadType) : Optional.empty();
+            return Optional.empty();
         }
 
         Map<String, Object> namespaceAttributes = namespaceAttributesFor(payloadType);

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolver.java
@@ -47,7 +47,7 @@ import java.util.Optional;
  * <p>
  * As annotations are static class metadata, the annotation-based resolution result is cached per payload type without
  * preventing that type from being unloaded. Only when the configured annotations do not yield a {@link MessageType}
- * is the fallback consulted, on every invocation.
+ * is the fallback consulted.
  *
  * @author Steven van Beelen
  * @since 5.0.0

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponent.java
@@ -91,7 +91,9 @@ public class AnnotatedEventHandlingComponent<T> implements EventHandlingComponen
         );
         @SuppressWarnings("unchecked")
         Class<T> clazz = (Class<T>) annotatedEventHandler.getClass();
-        this.model = AnnotatedHandlerInspector.inspectType(clazz, parameterResolverFactory, handlerDefinition);
+        this.model = AnnotatedHandlerInspector.inspectType(
+                clazz, messageTypeResolver, parameterResolverFactory, handlerDefinition
+        );
         this.messageTypeResolver = requireNonNull(messageTypeResolver, "The MessageTypeResolver may not be null.");
         this.converter = requireNonNull(converter, "The EventConverter may not be null.");
 

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponent.java
@@ -86,7 +86,9 @@ public class AnnotatedQueryHandlingComponent<T> implements QueryHandlingComponen
         );
         @SuppressWarnings("unchecked")
         Class<T> clazz = (Class<T>) annotatedQueryHandler.getClass();
-        this.model = AnnotatedHandlerInspector.inspectType(clazz, parameterResolverFactory, handlerDefinition);
+        this.model = AnnotatedHandlerInspector.inspectType(
+                clazz, messageTypeResolver, parameterResolverFactory, handlerDefinition
+        );
         this.messageTypeResolver = requireNonNull(messageTypeResolver, "The MessageTypeResolver may not be null.");
         this.converter = requireNonNull(converter, "The MessageConverter may not be null.");
 

--- a/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspectorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspectorTest.java
@@ -27,14 +27,12 @@ import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.junit.jupiter.api.*;
-import org.mockito.internal.util.collections.*;
 
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.SortedSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -62,10 +60,13 @@ class AnnotatedHandlerInspectorTest {
 
     @BeforeEach
     void setUp() {
-        inspector = AnnotatedHandlerInspector.inspectType(A.class,
-                                                          parameterResolverFactory,
-                                                          ClasspathHandlerDefinition.forClass(A.class),
-                                                          new HashSet<>(asList(D.class, C.class)));
+        inspector = AnnotatedHandlerInspector.inspectType(
+                A.class,
+                new AnnotationMessageTypeResolver(),
+                parameterResolverFactory,
+                ClasspathHandlerDefinition.forClass(A.class),
+                new HashSet<>(asList(D.class, C.class))
+        );
     }
 
     @Test
@@ -142,8 +143,9 @@ class AnnotatedHandlerInspectorTest {
 
     @Test
     void doesNotRegisterAbstractHandlersTwice() {
-        AnnotatedHandlerInspector<AB> aaInspector = AnnotatedHandlerInspector.inspectType(AB.class,
-                                                                                          parameterResolverFactory);
+        AnnotatedHandlerInspector<AB> aaInspector = AnnotatedHandlerInspector.inspectType(
+                AB.class, new AnnotationMessageTypeResolver(), parameterResolverFactory
+        );
 
         assertEquals(1, aaInspector.getAllHandlers().size());
         assertEquals(1, (int) aaInspector.getAllHandlers().values().stream().mapToLong(Collection::size).sum());

--- a/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolverTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotationMessageTypeResolverTest.java
@@ -361,6 +361,43 @@ class AnnotationMessageTypeResolverTest {
     }
 
     @Nested
+    class Caching {
+
+        @Test
+        void repeatedResolutionReturnsCachedMessageTypeWithoutConsultingFallback() {
+            // given / when - resolving the same annotated payload type twice
+            Optional<MessageType> first = testSubject.resolve(CachedEvent.class);
+            Optional<MessageType> second = testSubject.resolve(CachedEvent.class);
+
+            // then - the annotation-derived result is cached, so the exact same instance is returned
+            assertThat(first).isPresent();
+            assertThat(second).isPresent();
+            assertThat(second.get()).isSameAs(first.get());
+            verifyNoInteractions(fallback);
+        }
+
+        @Test
+        void fallbackIsConsultedOnEveryResolutionForNonAnnotatedPayloadType() {
+            MessageType fallbackType = new MessageType("fallback", "2025");
+            when(fallback.resolve(any())).thenReturn(Optional.of(fallbackType));
+
+            // when - resolving a payload type without annotations twice
+            Optional<MessageType> first = testSubject.resolve(Object.class);
+            Optional<MessageType> second = testSubject.resolve(Object.class);
+
+            // then - only the annotation miss is cached, the fallback resolves on each invocation
+            assertThat(first).contains(fallbackType);
+            assertThat(second).contains(fallbackType);
+            verify(fallback, times(2)).resolve(Object.class);
+        }
+
+        @Event(name = "cached-event", version = "7")
+        private record CachedEvent(String id) {
+
+        }
+    }
+
+    @Nested
     class NamespaceResolution {
 
         @Test

--- a/modelling/src/main/java/org/axonframework/modelling/SimpleEntityEvolvingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/SimpleEntityEvolvingComponent.java
@@ -25,8 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -47,6 +45,7 @@ public class SimpleEntityEvolvingComponent<E> implements EntityEvolvingComponent
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final Map<QualifiedName, EntityEvolver<E>> entityEvolvers;
+    private final Set<QualifiedName> supportedEvents;
 
     /**
      * Constructs a {@code SimpleEntityEvolvingComponent} that evolves an entity of type {@code e} through
@@ -56,7 +55,10 @@ public class SimpleEntityEvolvingComponent<E> implements EntityEvolvingComponent
      *                       through.
      */
     public SimpleEntityEvolvingComponent(Map<QualifiedName, EntityEvolver<E>> entityEvolvers) {
-        this.entityEvolvers = new HashMap<>(requireNonNull(entityEvolvers, "The entity evolvers cannot be null."));
+        this.entityEvolvers = Map.copyOf(
+                requireNonNull(entityEvolvers, "The entity evolvers cannot be null.")
+        );
+        this.supportedEvents = Set.copyOf(this.entityEvolvers.keySet());
     }
 
     @Override
@@ -78,11 +80,11 @@ public class SimpleEntityEvolvingComponent<E> implements EntityEvolvingComponent
 
     @Override
     public Set<QualifiedName> supportedEvents() {
-        return Set.copyOf(entityEvolvers.keySet());
+        return supportedEvents;
     }
 
     @Override
     public void describeTo(ComponentDescriptor descriptor) {
-        descriptor.describeProperty("delegates", Collections.unmodifiableMap(entityEvolvers));
+        descriptor.describeProperty("delegates", entityEvolvers);
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
@@ -69,9 +69,12 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
                                                   EventConverter converter,
                                                   MessageTypeResolver messageTypeResolver) {
         this(entityType,
-             AnnotatedHandlerInspector.inspectType(entityType,
-                                                   ClasspathParameterResolverFactory.forClass(entityType),
-                                                   ClasspathHandlerDefinition.forClass(entityType)),
+             AnnotatedHandlerInspector.inspectType(
+                     entityType,
+                     messageTypeResolver,
+                     ClasspathParameterResolverFactory.forClass(entityType),
+                     ClasspathHandlerDefinition.forClass(entityType)
+             ),
              converter,
              messageTypeResolver);
     }

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
@@ -45,6 +45,12 @@ import static java.util.Objects.requireNonNull;
  * Implementation of the {@link EntityEvolvingComponent} that applies state changes through
  * {@link EventHandler}(-meta)-annotated methods using the
  * {@link AnnotatedHandlerInspector}.
+ * <p>
+ * During construction, this component eagerly resolves the event names of all inspected handlers and builds an
+ * immutable routing index. This shifts annotation inspection and message type resolution to initialization, increasing
+ * startup work and memory usage in proportion to the number of handlers. In return, event evolution performs direct
+ * lookups without reflection, message type resolution, cache mutation, or a scan of all handlers. Resolution failures
+ * are also reported during initialization instead of on the first matching event.
  *
  * @param <E> The entity type to evolve.
  * @author Mateusz Nowak
@@ -56,7 +62,7 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
     private final Class<E> entityType;
     private final AnnotatedHandlerInspector<E> inspector;
     private final EventConverter converter;
-    private final Map<Class<?>, Map<QualifiedName, List<MessageHandlingMember<? super E>>>> handlersByEventName;
+    private final Map<Class<?>, Map<QualifiedName, List<MessageHandlingMember<? super E>>>> handlersByEntityType;
 
     /**
      * Initialize a new annotation-based {@link EntityEvolver}.
@@ -95,7 +101,7 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
         this.entityType = requireNonNull(entityType, "The entity type must not be null.");
         this.inspector = requireNonNull(inspector, "The Annotated Handler Inspector must not be null.");
         this.converter = requireNonNull(converter, "The Converter must not be null.");
-        this.handlersByEventName = indexHandlersByEventName(
+        this.handlersByEntityType = indexHandlersByEntityType(
                 requireNonNull(messageTypeResolver, "The Message Type Resolver must not be null.")
         );
     }
@@ -107,8 +113,8 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
         try {
             var listenerType = entity.getClass();
 
-            var handlers = handlersByEventName.getOrDefault(listenerType, Map.of())
-                                              .getOrDefault(event.type().qualifiedName(), List.of());
+            var handlers = handlersByEntityType.getOrDefault(listenerType, Map.of())
+                                               .getOrDefault(event.type().qualifiedName(), List.of());
 
             E evolvedEntity = entity;
             for (var handler : handlers) {
@@ -133,17 +139,17 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
         }
     }
 
-    private Map<Class<?>, Map<QualifiedName, List<MessageHandlingMember<? super E>>>> indexHandlersByEventName(
+    private Map<Class<?>, Map<QualifiedName, List<MessageHandlingMember<? super E>>>> indexHandlersByEntityType(
             MessageTypeResolver messageTypeResolver
     ) {
         return inspector.getAllHandlers().entrySet().stream()
                         .collect(Collectors.toUnmodifiableMap(
                                 Map.Entry::getKey,
-                                entry -> indexHandlers(entry.getValue(), messageTypeResolver)
+                                entry -> indexHandlersByEventName(entry.getValue(), messageTypeResolver)
                         ));
     }
 
-    private Map<QualifiedName, List<MessageHandlingMember<? super E>>> indexHandlers(
+    private Map<QualifiedName, List<MessageHandlingMember<? super E>>> indexHandlersByEventName(
             Collection<MessageHandlingMember<? super E>> handlers,
             MessageTypeResolver messageTypeResolver
     ) {
@@ -180,7 +186,7 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
 
     @Override
     public Set<QualifiedName> supportedEvents() {
-        return handlersByEventName.values().stream()
+        return handlersByEntityType.values().stream()
                                   .flatMap(handlers -> handlers.keySet().stream())
                                   .collect(Collectors.toUnmodifiableSet());
     }

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.modelling.annotation;
 
+import org.axonframework.common.StringUtils;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
@@ -26,6 +27,7 @@ import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.annotation.EventHandlingMember;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.axonframework.modelling.EntityEvolver;
 import org.axonframework.modelling.EntityEvolvingComponent;
@@ -34,7 +36,6 @@ import org.axonframework.modelling.StateEvolvingException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -147,12 +148,20 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
                        .filter(handler -> handler.canHandleMessageType(EventMessage.class))
                        .collect(Collectors.collectingAndThen(
                                Collectors.groupingBy(
-                                       handler -> messageTypeResolver.resolveOrThrow(handler.payloadType())
-                                                                             .qualifiedName(),
+                                       handler -> eventName(handler, messageTypeResolver),
                                        Collectors.toUnmodifiableList()
                                ),
                                Map::copyOf
                        ));
+    }
+
+    private QualifiedName eventName(MessageHandlingMember<? super E> handler,
+                                    MessageTypeResolver messageTypeResolver) {
+        return handler.unwrap(EventHandlingMember.class)
+                      .map(EventHandlingMember::eventName)
+                      .filter(StringUtils::nonEmpty)
+                      .map(QualifiedName::new)
+                      .orElseGet(() -> messageTypeResolver.resolveOrThrow(handler.payloadType()).qualifiedName());
     }
 
     private E entityFromStreamResultOrUpdatedExisting(MessageStream.Entry<?> potentialEntityFromStream, E existing) {
@@ -168,10 +177,8 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
 
     @Override
     public Set<QualifiedName> supportedEvents() {
-        return inspector.getHandlers(entityType).stream()
-                        .filter(Objects::nonNull)
-                        .map(MessageHandlingMember::payloadType)
-                        .map(QualifiedName::new)
-                        .collect(Collectors.toSet());
+        return handlersByEventName.values().stream()
+                                  .flatMap(handlers -> handlers.keySet().stream())
+                                  .collect(Collectors.toUnmodifiableSet());
     }
 }

--- a/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
+++ b/modelling/src/main/java/org/axonframework/modelling/annotation/AnnotationBasedEntityEvolvingComponent.java
@@ -31,6 +31,9 @@ import org.axonframework.modelling.EntityEvolver;
 import org.axonframework.modelling.EntityEvolvingComponent;
 import org.axonframework.modelling.StateEvolvingException;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +55,7 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
     private final Class<E> entityType;
     private final AnnotatedHandlerInspector<E> inspector;
     private final EventConverter converter;
-    private final MessageTypeResolver messageTypeResolver;
+    private final Map<Class<?>, Map<QualifiedName, List<MessageHandlingMember<? super E>>>> handlersByEventName;
 
     /**
      * Initialize a new annotation-based {@link EntityEvolver}.
@@ -88,7 +91,9 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
         this.entityType = requireNonNull(entityType, "The entity type must not be null.");
         this.inspector = requireNonNull(inspector, "The Annotated Handler Inspector must not be null.");
         this.converter = requireNonNull(converter, "The Converter must not be null.");
-        this.messageTypeResolver = requireNonNull(messageTypeResolver, "The Message Type Resolver must not be null.");
+        this.handlersByEventName = indexHandlersByEventName(
+                requireNonNull(messageTypeResolver, "The Message Type Resolver must not be null.")
+        );
     }
 
     @Override
@@ -98,11 +103,8 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
         try {
             var listenerType = entity.getClass();
 
-            var eventTypeName = event.type().name();
-            var handlers = inspector.getHandlers(listenerType).stream()
-                                    .filter(h -> messageTypeResolver.resolveOrThrow(h.payloadType())
-                                                                    .name().equals(eventTypeName))
-                                    .toList();
+            var handlers = handlersByEventName.getOrDefault(listenerType, Map.of())
+                                              .getOrDefault(event.type().qualifiedName(), List.of());
 
             E evolvedEntity = entity;
             for (var handler : handlers) {
@@ -125,6 +127,32 @@ public class AnnotationBasedEntityEvolvingComponent<E> implements EntityEvolving
                     e
             );
         }
+    }
+
+    private Map<Class<?>, Map<QualifiedName, List<MessageHandlingMember<? super E>>>> indexHandlersByEventName(
+            MessageTypeResolver messageTypeResolver
+    ) {
+        return inspector.getAllHandlers().entrySet().stream()
+                        .collect(Collectors.toUnmodifiableMap(
+                                Map.Entry::getKey,
+                                entry -> indexHandlers(entry.getValue(), messageTypeResolver)
+                        ));
+    }
+
+    private Map<QualifiedName, List<MessageHandlingMember<? super E>>> indexHandlers(
+            Collection<MessageHandlingMember<? super E>> handlers,
+            MessageTypeResolver messageTypeResolver
+    ) {
+        return handlers.stream()
+                       .filter(handler -> handler.canHandleMessageType(EventMessage.class))
+                       .collect(Collectors.collectingAndThen(
+                               Collectors.groupingBy(
+                                       handler -> messageTypeResolver.resolveOrThrow(handler.payloadType())
+                                                                             .qualifiedName(),
+                                       Collectors.toUnmodifiableList()
+                               ),
+                               Map::copyOf
+                       ));
     }
 
     private E entityFromStreamResultOrUpdatedExisting(MessageStream.Entry<?> potentialEntityFromStream, E existing) {

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
@@ -19,6 +19,7 @@ package org.axonframework.modelling.entity.annotation;
 import org.axonframework.common.Assert;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.ReflectionUtils;
+import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.conversion.ConversionException;
@@ -44,7 +45,6 @@ import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.entity.PolymorphicEntityMetamodel;
 import org.axonframework.modelling.entity.child.EntityChildMetamodel;
-import org.axonframework.common.annotation.Internal;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -260,7 +260,7 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
 
     private EntityMetamodel<E> initializeConcreteModel(Class<E> entityType) {
         EntityMetamodelBuilder<E> builder = EntityMetamodel.forEntityType(entityType);
-        AnnotatedHandlerInspector<E> inspected = inspectType(entityType, parameterResolverFactory);
+        AnnotatedHandlerInspector<E> inspected = inspectType(entityType, messageTypeResolver, parameterResolverFactory);
         builder.entityEvolver(new AnnotationBasedEntityEvolvingComponent<>(entityType,
                                                                            inspected,
                                                                            eventConverter,
@@ -278,6 +278,7 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
                                                                              .anyMatch(this::hasEntityMembers);
         AnnotatedHandlerInspector<E> inspected = inspectType(
                 entityType,
+                messageTypeResolver,
                 parameterResolverFactory,
                 ClasspathHandlerDefinition.forClass(entityType),
                 hasMemberEntities ? Collections.emptySet() : concreteTypes

--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -21,6 +21,7 @@ import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.Metadata;
+import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.MetadataValue;
@@ -28,6 +29,7 @@ import org.axonframework.messaging.core.annotation.SourceId;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.axonframework.messaging.eventhandling.annotation.Event;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.annotation.SequenceNumber;
 import org.axonframework.messaging.eventhandling.annotation.Timestamp;
@@ -393,6 +395,69 @@ class AnnotationBasedEntityEvolvingComponentTest {
             // then - all events are handled, while message types were resolved only when building the handler index
             assertThat(state.handledCount).isEqualTo(3);
             verifyNoInteractions(resolver);
+        }
+    }
+
+    @Nested
+    class EventNameResolution {
+
+        @Test
+        void usesResolvedMessageTypeForHandlingAndSupportedEvents() {
+            // given
+            var resolver = new AnnotationMessageTypeResolver();
+            var evolver = new AnnotationBasedEntityEvolvingComponent<>(RenamedEventState.class, converter, resolver);
+            var state = new RenamedEventState();
+            var eventType = resolver.resolveOrThrow(RenamedEvent.class);
+            var event = new GenericEventMessage(eventType, new RenamedEvent());
+
+            // when
+            evolver.evolve(state, event, StubProcessingContext.forMessage(event));
+
+            // then
+            assertThat(state.handledCount).isEqualTo(1);
+            assertThat(evolver.supportedEvents()).containsExactly(eventType.qualifiedName());
+        }
+
+        @Test
+        void explicitHandlerEventNameTakesPrecedenceOverPayloadType() {
+            // given
+            var evolver = new AnnotationBasedEntityEvolvingComponent<>(ExplicitNameState.class,
+                                                                        converter,
+                                                                        messageTypeResolver);
+            var state = new ExplicitNameState();
+            var event = new GenericEventMessage(new MessageType("explicit-event"), "payload");
+
+            // when
+            evolver.evolve(state, event, StubProcessingContext.forMessage(event));
+
+            // then
+            assertThat(state.handledCount).isEqualTo(1);
+            assertThat(evolver.supportedEvents()).containsExactly(event.type().qualifiedName());
+        }
+
+        @Event(name = "renamed-event", version = "1")
+        private record RenamedEvent() {
+
+        }
+
+        private static class RenamedEventState {
+
+            private int handledCount;
+
+            @EventHandler
+            void handle(RenamedEvent event) {
+                handledCount++;
+            }
+        }
+
+        private static class ExplicitNameState {
+
+            private int handledCount;
+
+            @EventHandler(eventName = "explicit-event")
+            void handle(String event) {
+                handledCount++;
+            }
         }
     }
 

--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -491,18 +491,28 @@ class AnnotationBasedEntityEvolvingComponentTest {
 
         }
 
-        private static final EntityEvolver<Course> COURSE_EVOLVER = new AnnotationBasedEntityEvolvingComponent<>(
-                Course.class,
-                inspectType(
+        private static final EntityEvolvingComponent<Course> COURSE_EVOLVER =
+                new AnnotationBasedEntityEvolvingComponent<>(
                         Course.class,
-                        new AnnotationMessageTypeResolver(),
-                        ClasspathParameterResolverFactory.forClass(Course.class),
-                        ClasspathHandlerDefinition.forClass(Course.class),
-                        Set.of(InitialCourse.class, CreatedCourse.class, PublishedCourse.class)
-                ),
-                converter,
-                messageTypeResolver
-        );
+                        inspectType(
+                                Course.class,
+                                new AnnotationMessageTypeResolver(),
+                                ClasspathParameterResolverFactory.forClass(Course.class),
+                                ClasspathHandlerDefinition.forClass(Course.class),
+                                Set.of(InitialCourse.class, CreatedCourse.class, PublishedCourse.class)
+                        ),
+                        converter,
+                        messageTypeResolver
+                );
+
+        @Test
+        void supportedEventsIncludesHandlersFromAllPolymorphicEntityTypes() {
+            assertThat(COURSE_EVOLVER.supportedEvents())
+                    .containsExactlyInAnyOrder(
+                            messageTypeResolver.resolveOrThrow(String.class).qualifiedName(),
+                            messageTypeResolver.resolveOrThrow(Integer.class).qualifiedName()
+                    );
+        }
 
         @Test
         void evolvesPolymorphicEntityFromInitialToCreatedType() {

--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -20,6 +20,7 @@ import org.axonframework.common.ClockUtils;
 import org.axonframework.conversion.jackson.JacksonConverter;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.Metadata;
 import org.axonframework.messaging.core.annotation.AnnotationMessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.*;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -192,6 +194,28 @@ class AnnotationBasedEntityEvolvingComponentTest {
 
     @Nested
     class HandlerInvocationRules {
+
+        @Test
+        void invokesAllEventHandlersResolvingToTheSameEventName() {
+            // given
+            var sharedEventType = new MessageType("shared-event");
+            MessageTypeResolver sharedTypeResolver = payloadType -> Optional.of(sharedEventType);
+            var eventSourcedComponent = new AnnotationBasedEntityEvolvingComponent<>(TestState.class,
+                                                                                     converter,
+                                                                                     sharedTypeResolver);
+            var state = new TestState();
+            var event = new GenericEventMessage(sharedEventType,
+                                                0,
+                                                Metadata.with("sampleKey", "sampleValue"));
+            var context = StubProcessingContext.forMessage(event, "id", 0, "test");
+
+            // when
+            state = eventSourcedComponent.evolve(state, event, context);
+
+            // then
+            assertTrue(state.objectHandlerInvoked);
+            assertEquals(2, state.handledCount);
+        }
 
         @Test
         void doNotHandleNotDeclaredEventType() {

--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -41,10 +41,15 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector.inspectType;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 /**
  * Test class validating the {@link AnnotationBasedEntityEvolvingComponent}.
@@ -362,6 +367,32 @@ class AnnotationBasedEntityEvolvingComponentTest {
         @EventHandler
         void handle(String event) {
             this.handledCount++;
+        }
+    }
+
+    @Nested
+    class MessageTypeResolutionCaching {
+
+        @Test
+        void resolvesHandlerPayloadTypesOnlyDuringInitialization() {
+            // given - TestState declares two handlers (Object and Integer payloads)
+            var resolver = spy(new ClassBasedMessageTypeResolver());
+            var evolver = new AnnotationBasedEntityEvolvingComponent<>(TestState.class, converter, resolver);
+            var state = new TestState();
+            verify(resolver).resolveOrThrow(Object.class);
+            verify(resolver).resolveOrThrow(Integer.class);
+            clearInvocations(resolver);
+
+            // when - evolving multiple events of the same type
+            for (int sequence = 0; sequence < 3; sequence++) {
+                var event = createEvent(sequence);
+                var context = StubProcessingContext.forMessage(event, "id", sequence, "test");
+                state = evolver.evolve(state, event, context);
+            }
+
+            // then - all events are handled, while message types were resolved only when building the handler index
+            assertThat(state.handledCount).isEqualTo(3);
+            verifyNoInteractions(resolver);
         }
     }
 

--- a/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/AnnotationBasedEntityEvolvingComponentTest.java
@@ -48,10 +48,7 @@ import static org.axonframework.messaging.core.annotation.AnnotatedHandlerInspec
 import static org.axonframework.messaging.eventhandling.EventTestUtils.asEventMessage;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.createEvent;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.clearInvocations;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.*;
 
 /**
  * Test class validating the {@link AnnotationBasedEntityEvolvingComponent}.
@@ -496,9 +493,13 @@ class AnnotationBasedEntityEvolvingComponentTest {
 
         private static final EntityEvolver<Course> COURSE_EVOLVER = new AnnotationBasedEntityEvolvingComponent<>(
                 Course.class,
-                inspectType(Course.class, ClasspathParameterResolverFactory.forClass(Course.class),
-                            ClasspathHandlerDefinition.forClass(Course.class),
-                            Set.of(InitialCourse.class, CreatedCourse.class, PublishedCourse.class)),
+                inspectType(
+                        Course.class,
+                        new AnnotationMessageTypeResolver(),
+                        ClasspathParameterResolverFactory.forClass(Course.class),
+                        ClasspathHandlerDefinition.forClass(Course.class),
+                        Set.of(InitialCourse.class, CreatedCourse.class, PublishedCourse.class)
+                ),
                 converter,
                 messageTypeResolver
         );

--- a/modelling/src/test/java/org/axonframework/modelling/SimpleEntityEvolvingComponentTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/SimpleEntityEvolvingComponentTest.java
@@ -132,6 +132,11 @@ class SimpleEntityEvolvingComponentTest {
     }
 
     @Test
+    void supportedEventsReturnsPrecomputedSet() {
+        assertSame(testSubject.supportedEvents(), testSubject.supportedEvents());
+    }
+
+    @Test
     void describeToThrowsNullPointerExceptionForNullComponentDescriptor() {
         //noinspection DataFlowIssue
         assertThrows(NullPointerException.class, () -> testSubject.describeTo(null));


### PR DESCRIPTION
## Summary

- cache annotation-derived `MessageType` resolution per payload class with `ClassValue`, while preserving dynamic fallback resolution
- reuse the result-message type resolver created by `AnnotatedHandlerInspector`
- build an immutable event-handler index for annotation-based entity evolution during initialization
- route evolved events through runtime entity type and qualified event name lookups instead of scanning and resolving every handler
- **fix** annotation-based entity evolution to honor explicit `@EventHandler(eventName = ...)` declarations
- **fix** `supportedEvents()` to report the same resolved qualified event names used for routing
- make declarative entity-evolver routing immutable and cache its supported-event set

## Why

Profiles of a large event-sourced entity import showed most processing time in `AnnotationUtils.findAnnotationAttributes`. The annotation-based entity evolver resolved the message type of every inspected handler for every applied event. Entity-member traversal multiplied that work across events and child entities.

`AnnotationMessageTypeResolver` also repeated the same reflective annotation and namespace lookup whenever a payload class was resolved. Since annotation metadata is static for a class, repeating those scans adds cost without changing the result.

While replacing the per-event scan, two existing correctness bugs in annotation-based entity evolution became apparent:

1. **Explicit event names were ignored during routing.** A handler such as `@EventHandler(eventName = "customer-created") void handle(String event)` was prefiltered using the resolved name of `String` instead of `customer-created`. The explicitly named event could therefore never reach that handler.
2. **`supportedEvents()` advertised unresolved payload-class names.** It constructed `QualifiedName` values directly from handler payload classes, ignoring explicit handler names, names and namespaces resolved by `MessageTypeResolver`, and handlers on polymorphic runtime entity types. Its output could therefore disagree with actual routing.

These are bug fixes rather than merely consequences of the performance optimization, and they intentionally change the previously incorrect behavior.

## Implementation

`AnnotationMessageTypeResolver` now caches only annotation-derived results in a `ClassValue`, so cached classes can still be unloaded. Annotation misses continue to invoke the configured fallback on every call, preserving fallback semantics.

`AnnotationBasedEntityEvolvingComponent` constructs an immutable index keyed by runtime entity class and event `QualifiedName`. Only event handlers are indexed. Event evolution now performs two map lookups before conversion and invocation; it no longer performs reflection, resolver calls, cache mutation, or a handler-wide scan in the hot path.

Index construction gives a non-empty explicit event-handler name precedence and otherwise uses the configured message type resolver. `supportedEvents()` is derived from that same routing index, ensuring that advertised and routable event names stay consistent.

The declarative `SimpleEntityEvolvingComponent` already used direct map routing. Its routing map is now immutable and its supported-event set is computed once. The existing missing-handler debug log remains unchanged.

## Impact

The reflective work moves from per-event processing to initialization and once-per-payload-class resolution. This should remove the annotation scanning hotspot during large imports and event replay, with a small bounded startup and memory cost for the precomputed indexes.

Explicitly named annotation-based entity event handlers are now reachable by that name. `supportedEvents()` now returns annotation-resolved, namespace-aware names from all indexed runtime entity types.

## Validation

- `./mvnw -q -pl messaging,modelling test`
- focused tests cover resolver caching and fallback behavior, initialization-only handler resolution, explicit event names, resolved supported events, polymorphic entity evolution, and declarative supported-event caching
