### PR TITLE
Add PostgreSQL known-issue link in Token Store section

### DIFF
--- a/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
@@ -25,7 +25,7 @@ When looking to provide a pull request, be sure to adjust link:https://github.co
 [TIP]
 .PostgreSQL Extension
 ====
-You can use Axoniq's PostgreSQL Extension instead of setting up PostgreSQL yourself as a event storage solution.For more information, please check the repository link:https://github.com/AxonIQ/extension-postgresql[here.]
+You can use Axoniq's PostgreSQL Extension instead of setting up PostgreSQL yourself as an event storage solution. For more information, please check the repository link:https://github.com/AxonIQ/extension-postgresql[here.]
 ====
 
 When storing the serialized formats of, for example, xref:events:event-processors/streaming.adoc#tracking_tokens[tokens], or xref:events:infrastructure.adoc[events], it is good to know Axon uses JPAs `@Lob` annotation for these columns.

--- a/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
+++ b/docs/reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc
@@ -19,12 +19,13 @@ You can make an enhancement request by clicking link:https://github.com/AxonFram
 When looking to provide a pull request, be sure to adjust link:https://github.com/AxonFramework/AxonFramework/blob/master/docs/old-reference-guide/modules/ROOT/pages/serialization.adochttps://github.com/AxonFramework/AxonFramework/blob/master/docs/old-reference-guide/modules/ROOT/pages/known-issues-and-workarounds.adoc[this file].
 ====
 
+[#postgresql_and_large_object_storage]
 == PostgreSQL and large object storage
 
 [TIP]
 .PostgreSQL Extension
 ====
-You can use Axoniq's PostgreSQL Extension instead of setting up PostgreSQL yourself as a event storage solution. For more information, please check the repository link:https://github.com/AxonIQ/extension-postgresql[here.]
+You can use Axoniq's PostgreSQL Extension instead of setting up PostgreSQL yourself as a event storage solution.For more information, please check the repository link:https://github.com/AxonIQ/extension-postgresql[here.]
 ====
 
 When storing the serialized formats of, for example, xref:events:event-processors/streaming.adoc#tracking_tokens[tokens], or xref:events:infrastructure.adoc[events], it is good to know Axon uses JPAs `@Lob` annotation for these columns.

--- a/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -483,6 +483,12 @@ This way, changes to the view model can be stored atomically with the changed to
 Furthermore, it guarantees **exactly once** processing semantics.
 ====
 
+[IMPORTANT]
+.Storing tokens in PostgreSQL
+====
+When you are using PostgreSQL to store your tracking tokens, we strongly recommend you read our known issues section on xref:ROOT:known-issues-and-workarounds.adoc#postgresql_and_large_object_storage[PostgreSQL and Large Object storage] to ensure you do not hit any production issue with this combination.
+====
+
 Note that you can configure the token store to use for a streaming processor in the `EventProcessingConfigurer`:
 
 [tabs]
@@ -523,7 +529,7 @@ include::example$events/eventprocessors/streaming/tokenstore/springboot/AxonConf
 --
 ====
 
-==== Retrieving the token store identifier
+==== **Retrieving the token store identifier**
 
 Implementations of `TokenStore` might share state in the underlying storage.
 To ensure correct operation, a token store has a unique identifier that uniquely identifies the storage location of the tokens in that store.


### PR DESCRIPTION
This pull request purely adds a link, containing in an `IMPORTANT` notice, in the [Token Store description section](https://docs.axoniq.io/axon-framework-reference/5.3/events/event-processors/streaming/#token_store), that links to the ["PostgreSQL and large object storage" section](https://docs.axoniq.io/axon-framework-reference/5.3/known-issues-and-workarounds/#_postgresql_and_large_object_storage).
This is done to provide an additional safety net to remind people that PostgreSQL's use of the OID in combination with how Axon Framework deals with Tracking Token updates introduces a large amount of "to be vacuumed" dead references, if a user doesn't want their production database to blow up (in production).