### PR TITLE
[Port] Dedicated `@EntityCreator` annotation enforcing entity creation regardless of existence

### DIFF
--- a/docs/reference-guide/modules/migration/examples/migration/paths/aggregates/index/forcedentitycreator/GiftCard.java
+++ b/docs/reference-guide/modules/migration/examples/migration/paths/aggregates/index/forcedentitycreator/GiftCard.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package migration.paths.aggregates.index.forcedentitycreator;
+
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.reflection.ForcedEntityCreator;
+import org.axonframework.eventsourcing.annotation.reflection.InjectEntityId;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+
+// tag::forced-entity-creator-create-if-missing[]
+@EventSourcedEntity
+public class GiftCard {
+
+    private String cardId;
+    private boolean issued;
+
+    @ForcedEntityCreator
+    public GiftCard(@InjectEntityId String cardId) {
+        this.cardId = cardId;
+    }
+
+    @CommandHandler
+    public void handle(IssueGiftCard cmd, EventAppender eventAppender) {
+        if (issued) {
+            throw new IllegalStateException("GiftCard already issued");
+        }
+        eventAppender.append(new GiftCardIssued(cardId, cmd.amount()));
+    }
+
+    @EventSourcingHandler
+    public void on(GiftCardIssued event) {
+        this.issued = true;
+    }
+}
+// end::forced-entity-creator-create-if-missing[]

--- a/docs/reference-guide/modules/migration/examples/migration/paths/aggregates/index/forcedentitycreator/GiftCardIssued.java
+++ b/docs/reference-guide/modules/migration/examples/migration/paths/aggregates/index/forcedentitycreator/GiftCardIssued.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package migration.paths.aggregates.index.forcedentitycreator;
+
+public record GiftCardIssued(String cardId, int amount) {
+}

--- a/docs/reference-guide/modules/migration/examples/migration/paths/aggregates/index/forcedentitycreator/IssueGiftCard.java
+++ b/docs/reference-guide/modules/migration/examples/migration/paths/aggregates/index/forcedentitycreator/IssueGiftCard.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package migration.paths.aggregates.index.forcedentitycreator;
+
+import org.axonframework.modelling.annotation.TargetEntityId;
+
+public record IssueGiftCard(@TargetEntityId String cardId, int amount) {
+}

--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
@@ -227,7 +227,7 @@ include::example$migration/paths/aggregates/index/creationpolicyalways/GiftCard.
 
 * *`CreationPolicy.CREATE_IF_MISSING`*
 +
-If you need "only create if missing" logic, you can implement it within the static handler by checking for the existence of an optional state parameter.
+If you need "only create if missing" logic, you can implement it within the static handler by checking for the existence of an optional state parameter. The renewed support is documented in more detail xref:commands:entities/stateful-command-handler.adoc#missing_injected_entity[here]. For convenience-sake, here's an immediate sample showing the injection of a nullable `GiftCard`:
 +
 [source,java]
 ----

--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/index.adoc
@@ -233,6 +233,13 @@ If you need "only create if missing" logic, you can implement it within the stat
 ----
 include::example$migration/paths/aggregates/index/creationpolicycreateifmissing/GiftCard.java[tag=creation-policy-create-if-missing,indent=0]
 ----
++
+Alternatively, if you want to keep the create-if-missing logic on an **instance** command handler, closer to how `@CreationPolicy(CREATE_IF_MISSING)` worked in Axon Framework 4, annotate a no-argument or identifier-based `@EntityCreator` with `@ForcedEntityCreator`. Axon then always constructs the entity, even when it does not yet exist, so the instance handler receives a non-null entity and can decide for itself whether to append the event that establishes its existence.
++
+[source,java]
+----
+include::example$migration/paths/aggregates/index/forcedentitycreator/GiftCard.java[tag=forced-entity-creator-create-if-missing,indent=0]
+----
 
 * *`CreationPolicy.NEVER`*
 +

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/AnnotationBasedEventSourcedEntityFactory.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/AnnotationBasedEventSourcedEntityFactory.java
@@ -54,7 +54,9 @@ import java.util.stream.StreamSupport;
  * {@link EntityCreator}-annotated constructors and static methods on the entity type and its supertypes to find a
  * suitable constructor or static method to create an entity instance.
  * <p>
- * This class implements the requirements as per the {@link EntityCreator} annotation. This class is thread-safe.
+ * This class implements the requirements as per the {@link EntityCreator} annotation. It also honors
+ * {@link ForcedEntityCreator}-annotated constructors and static methods, invoking them regardless of whether a first
+ * event is present, as described on {@link ForcedEntityCreator}. This class is thread-safe.
  *
  * @param <E>  The type of entity to create.
  * @param <ID> The type of identifier used by the entity.
@@ -176,6 +178,7 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
     }
 
     private void addEntityCreatorExecutable(Executable executable) {
+        boolean forced = AnnotationUtils.isAnnotationPresent(executable, ForcedEntityCreator.class);
         String[] payloadQualifiedNamesAttribute = AnnotationUtils
                 .findAnnotationAttribute(executable, EntityCreator.class, "payloadQualifiedNames")
                 .map(o -> (String[]) o)
@@ -239,7 +242,8 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
                                               payloadQualifiedNames,
                                               concreteIdType,
                                               expectedPayloadRepresentation,
-                                              hasMessageParameter));
+                                              hasMessageParameter,
+                                              forced));
     }
 
     private Set<ScannedEntityCreator> getMethodsCompatibleWithIdAndNoMessage(ID id) {
@@ -332,6 +336,7 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
         private final @Nullable Class<?> concreteIdType;
         private final @Nullable Class<?> expectedPayloadRepresentation;
         private final boolean hasMessageParameter;
+        private final boolean forced;
         private final boolean noOp;
 
         /**
@@ -346,6 +351,7 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
             this.concreteIdType = null;
             this.expectedPayloadRepresentation = null;
             this.hasMessageParameter = false;
+            this.forced = false;
             this.noOp = true;
         }
 
@@ -355,7 +361,8 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
                 List<QualifiedName> payloadQualifiedNames,
                 @Nullable Class<?> concreteIdType,
                 @Nullable Class<?> expectedPayloadRepresentation,
-                boolean hasMessageParameter
+                boolean hasMessageParameter,
+                boolean forced
         ) {
             ReflectionUtils.ensureAccessible(executable);
             this.executable = executable;
@@ -364,11 +371,12 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
             this.concreteIdType = concreteIdType;
             this.expectedPayloadRepresentation = expectedPayloadRepresentation;
             this.hasMessageParameter = hasMessageParameter;
+            this.forced = forced;
             this.noOp = false;
         }
 
         private @Nullable E invoke(ID id, @Nullable EventMessage firstEventMessage, ProcessingContext context) {
-            if (noOp || isNoArgOrIdBasedCreatorWithoutFirstEvent(firstEventMessage)) {
+            if (noOp || (!forced && isNoArgOrIdBasedCreatorWithoutFirstEvent(firstEventMessage))) {
                 return null;
             }
 
@@ -411,6 +419,10 @@ public class AnnotationBasedEventSourcedEntityFactory<E, ID> implements EventSou
          *       creators whose only parameters are {@link InjectEntityId}-annotated)</li>
          *   <li>{@code firstEventMessage} is {@code null}</li>
          * </ul>
+         * <p>
+         * The {@link #invoke(Object, EventMessage, ProcessingContext)} operation ignores this outcome for
+         * {@link ForcedEntityCreator}-annotated creators, since those are invoked regardless of whether a first event
+         * is present.
          *
          * @param firstEventMessage the first {@link EventMessage}, if any, for the entity that is about to be
          *                          constructed

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/EntityCreator.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/EntityCreator.java
@@ -160,7 +160,7 @@ import java.lang.annotation.Target;
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
-@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface EntityCreator {
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/ForcedEntityCreator.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/annotation/reflection/ForcedEntityCreator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.annotation.reflection;
+
+import org.axonframework.messaging.core.MessageTypeResolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that indicates that a method or constructor is a factory method for an event-sourced entity, forcing
+ * creation at all times.
+ * <p>
+ * It is meta-annotated with {@link EntityCreator} to support all behavior as described on the {@code EntityCreator}.
+ * What this annotation adds, is the assurance that <b>if</b> sufficient information is available to invoke the
+ * annotated method or constructor, that it will be invoked regardless of downstream usages of the entity itself. This
+ * adjusts the regular behavior of the no-arguments, identifier-only, and event-based {@code EntityCreator} solutions
+ * like so:
+ * <ol>
+ *     <li>A no-arguments, {@code @EntityCreator} annotated constructor or method, will always create the entity.</li>
+ *     <li>An identifier-based, {@code @EntityCreator} annotated constructor or method, will create if an identifier can be resolved.</li>
+ *     <li>An event-based, {@code @EntityCreator} annotated constructor or method, will <b>only</b> create if an initial event is present.</li>
+ * </ol>
+ * <p>
+ * This additional behavior becomes important for create-if-missing styled handlers. For plain {@code EntityCreator}
+ * solutions, the create-if-missing handler should either (1) be {@code static} (read: marked as a creational handler)
+ * when present in the entity itself or (2) moved out of the entity entirely. In both scenarios the create-if-missing
+ * behavior would require the entity as a parameter to the message handling function validate if it does exist. If
+ * optional subsequent decisions require life state changes of the potentially missing entity, the user is enforced to
+ * inject a {@link org.axonframework.modelling.repository.ManagedEntity} instead.
+ * <p>
+ * This annotation adjusts that behavior, by simply invoking the {@code @ForcedEntityCreator} annotated constructor or
+ * method and passing it through. This will effectively make the entity non-null for all no-argument scenarios and most
+ * identifier-based scenarios. Furthermore, it allows the create-if-missing solution to work on instance command
+ * handlers placed in the entity, resolving the need to make them {@code static}.
+ * <p>
+ * Note that this forced-creation-approach is viewed as an aggregate-centric solution, whereas this library aims to
+ * steer away from that. Hence, any opportunity to use other mechanisms than this are encouraged.
+ *
+ * @author Steven van Beelen
+ * @since 5.3.1
+ */
+@EntityCreator
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.ANNOTATION_TYPE})
+public @interface ForcedEntityCreator {
+
+    /**
+     * The qualified names of the payload types that this factory method can handle. If a payload parameter is declared,
+     * and this value is left at default, the payload's qualified name will be determined based on the
+     * {@link MessageTypeResolver}.
+     *
+     * @return The qualified names of the payload types that this factory method can handle.
+     */
+    String[] payloadQualifiedNames() default {};
+}

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/reflection/ForcedEntityCreatorTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/reflection/ForcedEntityCreatorTest.java
@@ -16,27 +16,30 @@
 
 package org.axonframework.eventsourcing.annotation.reflection;
 
+import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.conversion.PassThroughConverter;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.junit.jupiter.api.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 /**
  * Tests the behavior described on {@link ForcedEntityCreator}.
  * <p>
- * Ano-arguments (or {@link InjectEntityId}-only) factory constructor or method annotated with
+ * A no-arguments (or {@link InjectEntityId}-only) factory constructor or method annotated with
  * {@link ForcedEntityCreator} is invoked by {@link AnnotationBasedEventSourcedEntityFactory} even when no first event
- * is present, unlike a plain {@link EntityCreator}. This lets a create-if-missing instance command handler run directly
- * on the entity, append the event that establishes its existence, and let subsequent decisions rely on the resulting
- * state.
+ * is present, unlike a plain {@link EntityCreator}. This is what allows a create-if-missing instance command handler
+ * to run directly on the entity: the entity is never {@code null}, so it can decide for itself whether to append the
+ * event that establishes its existence.
  *
  * @author Steven van Beelen
  */
@@ -48,145 +51,267 @@ class ForcedEntityCreatorTest {
     private final EventConverter converter = new DelegatingEventConverter(PassThroughConverter.INSTANCE);
 
     @Nested
-    class ContrastWithPlainEntityCreator {
+    class NoArgumentCreators {
 
         @Test
-        void forcedNoArgConstructorCreatesEntityWithoutFirstEvent() {
+        void forcedConstructorCreatesEntityWithoutFirstEvent() {
+            // given
             var factory = new AnnotationBasedEventSourcedEntityFactory<>(
-                    ForcedNoArgEntity.class,
-                    String.class,
-                    parameterResolverFactory,
-                    messageTypeResolver,
-                    converter
+                    ForcedEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
             );
 
-            ForcedNoArgEntity entity = factory.create("entity-id", null, new StubProcessingContext());
+            // when
+            ForcedEntity entity = factory.create("entity-id", null, new StubProcessingContext());
 
+            // then
             assertThat(entity).isNotNull();
-            assertThat(entity.id).isEqualTo("entity-id");
         }
 
         @Test
-        void plainNoArgConstructorReturnsNullWithoutFirstEvent() {
+        void plainConstructorReturnsNullWithoutFirstEvent() {
+            // given
             var factory = new AnnotationBasedEventSourcedEntityFactory<>(
-                    PlainNoArgEntity.class,
-                    String.class,
-                    parameterResolverFactory,
-                    messageTypeResolver,
-                    converter
+                    PlainEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
             );
 
-            PlainNoArgEntity entity = factory.create("entity-id", null, new StubProcessingContext());
+            // when
+            PlainEntity entity = factory.create("entity-id", null, new StubProcessingContext());
 
+            // then
             assertThat(entity).isNull();
         }
 
-        public static class ForcedNoArgEntity {
-
-            private final String id;
+        public static class ForcedEntity {
 
             @ForcedEntityCreator
-            public ForcedNoArgEntity(@InjectEntityId String id) {
-                this.id = id;
+            public ForcedEntity() {
             }
         }
 
-        public static class PlainNoArgEntity {
+        public static class PlainEntity {
 
             @EntityCreator
-            public PlainNoArgEntity(@InjectEntityId String id) {
+            public PlainEntity() {
             }
         }
     }
 
     @Nested
-    class CreateIfMissingInstanceCommandHandler {
+    class IdentifierBasedCreators {
 
-        private AnnotationBasedEventSourcedEntityFactory<Account, String> factory;
-
-        @BeforeEach
-        void setUp() {
-            factory = new AnnotationBasedEventSourcedEntityFactory<>(
-                    Account.class,
-                    String.class,
-                    parameterResolverFactory,
-                    messageTypeResolver,
-                    converter
+        @Test
+        void forcedConstructorCreatesEntityWithoutFirstEvent() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    ForcedEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
             );
+
+            // when
+            ForcedEntity entity = factory.create("entity-id", null, new StubProcessingContext());
+
+            // then
+            assertThat(entity).isNotNull();
+            assertThat(entity.id).isEqualTo("entity-id");
         }
 
         @Test
-        void instanceHandlerCanDecideBasedOnStateEstablishedByItsOwnForcedCreation() {
-            // A repository sourcing a never-existing entity would invoke the factory with no first event.
-            Account account = factory.create("account-id", null, new StubProcessingContext());
-            assertThat(account).isNotNull();
-            assertThat(account.exists()).isFalse();
+        void plainConstructorReturnsNullWithoutFirstEvent() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    PlainEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
+            );
 
-            // The create-if-missing instance handler appends the creation event itself, since it received a
-            // non-null entity thanks to the @ForcedEntityCreator constructor.
-            String firstOutcome = account.handleOpenAccount(100);
-            assertThat(firstOutcome).isEqualTo("opened");
-            assertThat(account.exists()).isTrue();
-            assertThat(account.balance()).isEqualTo(100);
+            // when
+            PlainEntity entity = factory.create("entity-id", null, new StubProcessingContext());
 
-            // A subsequent decision on the very same instance relies on the state the creation event established.
-            String secondOutcome = account.handleWithdraw(40);
-            assertThat(secondOutcome).isEqualTo("withdrawn");
-            assertThat(account.balance()).isEqualTo(60);
+            // then
+            assertThat(entity).isNull();
         }
 
-        @Test
-        void subsequentDecisionThrowsWithoutPriorCreationEvent() {
-            Account account = factory.create("account-id", null, new StubProcessingContext());
-            assertThat(account).isNotNull();
-
-            assertThatThrownBy(() -> account.handleWithdraw(10))
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("does not exist");
-        }
-
-        /**
-         * Simulates an event-sourced entity with a create-if-missing instance command handler. In real usage,
-         * {@code handleOpenAccount} and {@code handleWithdraw} would be {@code @CommandHandler}-annotated methods, and
-         * {@code apply} would delegate to an {@code EventAppender} whose emitted events are routed back into
-         * {@code @EventSourcingHandler}-annotated methods. Here the state transitions are applied directly to keep the
-         * test focused on the entity-creation behavior under test.
-         */
-        public static class Account {
+        public static class ForcedEntity {
 
             private final String id;
-            private boolean exists;
-            private int balance;
 
             @ForcedEntityCreator
-            public Account(@InjectEntityId String id) {
+            public ForcedEntity(@InjectEntityId String id) {
                 this.id = id;
-                this.exists = false;
+            }
+        }
+
+        public static class PlainEntity {
+
+            @EntityCreator
+            public PlainEntity(@InjectEntityId String id) {
+            }
+        }
+    }
+
+    @Nested
+    class StaticFactoryMethodCreators {
+
+        @Test
+        void forcedFactoryMethodCreatesEntityWithoutFirstEvent() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    ForcedEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
+            );
+
+            // when
+            ForcedEntity entity = factory.create("entity-id", null, new StubProcessingContext());
+
+            // then
+            assertThat(entity).isNotNull();
+            assertThat(entity.id).isEqualTo("entity-id");
+        }
+
+        @Test
+        void plainFactoryMethodReturnsNullWithoutFirstEvent() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    PlainEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
+            );
+
+            // when
+            PlainEntity entity = factory.create("entity-id", null, new StubProcessingContext());
+
+            // then
+            assertThat(entity).isNull();
+        }
+
+        public static class ForcedEntity {
+
+            private final String id;
+
+            private ForcedEntity(String id) {
+                this.id = id;
             }
 
-            public String handleOpenAccount(int initialBalance) {
-                if (exists) {
-                    return "already-open";
-                }
-                exists = true;
-                balance = initialBalance;
-                return "opened";
+            @ForcedEntityCreator
+            public static ForcedEntity create(@InjectEntityId String id) {
+                return new ForcedEntity(id);
+            }
+        }
+
+        public static class PlainEntity {
+
+            @EntityCreator
+            public static PlainEntity create(@InjectEntityId String id) {
+                return new PlainEntity();
+            }
+        }
+    }
+
+    @Nested
+    class EventBasedPrecedence {
+
+        @Test
+        void eventBasedCreatorTakesPrecedenceOverForcedIdBasedCreatorWhenFirstEventPresent() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    MixedEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
+            );
+            EventMessage firstEvent = new GenericEventMessage(
+                    new MessageType(CreationPayload.class), new CreationPayload("payload-value")
+            );
+
+            // when
+            MixedEntity entity =
+                    factory.create("entity-id", firstEvent, StubProcessingContext.forMessage(firstEvent));
+
+            // then
+            assertThat(entity).isNotNull();
+            assertThat(entity.source).isEqualTo("event");
+            assertThat(entity.value).isEqualTo("payload-value");
+        }
+
+        @Test
+        void forcedIdBasedCreatorStillAppliesWhenFirstEventPresentButNoEventBasedCreatorMatches() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    IdOnlyForcedEntity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
+            );
+            EventMessage firstEvent = new GenericEventMessage(new MessageType("unrelated-type"), "irrelevant");
+
+            // when
+            IdOnlyForcedEntity entity =
+                    factory.create("entity-id", firstEvent, StubProcessingContext.forMessage(firstEvent));
+
+            // then
+            assertThat(entity).isNotNull();
+            assertThat(entity.id).isEqualTo("entity-id");
+        }
+
+        public record CreationPayload(String value) {
+
+        }
+
+        public static class MixedEntity {
+
+            private final String source;
+            private final String value;
+
+            @ForcedEntityCreator
+            public MixedEntity(@InjectEntityId String id) {
+                this.source = "id";
+                this.value = null;
             }
 
-            public String handleWithdraw(int amount) {
-                if (!exists) {
-                    throw new IllegalStateException("Account [%s] does not exist".formatted(id));
-                }
-                balance -= amount;
-                return "withdrawn";
+            @EntityCreator
+            public MixedEntity(CreationPayload payload) {
+                this.source = "event";
+                this.value = payload.value();
             }
+        }
 
-            public boolean exists() {
-                return exists;
+        public static class IdOnlyForcedEntity {
+
+            private final String id;
+
+            @ForcedEntityCreator
+            public IdOnlyForcedEntity(@InjectEntityId String id) {
+                this.id = id;
             }
+        }
+    }
 
-            public int balance() {
-                return balance;
+    @Nested
+    class PayloadQualifiedNamesOverride {
+
+        @Test
+        void forcedCreatorHonorsExplicitPayloadQualifiedNamesOverride() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    Entity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
+            );
+            EventMessage matchingEvent = new GenericEventMessage(new MessageType("custom-creation-type"), "payload");
+
+            // when
+            Entity entity =
+                    factory.create("entity-id", matchingEvent, StubProcessingContext.forMessage(matchingEvent));
+
+            // then
+            assertThat(entity).isNotNull();
+        }
+
+        @Test
+        void forcedCreatorRejectsNonMatchingPayloadQualifiedName() {
+            // given
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    Entity.class, String.class, parameterResolverFactory, messageTypeResolver, converter
+            );
+            EventMessage nonMatchingEvent = new GenericEventMessage(new MessageType("other-type"), "payload");
+
+            // when / then
+            assertThatThrownBy(() -> factory.create(
+                    "entity-id", nonMatchingEvent, StubProcessingContext.forMessage(nonMatchingEvent)
+            )).isInstanceOf(AxonConfigurationException.class)
+              .hasMessageContaining("No suitable @EntityCreator found for id");
+        }
+
+        public static class Entity {
+
+            @ForcedEntityCreator(payloadQualifiedNames = "custom-creation-type")
+            public Entity(String payload) {
             }
         }
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/reflection/ForcedEntityCreatorTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/annotation/reflection/ForcedEntityCreatorTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.annotation.reflection;
+
+import org.axonframework.conversion.PassThroughConverter;
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
+import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.conversion.DelegatingEventConverter;
+import org.axonframework.messaging.eventhandling.conversion.EventConverter;
+import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests the behavior described on {@link ForcedEntityCreator}.
+ * <p>
+ * Ano-arguments (or {@link InjectEntityId}-only) factory constructor or method annotated with
+ * {@link ForcedEntityCreator} is invoked by {@link AnnotationBasedEventSourcedEntityFactory} even when no first event
+ * is present, unlike a plain {@link EntityCreator}. This lets a create-if-missing instance command handler run directly
+ * on the entity, append the event that establishes its existence, and let subsequent decisions rely on the resulting
+ * state.
+ *
+ * @author Steven van Beelen
+ */
+class ForcedEntityCreatorTest {
+
+    private final ParameterResolverFactory parameterResolverFactory =
+            ClasspathParameterResolverFactory.forClass(getClass());
+    private final MessageTypeResolver messageTypeResolver = new ClassBasedMessageTypeResolver();
+    private final EventConverter converter = new DelegatingEventConverter(PassThroughConverter.INSTANCE);
+
+    @Nested
+    class ContrastWithPlainEntityCreator {
+
+        @Test
+        void forcedNoArgConstructorCreatesEntityWithoutFirstEvent() {
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    ForcedNoArgEntity.class,
+                    String.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    converter
+            );
+
+            ForcedNoArgEntity entity = factory.create("entity-id", null, new StubProcessingContext());
+
+            assertThat(entity).isNotNull();
+            assertThat(entity.id).isEqualTo("entity-id");
+        }
+
+        @Test
+        void plainNoArgConstructorReturnsNullWithoutFirstEvent() {
+            var factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    PlainNoArgEntity.class,
+                    String.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    converter
+            );
+
+            PlainNoArgEntity entity = factory.create("entity-id", null, new StubProcessingContext());
+
+            assertThat(entity).isNull();
+        }
+
+        public static class ForcedNoArgEntity {
+
+            private final String id;
+
+            @ForcedEntityCreator
+            public ForcedNoArgEntity(@InjectEntityId String id) {
+                this.id = id;
+            }
+        }
+
+        public static class PlainNoArgEntity {
+
+            @EntityCreator
+            public PlainNoArgEntity(@InjectEntityId String id) {
+            }
+        }
+    }
+
+    @Nested
+    class CreateIfMissingInstanceCommandHandler {
+
+        private AnnotationBasedEventSourcedEntityFactory<Account, String> factory;
+
+        @BeforeEach
+        void setUp() {
+            factory = new AnnotationBasedEventSourcedEntityFactory<>(
+                    Account.class,
+                    String.class,
+                    parameterResolverFactory,
+                    messageTypeResolver,
+                    converter
+            );
+        }
+
+        @Test
+        void instanceHandlerCanDecideBasedOnStateEstablishedByItsOwnForcedCreation() {
+            // A repository sourcing a never-existing entity would invoke the factory with no first event.
+            Account account = factory.create("account-id", null, new StubProcessingContext());
+            assertThat(account).isNotNull();
+            assertThat(account.exists()).isFalse();
+
+            // The create-if-missing instance handler appends the creation event itself, since it received a
+            // non-null entity thanks to the @ForcedEntityCreator constructor.
+            String firstOutcome = account.handleOpenAccount(100);
+            assertThat(firstOutcome).isEqualTo("opened");
+            assertThat(account.exists()).isTrue();
+            assertThat(account.balance()).isEqualTo(100);
+
+            // A subsequent decision on the very same instance relies on the state the creation event established.
+            String secondOutcome = account.handleWithdraw(40);
+            assertThat(secondOutcome).isEqualTo("withdrawn");
+            assertThat(account.balance()).isEqualTo(60);
+        }
+
+        @Test
+        void subsequentDecisionThrowsWithoutPriorCreationEvent() {
+            Account account = factory.create("account-id", null, new StubProcessingContext());
+            assertThat(account).isNotNull();
+
+            assertThatThrownBy(() -> account.handleWithdraw(10))
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("does not exist");
+        }
+
+        /**
+         * Simulates an event-sourced entity with a create-if-missing instance command handler. In real usage,
+         * {@code handleOpenAccount} and {@code handleWithdraw} would be {@code @CommandHandler}-annotated methods, and
+         * {@code apply} would delegate to an {@code EventAppender} whose emitted events are routed back into
+         * {@code @EventSourcingHandler}-annotated methods. Here the state transitions are applied directly to keep the
+         * test focused on the entity-creation behavior under test.
+         */
+        public static class Account {
+
+            private final String id;
+            private boolean exists;
+            private int balance;
+
+            @ForcedEntityCreator
+            public Account(@InjectEntityId String id) {
+                this.id = id;
+                this.exists = false;
+            }
+
+            public String handleOpenAccount(int initialBalance) {
+                if (exists) {
+                    return "already-open";
+                }
+                exists = true;
+                balance = initialBalance;
+                return "opened";
+            }
+
+            public String handleWithdraw(int amount) {
+                if (!exists) {
+                    throw new IllegalStateException("Account [%s] does not exist".formatted(id));
+                }
+                balance -= amount;
+                return "withdrawn";
+            }
+
+            public boolean exists() {
+                return exists;
+            }
+
+            public int balance() {
+                return balance;
+            }
+        }
+    }
+}

--- a/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/EntityStateOnAppendDuringCommandIT.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/testsuite/giftcard/EntityStateOnAppendDuringCommandIT.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests.testsuite.giftcard;
+
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.annotation.reflection.InjectEntityId;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.TargetEntityId;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies how an event-sourced entity's own state behaves when it appends events <em>during</em> a single
+ * command-handler method invocation, contrasting a mutable and an immutable entity.
+ * <p>
+ * The scenario mirrors a command handler that appends more than one event in a row, reading its own state in between.
+ * Two distinct behaviors are demonstrated:
+ * <ul>
+ *     <li>The persisted, re-sourced state is always correct (the appended events evolve the managed entity), regardless
+ *     of whether the entity is mutable or immutable. This confirms the managed entity holds the evolved instance even
+ *     for immutable entities, where each event-sourcing handler returns a brand-new instance.</li>
+ *     <li>The state observed through {@code this} <em>within the same method</em>, after an append, only reflects the
+ *     appended event for a mutable entity. A mutable event-sourcing handler mutates the very object {@code this} points
+ *     to, so the change is visible immediately. An immutable event-sourcing handler returns a new instance that
+ *     replaces the managed reference, but the local {@code this} of the executing method remains the pre-append
+ *     snapshot, so intra-method reads do not observe it.</li>
+ * </ul>
+ *
+ * @author Mateusz Nowak
+ */
+class EntityStateOnAppendDuringCommandIT {
+
+    // Captures what count the entity observes on `this` AFTER the first append, still inside the same handler method.
+    private static final List<Integer> MUTABLE_INTRA_METHOD_READS = new CopyOnWriteArrayList<>();
+    private static final List<Integer> IMMUTABLE_INTRA_METHOD_READS = new CopyOnWriteArrayList<>();
+
+    // FQCN of the AxonServer enhancer, disabled to keep the in-memory defaults in place.
+    private static final String AXON_SERVER_ENHANCER_FQCN =
+            "io.axoniq.framework.axonserver.connector.configuration.AxonServerConfigurationEnhancer";
+
+    private AxonConfiguration configuration;
+    private CommandGateway commandGateway;
+
+    @AfterEach
+    void tearDown() {
+        MUTABLE_INTRA_METHOD_READS.clear();
+        IMMUTABLE_INTRA_METHOD_READS.clear();
+        if (configuration != null) {
+            configuration.shutdown();
+        }
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private void startAppWith(Class<?> idType, Class<?> entityType) {
+        EventSourcedEntityModule<?, ?> entityModule = EventSourcedEntityModule.autodetected(idType, entityType);
+        configuration = EventSourcingConfigurer.create()
+                                               .componentRegistry(cr -> cr.registerModule(entityModule))
+                                               .componentRegistry(cr -> cr.disableEnhancer(AXON_SERVER_ENHANCER_FQCN))
+                                               .start();
+        commandGateway = configuration.getComponent(CommandGateway.class);
+    }
+
+    @Nested
+    class MutableEntity {
+
+        @BeforeEach
+        void setUp() {
+            startAppWith(String.class, MutableCounter.class);
+        }
+
+        @Test
+        void mutableEntitySeesItsOwnAppendedEventWithinTheSameHandlerMethod() {
+            // given a created counter
+            commandGateway.send(new CreateCounter("m-1")).getResultMessage().join();
+
+            // when a single handler appends two Incremented events, reading `this` in between
+            commandGateway.send(new IncrementTwiceInOneHandler("m-1")).getResultMessage().join();
+
+            // then the intra-method read observed the first append (mutation of `this`)
+            assertThat(MUTABLE_INTRA_METHOD_READS).containsExactly(1);
+            // and the re-sourced state reflects both appends
+            Integer count = commandGateway.send(new GetCount("m-1"), Integer.class).join();
+            assertThat(count).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    class ImmutableEntity {
+
+        @BeforeEach
+        void setUp() {
+            startAppWith(String.class, ImmutableCounter.class);
+        }
+
+        @Test
+        void immutableEntityDoesNotSeeItsOwnAppendedEventWithinTheSameHandlerMethodButStateIsStillPersisted() {
+            // given a created counter
+            commandGateway.send(new CreateCounter("i-1")).getResultMessage().join();
+
+            // when a single handler appends two Incremented events, reading `this` in between
+            commandGateway.send(new IncrementTwiceInOneHandler("i-1")).getResultMessage().join();
+
+            // then the intra-method read did NOT observe the first append: `this` stays the pre-append snapshot
+            assertThat(IMMUTABLE_INTRA_METHOD_READS).containsExactly(0);
+            // but the managed entity still evolved: the re-sourced state reflects both appends
+            Integer count = commandGateway.send(new GetCount("i-1"), Integer.class).join();
+            assertThat(count).isEqualTo(2);
+        }
+    }
+
+    // --- Commands ---
+
+    record CreateCounter(@TargetEntityId String counterId) {
+
+    }
+
+    record IncrementTwiceInOneHandler(@TargetEntityId String counterId) {
+
+    }
+
+    record GetCount(@TargetEntityId String counterId) {
+
+    }
+
+    // --- Events ---
+
+    record CounterCreated(@EventTag(key = "Counter") String counterId) {
+
+    }
+
+    record Incremented(@EventTag(key = "Counter") String counterId) {
+
+    }
+
+    // --- Mutable entity: void event-sourcing handlers mutate `this` in place ---
+
+    @SuppressWarnings("unused")
+    @EventSourcedEntity(tagKey = "Counter")
+    static class MutableCounter {
+
+        private final String counterId;
+        private int count;
+
+        @EntityCreator
+        MutableCounter(@InjectEntityId String counterId) {
+            this.counterId = counterId;
+        }
+
+        @CommandHandler
+        static void handle(CreateCounter command, EventAppender appender) {
+            appender.append(new CounterCreated(command.counterId()));
+        }
+
+        @CommandHandler
+        void handle(IncrementTwiceInOneHandler command, EventAppender appender) {
+            appender.append(new Incremented(counterId));
+            MUTABLE_INTRA_METHOD_READS.add(count);
+            appender.append(new Incremented(counterId));
+        }
+
+        @CommandHandler
+        int handle(GetCount command) {
+            return count;
+        }
+
+        @EventSourcingHandler
+        void on(Incremented event) {
+            this.count++;
+        }
+    }
+
+    // --- Immutable entity: event-sourcing handlers return a new instance ---
+
+    @SuppressWarnings("unused")
+    @EventSourcedEntity(tagKey = "Counter")
+    record ImmutableCounter(String counterId, int count) {
+
+        @EntityCreator
+        ImmutableCounter(CounterCreated event) {
+            this(event.counterId(), 0);
+        }
+
+        @CommandHandler
+        static void handle(CreateCounter command, EventAppender appender) {
+            appender.append(new CounterCreated(command.counterId()));
+        }
+
+        @CommandHandler
+        void handle(IncrementTwiceInOneHandler command, EventAppender appender) {
+            appender.append(new Incremented(counterId));
+            IMMUTABLE_INTRA_METHOD_READS.add(count);
+            appender.append(new Incremented(counterId));
+        }
+
+        @CommandHandler
+        int handle(GetCount command) {
+            return count;
+        }
+
+        @EventSourcingHandler
+        ImmutableCounter on(Incremented event) {
+            return new ImmutableCounter(counterId, count + 1);
+        }
+    }
+}


### PR DESCRIPTION
This PR is a port of https://github.com/AxonIQ/AxonFramework/pull/4930.