### PR TITLE
Convert message handlers to right MessageStream cardinality

### DIFF
--- a/integrationtests/src/test/java/org/axonframework/integrationtests/HandlerReturnValueTest.java
+++ b/integrationtests/src/test/java/org/axonframework/integrationtests/HandlerReturnValueTest.java
@@ -1,0 +1,380 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.integrationtests;
+
+import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.queryhandling.annotation.QueryHandler;
+import org.axonframework.messaging.queryhandling.configuration.QueryHandlingModule;
+import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration test validating how many responses a message handler's return value becomes, and thus what the dispatcher
+ * receives back.
+ * <p>
+ * Command handlers produce exactly one result, so a returned collection reaches the dispatcher as a whole. Query
+ * handlers may produce several, so a returned collection reaches the dispatcher as one response per element. Both hold
+ * regardless of the {@link CompletableFuture} and {@link Optional} wrappers the return value is nested in, and single
+ * values are unaffected by either rule.
+ *
+ * @author Mitchell Herrijgers
+ */
+class HandlerReturnValueTest {
+
+    private static final List<String> ELEMENTS = List.of("first", "second", "third");
+    private static final String SINGLE = "only";
+
+    private AxonConfiguration configuration;
+    private CommandGateway commandGateway;
+    private QueryGateway queryGateway;
+
+    @BeforeEach
+    void setUp() {
+        configuration = MessagingConfigurer.create()
+                                           .registerCommandHandlingModule(
+                                                   CommandHandlingModule.named("return-value-commands")
+                                                                        .commandHandlers()
+                                                                        .autodetectedCommandHandlingComponent(
+                                                                                c -> new ReturnValueCommandHandler())
+                                           )
+                                           .registerQueryHandlingModule(
+                                                   QueryHandlingModule.named("return-value-queries")
+                                                                      .queryHandlers()
+                                                                      .autodetectedQueryHandlingComponent(
+                                                                              c -> new ReturnValueQueryHandler())
+                                           )
+                                           .start();
+        commandGateway = configuration.getComponent(CommandGateway.class);
+        queryGateway = configuration.getComponent(QueryGateway.class);
+    }
+
+    @AfterEach
+    void tearDown() {
+        configuration.shutdown();
+    }
+
+    @Nested
+    class CommandHandlerReturningACollection {
+
+        @Test
+        void sendAndWaitReturnsTheCompleteList() {
+            // when
+            List<?> result = commandGateway.sendAndWait(new ListCommand("id"), List.class);
+
+            // then
+            assertThat(result).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void sendAndWaitReturnsTheCompleteListForAnAsyncHandler() {
+            // when
+            List<?> result = commandGateway.sendAndWait(new AsyncListCommand("id"), List.class);
+
+            // then
+            assertThat(result).isEqualTo(ELEMENTS);
+        }
+    }
+
+    @Nested
+    class CommandHandlerReturningASingleValue {
+
+        @Test
+        void sendAndWaitReturnsThePlainValue() {
+            // when
+            String result = commandGateway.sendAndWait(new SingleCommand("id"), String.class);
+
+            // then
+            assertThat(result).isEqualTo(SINGLE);
+        }
+
+        @Test
+        void sendAndWaitUnwrapsAnOptionalValue() {
+            // when
+            String result = commandGateway.sendAndWait(new OptionalCommand("id"), String.class);
+
+            // then
+            assertThat(result).isEqualTo(SINGLE);
+        }
+
+        @Test
+        void sendAndWaitReturnsTheValueOfAnAsyncHandler() {
+            // when
+            String result = commandGateway.sendAndWait(new AsyncSingleCommand("id"), String.class);
+
+            // then
+            assertThat(result).isEqualTo(SINGLE);
+        }
+
+        @Test
+        void sendAndWaitUnwrapsAnOptionalValueOfAnAsyncHandler() {
+            // when
+            String result = commandGateway.sendAndWait(new AsyncOptionalCommand("id"), String.class);
+
+            // then
+            assertThat(result).isEqualTo(SINGLE);
+        }
+
+        @Test
+        void sendAndWaitReturnsNullWhenTheHandlerProducesNoResult() {
+            // when / then
+            assertThat(commandGateway.sendAndWait(new NullCommand("id"), String.class)).isNull();
+            assertThat(commandGateway.sendAndWait(new EmptyOptionalCommand("id"), String.class)).isNull();
+        }
+    }
+
+    @Nested
+    class QueryHandlerReturningACollection {
+
+        @Test
+        void queryManyReturnsAllElements() throws Exception {
+            // when
+            List<String> result = queryGateway.queryMany(new ListQuery("id"), String.class, null)
+                                              .get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(result).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void queryManyReturnsAllElementsForAnAsyncHandler() throws Exception {
+            // when
+            List<String> result = queryGateway.queryMany(new AsyncListQuery("id"), String.class, null)
+                                              .get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(result).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void queryReturnsTheFirstResponseOfAMultiResponseHandler() throws Exception {
+            // given a handler returning a collection, which declares it produces several responses
+            // when asking for a single response
+            String result = queryGateway.query(new ListQuery("id"), String.class, null)
+                                        .get(5, TimeUnit.SECONDS);
+
+            // then the first response is returned, the remainder is discarded
+            assertThat(result).isEqualTo(ELEMENTS.get(0));
+        }
+    }
+
+    @Nested
+    class QueryHandlerReturningASingleValue {
+
+        @Test
+        void queryReturnsThePlainValue() throws Exception {
+            // when
+            String result = queryGateway.query(new SingleQuery("id"), String.class, null)
+                                        .get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(result).isEqualTo(SINGLE);
+        }
+
+        @Test
+        void queryUnwrapsAnOptionalValue() throws Exception {
+            // when
+            String result = queryGateway.query(new OptionalQuery("id"), String.class, null)
+                                        .get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(result).isEqualTo(SINGLE);
+        }
+
+        @Test
+        void queryReturnsTheValueOfAnAsyncHandler() throws Exception {
+            // when
+            String result = queryGateway.query(new AsyncSingleQuery("id"), String.class, null)
+                                        .get(5, TimeUnit.SECONDS);
+
+            // then
+            assertThat(result).isEqualTo(SINGLE);
+        }
+
+        @Test
+        void queryManyReturnsExactlyOneElement() throws Exception {
+            // when asking for several responses from a handler producing one
+            List<String> result = queryGateway.queryMany(new SingleQuery("id"), String.class, null)
+                                              .get(5, TimeUnit.SECONDS);
+
+            // then that one response is the only element
+            assertThat(result).containsExactly(SINGLE);
+        }
+
+        @Test
+        void queryReturnsNullWhenTheHandlerProducesNoResult() throws Exception {
+            // when / then
+            assertThat(queryGateway.query(new NullQuery("id"), String.class, null).get(5, TimeUnit.SECONDS)).isNull();
+            assertThat(queryGateway.query(new EmptyOptionalQuery("id"), String.class, null)
+                                   .get(5, TimeUnit.SECONDS)).isNull();
+        }
+    }
+
+    record ListCommand(String id) {
+
+    }
+
+    record AsyncListCommand(String id) {
+
+    }
+
+    record SingleCommand(String id) {
+
+    }
+
+    record AsyncSingleCommand(String id) {
+
+    }
+
+    record OptionalCommand(String id) {
+
+    }
+
+    record AsyncOptionalCommand(String id) {
+
+    }
+
+    record NullCommand(String id) {
+
+    }
+
+    record EmptyOptionalCommand(String id) {
+
+    }
+
+    record ListQuery(String id) {
+
+    }
+
+    record AsyncListQuery(String id) {
+
+    }
+
+    record SingleQuery(String id) {
+
+    }
+
+    record AsyncSingleQuery(String id) {
+
+    }
+
+    record OptionalQuery(String id) {
+
+    }
+
+    record NullQuery(String id) {
+
+    }
+
+    record EmptyOptionalQuery(String id) {
+
+    }
+
+    static class ReturnValueCommandHandler {
+
+        @CommandHandler
+        List<String> handle(ListCommand command) {
+            return ELEMENTS;
+        }
+
+        @CommandHandler
+        CompletableFuture<List<String>> handle(AsyncListCommand command) {
+            return CompletableFuture.completedFuture(ELEMENTS);
+        }
+
+        @CommandHandler
+        String handle(SingleCommand command) {
+            return SINGLE;
+        }
+
+        @CommandHandler
+        CompletableFuture<String> handle(AsyncSingleCommand command) {
+            return CompletableFuture.completedFuture(SINGLE);
+        }
+
+        @CommandHandler
+        Optional<String> handle(OptionalCommand command) {
+            return Optional.of(SINGLE);
+        }
+
+        @CommandHandler
+        CompletableFuture<Optional<String>> handle(AsyncOptionalCommand command) {
+            return CompletableFuture.completedFuture(Optional.of(SINGLE));
+        }
+
+        @CommandHandler
+        @Nullable
+        String handle(NullCommand command) {
+            return null;
+        }
+
+        @CommandHandler
+        Optional<String> handle(EmptyOptionalCommand command) {
+            return Optional.empty();
+        }
+    }
+
+    static class ReturnValueQueryHandler {
+
+        @QueryHandler
+        List<String> handle(ListQuery query) {
+            return ELEMENTS;
+        }
+
+        @QueryHandler
+        CompletableFuture<List<String>> handle(AsyncListQuery query) {
+            return CompletableFuture.completedFuture(ELEMENTS);
+        }
+
+        @QueryHandler
+        String handle(SingleQuery query) {
+            return SINGLE;
+        }
+
+        @QueryHandler
+        CompletableFuture<String> handle(AsyncSingleQuery query) {
+            return CompletableFuture.completedFuture(SINGLE);
+        }
+
+        @QueryHandler
+        Optional<String> handle(OptionalQuery query) {
+            return Optional.of(SINGLE);
+        }
+
+        @QueryHandler
+        @Nullable
+        String handle(NullQuery query) {
+            return null;
+        }
+
+        @QueryHandler
+        Optional<String> handle(EmptyOptionalQuery query) {
+            return Optional.empty();
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerInspector.java
@@ -17,12 +17,15 @@
 package org.axonframework.messaging.core.annotation;
 
 import org.axonframework.common.annotation.Internal;
+import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.interception.annotation.ChainedMessageHandlerInterceptorMember;
 import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.interception.annotation.MessageInterceptingMember;
 import org.axonframework.messaging.core.interception.annotation.NoMoreInterceptors;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
@@ -43,6 +46,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptySet;
 import static java.util.Collections.emptySortedSet;
+import static org.axonframework.messaging.core.annotation.MessageStreamResolverUtils.resolveToSingleStream;
 import static org.axonframework.messaging.core.annotation.MessageStreamResolverUtils.resolveToStream;
 
 /**
@@ -238,12 +242,13 @@ public class AnnotatedHandlerInspector<T> {
     private void initializeMessageHandlers(ParameterResolverFactory parameterResolverFactory,
                                            HandlerDefinition handlerDefinition) {
         handlers.put(inspectedType, new TreeSet<>(HandlerComparator.instance()));
+        MessageStreamResolver messageStreamResolver = this::resolveResultToStream;
         for (Method method : inspectedType.getDeclaredMethods()) {
             handlerDefinition.createHandler(
                     inspectedType,
                     method,
                     parameterResolverFactory,
-                    result -> resolveToStream(result, messageTypeResolver)
+                    messageStreamResolver
             ).ifPresent(h -> registerHandler(inspectedType, h));
         }
 
@@ -273,6 +278,22 @@ public class AnnotatedHandlerInspector<T> {
                                                    registerHandler(key, h);
                                                    registerHandler(inspectedType, h);
                                                })));
+    }
+
+    /**
+     * Resolves a handler's return value into a {@link MessageStream}, taking the {@code messageType} the handler is
+     * subscribed for into account to decide how many {@link Message Messages} it may produce.
+     * <p>
+     * Handlers of {@link CommandMessage CommandMessages} produce exactly one result, as expressed by
+     * {@link org.axonframework.messaging.commandhandling.CommandHandler} returning a {@link MessageStream.Single}. A
+     * collection returned by such a handler is therefore carried as the payload of a single {@link Message}, since
+     * spreading it over one {@code Message} per element would silently discard all elements but the first. Handlers of
+     * other message types may produce several results, and thus do spread a returned collection.
+     */
+    private MessageStream<?> resolveResultToStream(@Nullable Object result, Class<? extends Message> messageType) {
+        return CommandMessage.class.isAssignableFrom(messageType)
+                ? resolveToSingleStream(result, messageTypeResolver)
+                : resolveToStream(result, messageTypeResolver);
     }
 
     private void registerHandler(Class<?> type, MessageHandlingMember<? super T> handler) {

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core.annotation;
+
+import org.axonframework.messaging.core.Message;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Function;
+
+/**
+ * Resolves the value returned by a message handler into the {@link MessageStream} that carries it to the dispatcher.
+ * <p>
+ * The {@code messageType} the handler is subscribed for is given alongside the {@code result}, as it determines how many
+ * {@link Message Messages} the handler may produce. Handlers of
+ * {@link org.axonframework.messaging.commandhandling.CommandMessage CommandMessages} produce exactly one result, so a
+ * returned collection is carried as the payload of a single {@code Message}. Handlers of other message types may
+ * produce several results, so a returned collection is spread over one {@code Message} per element.
+ * <p>
+ * This interface refines the {@link Function} that
+ * {@link HandlerDefinition#createHandler(Class, java.lang.reflect.Method, ParameterResolverFactory, Function)} has
+ * accepted since 5.0.0, so that it can be passed wherever that {@code Function} is expected. A
+ * {@code HandlerDefinition} that forwards the {@code Function} it receives keeps the message type intact; one that
+ * replaces it with a {@code Function} of its own falls back to {@link #apply(Object)}, which cannot know the message
+ * type and therefore resolves as if the handler may produce several results.
+ *
+ * @author Mitchell Herrijgers
+ * @see MessageStreamResolverUtils
+ * @since 5.3.0
+ */
+@FunctionalInterface
+public interface MessageStreamResolver extends Function<Object, MessageStream<?>> {
+
+    /**
+     * Resolves the given {@code result} of a handler subscribed for the given {@code messageType} into a
+     * {@link MessageStream}.
+     *
+     * @param result      The value returned by
+     *                    {@link MessageHandlingMember#handle(Message, ProcessingContext, Object)}, possibly
+     *                    {@code null}.
+     * @param messageType The type of {@link Message} the handler returning the {@code result} is subscribed for.
+     * @return A {@code MessageStream} carrying the given {@code result}.
+     */
+    MessageStream<?> resolve(@Nullable Object result, Class<? extends Message> messageType);
+
+    /**
+     * Resolves the given {@code result} without knowing which type of {@link Message} the handler is subscribed for,
+     * and thus how many {@code Messages} it may produce.
+     * <p>
+     * Exists to satisfy the {@link Function} contract for callers predating
+     * {@link #resolve(Object, Class)}. Resolves as if the handler may produce several results, matching the behaviour
+     * of those callers. Prefer {@code resolve(Object, Class)} whenever the message type is known.
+     *
+     * @param result The value returned by {@link MessageHandlingMember#handle(Message, ProcessingContext, Object)},
+     *               possibly {@code null}.
+     * @return A {@code MessageStream} carrying the given {@code result}.
+     */
+    @Override
+    default MessageStream<?> apply(@Nullable Object result) {
+        return resolve(result, Message.class);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
@@ -41,7 +41,7 @@ import java.util.function.Function;
  *
  * @author Mitchell Herrijgers
  * @see MessageStreamResolverUtils
- * @since 5.3.0
+ * @since 5.3.1
  */
 @FunctionalInterface
 public interface MessageStreamResolver extends Function<Object, MessageStream<?>> {

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
@@ -50,11 +50,11 @@ public interface MessageStreamResolver extends Function<Object, MessageStream<?>
      * Resolves the given {@code result} of a handler subscribed for the given {@code messageType} into a
      * {@link MessageStream}.
      *
-     * @param result      The value returned by
+     * @param result      the value returned by
      *                    {@link MessageHandlingMember#handle(Message, ProcessingContext, Object)}, possibly
-     *                    {@code null}.
-     * @param messageType The type of {@link Message} the handler returning the {@code result} is subscribed for.
-     * @return A {@code MessageStream} carrying the given {@code result}.
+     *                    {@code null}
+     * @param messageType the type of {@link Message} the handler returning the {@code result} is subscribed for
+     * @return a {@code MessageStream} carrying the given {@code result}
      */
     MessageStream<?> resolve(@Nullable Object result, Class<? extends Message> messageType);
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolver.java
@@ -66,9 +66,9 @@ public interface MessageStreamResolver extends Function<Object, MessageStream<?>
      * {@link #resolve(Object, Class)}. Resolves as if the handler may produce several results, matching the behaviour
      * of those callers. Prefer {@code resolve(Object, Class)} whenever the message type is known.
      *
-     * @param result The value returned by {@link MessageHandlingMember#handle(Message, ProcessingContext, Object)},
-     *               possibly {@code null}.
-     * @return A {@code MessageStream} carrying the given {@code result}.
+     * @param result the value returned by {@link MessageHandlingMember#handle(Message, ProcessingContext, Object)},
+     *               possibly {@code null}
+     * @return a {@code MessageStream} carrying the given {@code result}
      */
     @Override
     default MessageStream<?> apply(@Nullable Object result) {

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
@@ -96,10 +96,10 @@ public class MessageStreamResolverUtils {
      * {@link org.axonframework.messaging.commandhandling.CommandHandler command handlers}, for which spreading would
      * mean silently discarding all but the first element.
      *
-     * @param result       The result to map into a {@link MessageStream}.
-     * @param typeResolver The {@code MessageTypeResolver} used to resolve the {@link MessageType} for the
-     *                     {@link Message} that is held in the returned {@link MessageStream}.
-     * @return A {@code MessageStream} based on the given {@code result}.
+     * @param result       the result to map into a {@link MessageStream}
+     * @param typeResolver the {@code MessageTypeResolver} used to resolve the {@link MessageType} for the
+     *                     {@link Message} that is held in the returned {@link MessageStream}
+     * @return a {@code MessageStream} based on the given {@code result}
      */
     public static MessageStream<?> resolveToSingleStream(@Nullable Object result,
                                                          MessageTypeResolver typeResolver) {

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
@@ -79,7 +79,11 @@ public class MessageStreamResolverUtils {
      * @param typeResolver The {@code MessageTypeResolver} used to resolve the {@link MessageType} for
      *                     {@link Message Messages} that are held in the returned
      *                     {@link MessageStream}.
-     * @return A {@code MessageStream} based on the given {@code result}.
+    * @param result       the result to map into a {@link MessageStream}
+    * @param typeResolver the {@code MessageTypeResolver} used to resolve the {@link MessageType} for
+    *                     {@link Message Messages} that are held in the returned
+    *                     {@link MessageStream}
+    * @return a {@code MessageStream} based on the given {@code result}
      */
     public static MessageStream<?> resolveToStream(@Nullable Object result,
                                                    MessageTypeResolver typeResolver) {

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtils.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.core.annotation;
 
 import org.jspecify.annotations.Nullable;
 import org.axonframework.common.annotation.Internal;
+import org.axonframework.messaging.core.DelayedMessageStream;
 import org.axonframework.messaging.core.FluxUtils;
 import org.axonframework.messaging.core.GenericMessage;
 import org.axonframework.messaging.core.Message;
@@ -40,14 +41,19 @@ import java.util.stream.StreamSupport;
  * Utility class that can resolve the result of any {@link MessageHandler}
  * into the expected corresponding {@link MessageStream}.
  * <p>
- * This utility class currently has a major drawback, which is that it only takes the "top level" type into account.
- * Differently put, if we receive a {@code Mono<Message>} as the given {@code result} of
- * {@link #resolveToStream(Object, MessageTypeResolver)}, we will push that {@code Message} through the given
- * {@code typeResolver} and make it the {@link Message#payload()}. Similarly, if we receive a
- * {@code CompletableFuture<List<Object>>} (or {@code CompletableFuture<List<Message>>} for that matter), we will return
- * a {@link MessageStream.Single}, while we are actually dealing with a {@link MessageStream}.
+ * Whether a returned {@link Iterable} represents <em>several</em> results or <em>one</em> result that happens to be a
+ * collection cannot be derived from the value itself. Callers therefore choose the cardinality up front:
+ * {@link #resolveToStream(Object, MessageTypeResolver)} spreads an {@code Iterable} over as many
+ * {@link Message Messages} as it holds elements, while {@link #resolveToSingleStream(Object, MessageTypeResolver)}
+ * carries it as the {@link Message#payload()} of a single {@code Message}. Both unwrap asynchronous containers such as
+ * {@link CompletableFuture} first, so that {@code List<T>} and {@code CompletableFuture<List<T>>} yield the same
+ * cardinality.
  * <p>
- * These are known limitation that will be supported in due time.
+ * This utility class currently has a drawback, which is that it only takes the "top level" type into account.
+ * Differently put, if we receive a {@code Mono<Message>} as the given {@code result}, we will push that
+ * {@code Message} through the given {@code typeResolver} and make it the {@link Message#payload()}.
+ * <p>
+ * This is a known limitation that will be supported in due time.
  *
  * @author Simon Zambrovski
  * @author Steven van Beelen
@@ -57,12 +63,17 @@ import java.util.stream.StreamSupport;
 public class MessageStreamResolverUtils {
 
     /**
-     * Resolves the given {@code result} into a {@link MessageStream}, using the {@code typeResolver} when a
-     * {@link Message} is constructed to define the {@link MessageType}.
+     * Resolves the given {@code result} into a {@link MessageStream} that may carry several {@link Message Messages},
+     * using the {@code typeResolver} when a {@code Message} is constructed to define the {@link MessageType}.
      * <p>
      * Is able to switch between {@link Optional}, {@link CompletableFuture}, {@link Iterable}, {@link Stream},
-     * {@link Mono}, and {@link Flux}. If none of the above apply, or the given {@code result} is {@code null},
-     * {@link MessageStream#just(Message)} will be used.
+     * {@link Mono}, and {@link Flux}. An {@code Iterable} or {@code Stream} is spread over as many {@code Messages} as
+     * it holds elements, also when wrapped in a {@code CompletableFuture} or {@code Optional}. If none of the above
+     * apply, {@link MessageStream#just(Message)} will be used. If the given {@code result} is {@code null},
+     * {@link MessageStream#empty()} is returned.
+     * <p>
+     * Use {@link #resolveToSingleStream(Object, MessageTypeResolver)} for handlers that produce exactly one result, as
+     * those must carry a returned collection as a whole instead of spreading it.
      *
      * @param result       The result to map into a {@link MessageStream}.
      * @param typeResolver The {@code MessageTypeResolver} used to resolve the {@link MessageType} for
@@ -72,6 +83,32 @@ public class MessageStreamResolverUtils {
      */
     public static MessageStream<?> resolveToStream(@Nullable Object result,
                                                    MessageTypeResolver typeResolver) {
+        return resolve(result, typeResolver, true);
+    }
+
+    /**
+     * Resolves the given {@code result} into a {@link MessageStream} carrying at most one {@link Message}, using the
+     * {@code typeResolver} when that {@code Message} is constructed to define the {@link MessageType}.
+     * <p>
+     * Behaves like {@link #resolveToStream(Object, MessageTypeResolver)}, except that a returned {@link Iterable}
+     * becomes the {@link Message#payload()} of a single {@code Message} rather than being spread over one {@code
+     * Message} per element. This suits handlers that produce exactly one result, such as
+     * {@link org.axonframework.messaging.commandhandling.CommandHandler command handlers}, for which spreading would
+     * mean silently discarding all but the first element.
+     *
+     * @param result       The result to map into a {@link MessageStream}.
+     * @param typeResolver The {@code MessageTypeResolver} used to resolve the {@link MessageType} for the
+     *                     {@link Message} that is held in the returned {@link MessageStream}.
+     * @return A {@code MessageStream} based on the given {@code result}.
+     */
+    public static MessageStream<?> resolveToSingleStream(@Nullable Object result,
+                                                         MessageTypeResolver typeResolver) {
+        return resolve(result, typeResolver, false);
+    }
+
+    private static MessageStream<?> resolve(@Nullable Object result,
+                                            MessageTypeResolver typeResolver,
+                                            boolean spreadIterables) {
         Objects.requireNonNull(typeResolver, "The Message Type Resolver must not be null.");
         if (result == null) {
             return MessageStream.empty();
@@ -90,15 +127,14 @@ public class MessageStreamResolverUtils {
         // Handle standard types with pattern matching switch
         return switch (result) {
             case MessageStream<?> messageStream -> messageStream;
-            case CompletableFuture<?> future -> MessageStream.fromFuture(
-                    future.thenApply(r -> r == null ? null : new GenericMessage(typeResolver.resolveOrThrow(r), r))
+            case CompletableFuture<?> future -> DelayedMessageStream.create(
+                    future.thenApply(r -> asMessageStream(resolve(r, typeResolver, spreadIterables)))
             );
-            case Optional<?> optional when optional.isPresent() -> {
-                Object r = optional.get();
-                yield MessageStream.just(new GenericMessage(typeResolver.resolveOrThrow(r), r));
-            }
+            case Optional<?> optional when optional.isPresent() -> resolve(optional.get(),
+                                                                           typeResolver,
+                                                                           spreadIterables);
             case Optional<?> empty -> MessageStream.empty();
-            case Iterable<?> iterable -> MessageStream.fromStream(
+            case Iterable<?> iterable when spreadIterables -> MessageStream.fromStream(
                     StreamSupport.stream(iterable.spliterator(), false)
                                  .map(r -> new GenericMessage(typeResolver.resolveOrThrow(r), r))
             );
@@ -107,6 +143,11 @@ public class MessageStreamResolverUtils {
             );
             default -> MessageStream.just(new GenericMessage(typeResolver.resolveOrThrow(result), result));
         };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static MessageStream<Message> asMessageStream(MessageStream<?> stream) {
+        return (MessageStream<Message>) stream;
     }
 
     private MessageStreamResolverUtils() {

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/MethodInvokingMessageHandlingMember.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/MethodInvokingMessageHandlingMember.java
@@ -62,7 +62,10 @@ public class MethodInvokingMessageHandlingMember<T> implements MessageHandlingMe
      * @param messageType              the type of message that is expected by the target method
      * @param explicitPayloadType      the expected message payload type
      * @param parameterResolverFactory factory used to resolve method parameters
-     * @param returnTypeConverter      the return type converter to apply to the handling result
+     * @param returnTypeConverter      the return type converter to apply to the handling result. When it is a
+     *                                 {@link MessageStreamResolver}, the given {@code messageType} is passed along to
+     *                                 it, so that it can tell how many {@link Message Messages} this handler may
+     *                                 produce
      */
     public MethodInvokingMessageHandlingMember(Method method,
                                                Class<? extends Message> messageType,
@@ -71,7 +74,9 @@ public class MethodInvokingMessageHandlingMember<T> implements MessageHandlingMe
                                                Function<Object, MessageStream<?>> returnTypeConverter) {
         this.messageType = messageType;
         this.method = ReflectionUtils.ensureAccessible(method);
-        this.returnTypeConverter = returnTypeConverter;
+        this.returnTypeConverter = returnTypeConverter instanceof MessageStreamResolver resolver
+                ? result -> resolver.resolve(result, messageType)
+                : returnTypeConverter;
         Parameter[] parameters = method.getParameters();
         this.parameterCount = method.getParameterCount();
         parameterResolvers = new ParameterResolver[parameterCount];

--- a/messaging/src/test/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtilsTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/annotation/MessageStreamResolverUtilsTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core.annotation;
+
+import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.axonframework.messaging.core.annotation.MessageStreamResolverUtils.resolveToSingleStream;
+import static org.axonframework.messaging.core.annotation.MessageStreamResolverUtils.resolveToStream;
+
+/**
+ * Test class validating how {@link MessageStreamResolverUtils} maps a handler's return value onto a
+ * {@link MessageStream}, for handlers that may produce several results as well as for handlers that produce exactly
+ * one.
+ *
+ * @author Mitchell Herrijgers
+ */
+class MessageStreamResolverUtilsTest {
+
+    private static final List<String> ELEMENTS = List.of("first", "second", "third");
+
+    private final MessageTypeResolver typeResolver = new ClassBasedMessageTypeResolver();
+
+    @Nested
+    class SeveralResultsExpected {
+
+        @Test
+        void collectionIsSpreadOverOneMessagePerElement() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToStream(ELEMENTS, typeResolver));
+
+            // then
+            assertThat(payloads).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void collectionInsideFutureIsSpreadOverOneMessagePerElement() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToStream(completedFuture(ELEMENTS), typeResolver));
+
+            // then
+            assertThat(payloads).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void collectionInsideOptionalIsSpreadOverOneMessagePerElement() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToStream(Optional.of(ELEMENTS), typeResolver));
+
+            // then
+            assertThat(payloads).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void collectionInsideOptionalInsideFutureIsSpreadOverOneMessagePerElement() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToStream(completedFuture(Optional.of(ELEMENTS)), typeResolver));
+
+            // then
+            assertThat(payloads).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void streamIsSpreadOverOneMessagePerElement() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToStream(completedFuture(ELEMENTS.stream()), typeResolver));
+
+            // then
+            assertThat(payloads).isEqualTo(ELEMENTS);
+        }
+
+        @Test
+        void nonCollectionInsideFutureBecomesASingleMessage() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToStream(completedFuture("only"), typeResolver));
+
+            // then
+            assertThat(payloads).containsExactly("only");
+        }
+
+        @Test
+        void emptyResultsYieldNoMessages() {
+            // when / then
+            assertThat(payloadsOf(resolveToStream(null, typeResolver))).isEmpty();
+            assertThat(payloadsOf(resolveToStream(completedFuture(null), typeResolver))).isEmpty();
+            assertThat(payloadsOf(resolveToStream(Optional.empty(), typeResolver))).isEmpty();
+            assertThat(payloadsOf(resolveToStream(completedFuture(Optional.empty()), typeResolver))).isEmpty();
+            assertThat(payloadsOf(resolveToStream(List.of(), typeResolver))).isEmpty();
+        }
+    }
+
+    @Nested
+    class SingleResultExpected {
+
+        @Test
+        void collectionBecomesThePayloadOfASingleMessage() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToSingleStream(ELEMENTS, typeResolver));
+
+            // then
+            assertThat(payloads).containsExactly(ELEMENTS);
+        }
+
+        @Test
+        void collectionInsideFutureBecomesThePayloadOfASingleMessage() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToSingleStream(completedFuture(ELEMENTS), typeResolver));
+
+            // then
+            assertThat(payloads).containsExactly(ELEMENTS);
+        }
+
+        @Test
+        void collectionInsideOptionalBecomesThePayloadOfASingleMessage() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToSingleStream(Optional.of(ELEMENTS), typeResolver));
+
+            // then
+            assertThat(payloads).containsExactly(ELEMENTS);
+        }
+
+        @Test
+        void collectionInsideOptionalInsideFutureBecomesThePayloadOfASingleMessage() {
+            // when
+            List<Object> payloads =
+                    payloadsOf(resolveToSingleStream(completedFuture(Optional.of(ELEMENTS)), typeResolver));
+
+            // then
+            assertThat(payloads).containsExactly(ELEMENTS);
+        }
+
+        @Test
+        void nonCollectionInsideFutureBecomesASingleMessage() {
+            // when
+            List<Object> payloads = payloadsOf(resolveToSingleStream(completedFuture("only"), typeResolver));
+
+            // then
+            assertThat(payloads).containsExactly("only");
+        }
+
+        @Test
+        void emptyResultsYieldNoMessages() {
+            // when / then
+            assertThat(payloadsOf(resolveToSingleStream(null, typeResolver))).isEmpty();
+            assertThat(payloadsOf(resolveToSingleStream(completedFuture(null), typeResolver))).isEmpty();
+            assertThat(payloadsOf(resolveToSingleStream(Optional.empty(), typeResolver))).isEmpty();
+            assertThat(payloadsOf(resolveToSingleStream(completedFuture(Optional.empty()), typeResolver))).isEmpty();
+        }
+    }
+
+    private static <T> CompletableFuture<T> completedFuture(@Nullable T value) {
+        return CompletableFuture.completedFuture(value);
+    }
+
+    private static List<Object> payloadsOf(MessageStream<?> stream) {
+        return stream.<List<Object>>collect(ArrayList::new, (payloads, message) -> payloads.add(message.payload()))
+                     .orTimeout(5, TimeUnit.SECONDS)
+                     .join();
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/FutureAsResponseTypeToQueryHandlersTest.java
@@ -75,16 +75,14 @@ class FutureAsResponseTypeToQueryHandlersTest {
         queryBus.subscribe(queryHandlingComponent);
     }
 
-    @Disabled("TODO #3717")
     @Test
     void queryWithMultipleResponses() throws ExecutionException, InterruptedException {
         QueryMessage testQuery =
                 new GenericQueryMessage(new MessageType("myQueryWithMultipleResponses"), "criteria");
 
         List<String> result = queryBus.query(testQuery, null)
-                .first()
-                .asCompletableFuture()
-                .thenApply(e -> e.message().payloadAs(LIST_OF_STRINGS))
+                                      .collect(ArrayList<String>::new,
+                                               (list, message) -> list.add(message.payloadAs(String.class)))
                                       .get();
 
         assertEquals(asList("Response1", "Response2"), result);
@@ -113,14 +111,14 @@ class FutureAsResponseTypeToQueryHandlersTest {
                 new MessageType("myQueryWithMultipleResponses"), "criteria"
         );
 
-        Flux<List<String>> response = FluxUtils.of(queryBus.subscriptionQuery(testQuery, null, 50))
-                                               .map(MessageStream.Entry::message)
-                                               .mapNotNull(m -> m.payloadAs(
-                                                       LIST_OF_STRINGS, TestConverter.JACKSON.getConverter()
-                                               ));
+        Flux<String> response = FluxUtils.of(queryBus.subscriptionQuery(testQuery, null, 50))
+                                         .map(MessageStream.Entry::message)
+                                         .mapNotNull(m -> m.payloadAs(
+                                                 String.class, TestConverter.JACKSON.getConverter()
+                                         ));
         queryBus.completeSubscriptions(s -> true, null);
         StepVerifier.create(response)
-                    .expectNext(asList("Response1", "Response2"))
+                    .expectNext("Response1", "Response2")
                     .verifyComplete();
     }
 


### PR DESCRIPTION
When converting the return type of an annotated handler method to a MessageStream, the MethodInvokingMessageHandlingMember did not take the potential cardinality of the handler into account. Commands lead to a MessageStream.Single, and queries to a MessageStream.Many.

This caused a command returning a list of items to only return the first item. And, a CompletableFuture of a List of items for queries would just return 1 item holding the whole array.

| Handler returns | Caller | Before |
|---|---|---|
| `List<String>` | `sendAndWait(cmd, List.class)` | ❌ only `"first"` |
| `CompletableFuture<List<String>>` | `sendAndWait(cmd, List.class)` | ✅ full list | 
| `List<String>` | `queryMany(q, String.class)` | ✅ 3 elements | 
 |`CompletableFuture<List<String>>` | `queryMany(q, String.class)` | ❌ 1 element holding the whole JSON array |

This fix introduces the MessageStreamResolver. It does not replace the `HandlerDefinition.createHandler`'s `messageStreamResolver` as this would be a breaking change to this interface. However, a MessageStreamResolver is compatible due to its default method, and in the MethodInvokingMessageHandlingMember is unwrapped and the message type is passed into it to come to the original  `Function<Object, MessageStream<?>> messageStreamResolver` function. The result is the proper result conversion.

The behaviour is validated for all scenarios through the `HandlerReturnValueTest`.

In doing the above, this PR partially resolves issue #3717.