### PR TITLE
Fix SNAPSHOT publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ !matrix.sonar-enabled }}
         run: |
           ./mvnw -B -U -ntp -Dstyle.color=always clean verify \
-          -Possrh -Pintegration-test -Djacoco.skip=true -Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=5 \
+          -Pintegration-test -Djacoco.skip=true -Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=5 \
           -Dparallel=classes -DthreadCount=1 -DforkCount=2
       - name: Build with Coverage reports
         if: matrix.sonar-enabled
@@ -67,7 +67,7 @@ jobs:
       - name: Deploy to Sonatype
         if: success() && matrix.deploy-enabled
         run: |
-          ./mvnw -B -U -ntp -Dstyle.color=always -Possrh deploy -DskipTests=true
+          ./mvnw -B -U -ntp -Dstyle.color=always deploy -DskipTests=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAVEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_ID }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -41,14 +41,14 @@ jobs:
       - name: Regular Build
         if: ${{ !matrix.sonar-enabled }}
         run: |
-          ./mvnw -B -U -ntp -Dstyle.color=always -Possrh -Pintegration-test -Djacoco.skip=true clean verify \
+          ./mvnw -B -U -ntp -Dstyle.color=always -Pintegration-test -Djacoco.skip=true clean verify \
           -Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=5 \
           -Dparallel=classes -DthreadCount=1 -DforkCount=2
 
       - name: Build with Coverage reports
         if: matrix.sonar-enabled
         run: |
-          ./mvnw -B -U -ntp -Dstyle.color=always -Possrh -Dcoverage clean verify \
+          ./mvnw -B -U -ntp -Dstyle.color=always -Dcoverage clean verify \
           -Dsurefire.rerunFailingTestsCount=5 -Dfailsafe.rerunFailingTestsCount=5 \
           -Dparallel=classes -DthreadCount=1 -DforkCount=2
 

--- a/docs/_samples/pom.xml
+++ b/docs/_samples/pom.xml
@@ -151,17 +151,6 @@
 
     <build>
         <plugins>
-            <!-- The central-publishing-maven-plugin extension is loaded once for the whole reactor and injects a
-                 publish execution into every module regardless of maven.deploy.skip, so this module's own deployment
-                 must be disabled explicitly, or Central rejects it for missing the sources/javadoc jars skipped above. -->
-            <plugin>
-                <groupId>org.sonatype.central</groupId>
-                <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.11.0</version>
-                <configuration>
-                    <skipPublishing>true</skipPublishing>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -39,6 +39,13 @@
         to be stated here explicitly, managed centrally so example modules declare it version-free.
         -->
         <axoniq-platform-framework-client.version>5.2.1</axoniq-platform-framework-client.version>
+        <!--
+        Kept separate from ${revision}: that property is this reactor's own CI-friendly version and must
+        stay in sync with the parent's <version>. axoniq-framework-bom ships on its own release line, so
+        reusing ${revision} here let a Dependabot bump of this dependency overwrite the reactor's own
+        version instead.
+        -->
+        <axoniq-framework.version>5.3.0</axoniq-framework.version>
     </properties>
 
     <dependencyManagement>
@@ -48,7 +55,7 @@
             <dependency>
                 <groupId>io.axoniq.framework</groupId>
                 <artifactId>axoniq-framework-bom</artifactId>
-                <version>${revision}</version>
+                <version>${axoniq-framework.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     </organization>
 
     <properties>
-        <revision>5.3.0</revision>
+        <revision>5.4.0-SNAPSHOT</revision>
         <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -174,6 +174,12 @@
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
+                    <!-- axon-docs-samples never publishes javadoc/sources jars (see its pom), so Central rejects
+                         its bundle as incomplete. The plugin injects one publish execution per reactor build
+                         (first module wins), so this must be excluded here rather than on that module's own pom. -->
+                    <excludeArtifacts>
+                        <excludeArtifact>axon-docs-samples</excludeArtifact>
+                    </excludeArtifacts>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
This PR fixes the SNAPSHOT publishing flow of Axon Framework.
The predicament here was two fold:

1. Correctly place the skip flag of `axon-doc-samples`, by doing so in the main `pom.xml` i.o. in the plugin definition of `axon-doc-samples`
2. Correct the `revision` property to `5.4.0-SNAPSHOT`. This was accidentally updated by Dependabot, as the `revision` was used as the version in the `axon-examples` project to pull in the Axoniq Framework version. The Axoniq Framework version has now been decoupled by making it a separate property.

Added, I dropped an old flag that was still present in the `main` and `pullrequest` GHA, which was no longer used.