### PR TITLE
Fix broken link to entity-creator.adoc in stateful-command-handler.adoc

### DIFF
--- a/docs/reference-guide/modules/commands/pages/entities/stateful-command-handler.adoc
+++ b/docs/reference-guide/modules/commands/pages/entities/stateful-command-handler.adoc
@@ -66,7 +66,7 @@ Without either attribute set, Axon falls back to the default resolver, which rea
 By default, an `@InjectEntity` parameter requires the entity to exist.
 If no entity can be found for the resolved identifier, Axon throws an `EntityNotFoundException`, failing the command instead of invoking the handler.
 
-Note that this existence check applies regardless of how the entity's `@EntityCreator` (applicable to event-sourced entities **only**, as detailed further link:entity-creator.adoc[here]) constructs it.
+Note that this existence check applies regardless of how the entity's `@EntityCreator` (applicable to event-sourced entities **only**, as detailed further xref:commands:entities/entity-creator.adoc[here]) constructs it.
 Even a no-arg or identifier-based creator, which do not need a preceding event to produce an instance, only create said entity if that instance actually exists.
 The same holds for `ManagedEntity.entity()`, for which the behavior is further explained xref:inject_managed_entity[here].
 


### PR DESCRIPTION
## Summary
- The "Handling a missing entity" section used the `link:` macro with a raw relative path (`link:entity-creator.adoc[here]`) instead of `xref:`. Antora doesn't resolve `link:` targets the way it resolves `xref:`, so it rendered as a literal `entity-creator.adoc` href relative to the current page and 404'd (Antora never serves `.adoc` files directly). This was failing the `axoniq-library-site` CI build's broken-link check.
- Switched to `xref:commands:entities/entity-creator.adoc[here]`, matching the pattern already used elsewhere in the same file.

## Test plan
- [x] Rebuilt the `axoniq-library-site` docs locally against this branch; the link now resolves to `../entity-creator/` instead of the broken `.adoc` path.
- [x] Ran `check-broken-links.js` against the local build; no broken links reported.