### PR TITLE
Add reporting of tags used for the append in the append exception

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AppendEventsTransactionRejectedException.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/AppendEventsTransactionRejectedException.java
@@ -17,41 +17,132 @@
 package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.common.AxonNonTransientException;
+import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.messaging.eventstreaming.Tag;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Exception indicating that a transaction was rejected due to conflicts detected in the events to append.
  *
  * @author Steven van Beelen
  * @author Allard Buijze
+ * @author John Hendrikx
  * @since 5.0.0
  */
 public class AppendEventsTransactionRejectedException extends AxonNonTransientException {
 
+    private final Set<Tag> tags;
+    private final @Nullable EventMessage conflictingEvent;
+
     /**
-     * Constructs an {@code AppendConditionAssertionException} with the given {@code message}.
+     * Constructs an {@code AppendEventsTransactionRejectedException} with the given {@code message}.
      *
-     * @param message The message of the {@code AppendConditionAssertionException} under construction.
+     * @param message the message of the {@code AppendEventsTransactionRejectedException} under construction
      */
     public AppendEventsTransactionRejectedException(String message) {
-        super(message);
+        this(message, Set.of(), null);
     }
 
     /**
-     * Constructs an {@code AppendConditionAssertionException} noting that the {@link EventStorageEngine} contains
-     * events matching the {@link AppendCondition#criteria() criteria} passed the given {@code consistencyMarker}.
+     * Constructs an {@code AppendEventsTransactionRejectedException} with the given {@code message}, noting the
+     * {@code tags} of the {@link AppendCondition#criteria() criteria} that were violated.
      *
-     * @param consistencyMarker The pointer in the {@link EventStorageEngine} after which no events should've been
-     *                          appended that match the {@link EventCriteria} of an {@link AppendCondition}.
-     * @return An {@code AppendConditionAssertionException} noting that the {@link EventStorageEngine} contains events
-     * matching the {@link AppendCondition#criteria() criteria} passed the given {@code consistencyMarker}.
+     * @param message the message of the {@code AppendEventsTransactionRejectedException} under construction
+     * @param tags    the {@link Tag Tags} of the {@link AppendCondition#criteria() criteria} that were checked when
+     *                the rejection occurred
+     */
+    public AppendEventsTransactionRejectedException(String message, Set<Tag> tags) {
+        this(message, tags, null);
+    }
+
+    private AppendEventsTransactionRejectedException(String message, Set<Tag> tags,
+                                                     @Nullable EventMessage conflictingEvent) {
+        super(message);
+
+        this.tags = Set.copyOf(tags);
+        this.conflictingEvent = conflictingEvent;
+    }
+
+    /**
+     * Constructs an {@code AppendEventsTransactionRejectedException} noting that the {@link EventStorageEngine}
+     * contains events matching the {@link AppendCondition#criteria() criteria} passed the given
+     * {@code consistencyMarker}.
+     *
+     * @param consistencyMarker the pointer in the {@link EventStorageEngine} after which no events should've been
+     *                          appended that match the {@link EventCriteria} of an {@link AppendCondition}
+     * @return an {@code AppendEventsTransactionRejectedException} noting that the {@link EventStorageEngine} contains
+     *     events matching the {@link AppendCondition#criteria() criteria} passed the given {@code consistencyMarker}
      */
     public static AppendEventsTransactionRejectedException conflictingEventsDetected(
             ConsistencyMarker consistencyMarker
     ) {
+        return conflictingEventsDetected(consistencyMarker, Set.of());
+    }
+
+    /**
+     * Constructs an {@code AppendEventsTransactionRejectedException} noting that the {@link EventStorageEngine}
+     * contains events matching the {@link AppendCondition#criteria() criteria} passed the given
+     * {@code consistencyMarker}.
+     *
+     * @param consistencyMarker the pointer in the {@link EventStorageEngine} after which no events should've been
+     *                          appended that match the {@link EventCriteria} of an {@link AppendCondition}
+     * @param tags              the {@link Tag Tags} of the {@link AppendCondition#criteria() criteria} that were
+     *                          checked when the rejection occurred
+     * @return an {@code AppendEventsTransactionRejectedException} noting that the {@link EventStorageEngine} contains
+     *     events matching the {@link AppendCondition#criteria() criteria} passed the given {@code consistencyMarker}
+     */
+    public static AppendEventsTransactionRejectedException conflictingEventsDetected(
+            ConsistencyMarker consistencyMarker, Set<Tag> tags
+    ) {
         return new AppendEventsTransactionRejectedException(
                 "Event matching append criteria have been detected beyond provided consistency marker: "
-                        + consistencyMarker
+                        + consistencyMarker,
+                tags
         );
+    }
+
+    /**
+     * The {@link Tag Tags} of the {@link AppendCondition#criteria() criteria} that were checked when this rejection
+     * occurred.
+     *
+     * @return the {@link Tag Tags} of the {@link AppendCondition#criteria() criteria} that were checked when this
+     *     rejection occurred, or an empty {@link Set} if unknown
+     */
+    public Set<Tag> tags() {
+        return tags;
+    }
+
+    /**
+     * The first event matching the {@link AppendCondition#criteria() criteria} found beyond the violated consistency
+     * marker, if looked up; empty otherwise.
+     *
+     * @return the first conflicting event, or empty if not looked up
+     */
+    public Optional<EventMessage> conflictingEvent() {
+        return Optional.ofNullable(conflictingEvent);
+    }
+
+    /**
+     * Returns a copy of {@code this AppendEventsTransactionRejectedException} with its {@link #conflictingEvent()}
+     * replaced by the given {@code conflictingEvent}, preserving the original message, {@link #tags()}, stack trace,
+     * and cause.
+     *
+     * @param conflictingEvent an event that conflicted with the {@link AppendCondition#criteria() criteria}, or
+     *                         {@code null} if none was found
+     * @return a copy of {@code this AppendEventsTransactionRejectedException} carrying the given
+     *     {@code conflictingEvent}
+     */
+    public AppendEventsTransactionRejectedException withConflictingEvent(@Nullable EventMessage conflictingEvent) {
+        AppendEventsTransactionRejectedException copy =
+                new AppendEventsTransactionRejectedException(getMessage(), tags, conflictingEvent);
+
+        copy.setStackTrace(getStackTrace());
+        copy.initCause(getCause());
+
+        return copy;
     }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConflictDiagnosingEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConflictDiagnosingEventStorageEngine.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
+import org.axonframework.messaging.eventstreaming.StreamingCondition;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Decorator for an {@link EventStorageEngine} that, upon an {@link AppendEventsTransactionRejectedException},
+ * identifies an event that caused the rejection.
+ * <p>
+ * It does so by sourcing the same {@link AppendCondition#criteria() criteria} used for the rejected append, starting
+ * from the violated {@link AppendCondition#consistencyMarker() consistency marker}, and taking the first event
+ * returned. Any event returned by that lookup matches the criteria beyond the marker, which is exactly what an append
+ * rejection reports - so the lookup always identifies a genuine conflicting event, regardless of how many criteria
+ * the condition combines, and without needing any storage-engine-specific knowledge of how the conflict was detected.
+ * Only the first match is fetched, closing the underlying read as soon as it is found, since a single example is
+ * enough to confirm and reproduce a conflict.
+ * <p>
+ * This lookup is an additional read against the wrapped {@code delegate}, performed only after a rejection has
+ * already occurred, so it does not add cost to the common, successful append path. It is not enabled by default;
+ * wrap an {@link EventStorageEngine} with this decorator to opt into it, for example while reproducing a specific
+ * issue.
+ * <p>
+ * All other operations are delegated to the wrapped engine unchanged.
+ *
+ * @author John Hendrikx
+ * @since 5.3.2
+ */
+@Internal
+public class ConflictDiagnosingEventStorageEngine implements EventStorageEngine {
+
+    private final EventStorageEngine delegate;
+
+    /**
+     * Constructs a {@code ConflictDiagnosingEventStorageEngine} wrapping the given {@code delegate}.
+     *
+     * @param delegate the {@link EventStorageEngine} to delegate to, and to source conflicting events from, cannot
+     *                 be {@code null}
+     */
+    public ConflictDiagnosingEventStorageEngine(EventStorageEngine delegate) {
+        this.delegate = Objects.requireNonNull(delegate, "The delegate parameter cannot be null.");
+    }
+
+    @Override
+    public CompletableFuture<AppendTransaction<?>> appendEvents(AppendCondition condition,
+                                                                 @Nullable ProcessingContext context,
+                                                                 List<TaggedEventMessage<?>> events) {
+        return delegate.appendEvents(condition, context, events)
+                       .exceptionallyCompose(failure -> diagnose(failure, condition, context))
+                       .thenApply(transaction -> wrap(transaction, condition, context));
+    }
+
+    private AppendTransaction<?> wrap(AppendTransaction<?> transaction, AppendCondition condition,
+                                       @Nullable ProcessingContext context) {
+        return wrapTyped(transaction, condition, context);
+    }
+
+    private <R> AppendTransaction<R> wrapTyped(AppendTransaction<R> transaction, AppendCondition condition,
+                                               @Nullable ProcessingContext context) {
+        return new DiagnosingAppendTransaction<>(transaction, condition, context);
+    }
+
+    /**
+     * Identifies an event that conflicted with the given {@code condition}, if the given {@code failure} is an
+     * {@link AppendEventsTransactionRejectedException}, and re-fails with an enriched copy of it.
+     * <p>
+     * Best-effort: if the diagnostic lookup itself fails, the original {@code rejection} is re-thrown unenriched
+     * rather than letting the lookup's failure mask it. Any other kind of {@code failure} is re-thrown unchanged.
+     *
+     * @param condition the {@link AppendCondition} of the rejected append, used to source the conflicting events
+     * @param context   the {@link ProcessingContext} active during the rejected append, may be {@code null}
+     * @param <T>       the value type of the returned, always-failed {@code CompletableFuture}
+     * @return a {@code CompletableFuture} that always completes exceptionally
+     */
+    private <T> CompletableFuture<T> diagnose(Throwable failure, AppendCondition condition,
+                                              @Nullable ProcessingContext context) {
+        if (!(failure instanceof AppendEventsTransactionRejectedException rejection)) {
+            return CompletableFuture.failedFuture(failure);
+        }
+
+        SourcingCondition sourcingCondition =
+                SourcingCondition.conditionFor(condition.consistencyMarker().position(), condition.criteria());
+
+        return delegate.source(sourcingCondition, context)
+                       .filter(entry -> !(entry.message() instanceof TerminalEventMessage))
+                       .first()
+                       .asCompletableFuture()
+                       .handle((entry, sourcingError) -> sourcingError == null
+                                ? rejection.withConflictingEvent(entry == null ? null : entry.message())
+                                : rejection)
+                       .thenCompose(enriched -> CompletableFuture.<T>failedFuture(enriched));
+    }
+
+    @Override
+    public MessageStream<EventMessage> source(SourcingCondition condition, @Nullable ProcessingContext context) {
+        return delegate.source(condition, context);
+    }
+
+    @Override
+    public MessageStream<EventMessage> stream(StreamingCondition condition) {
+        return delegate.stream(condition);
+    }
+
+    @Override
+    public CompletableFuture<TrackingToken> firstToken() {
+        return delegate.firstToken();
+    }
+
+    @Override
+    public CompletableFuture<TrackingToken> latestToken() {
+        return delegate.latestToken();
+    }
+
+    @Override
+    public CompletableFuture<TrackingToken> tokenAt(Instant at) {
+        return delegate.tokenAt(at);
+    }
+
+    @Override
+    public void describeTo(ComponentDescriptor descriptor) {
+        descriptor.describeWrapperOf(delegate);
+    }
+
+    private final class DiagnosingAppendTransaction<R> implements AppendTransaction<R> {
+
+        private final AppendTransaction<R> delegate;
+        private final AppendCondition condition;
+        private final ProcessingContext context;
+
+        private DiagnosingAppendTransaction(AppendTransaction<R> delegate, AppendCondition condition,
+                                             @Nullable ProcessingContext context) {
+            this.delegate = delegate;
+            this.condition = condition;
+            this.context = context;
+        }
+
+        @Override
+        public CompletableFuture<R> commit() {
+            return delegate.commit()
+                            .exceptionallyCompose(failure -> diagnose(failure, condition, context));
+        }
+
+        @Override
+        public void rollback() {
+            delegate.rollback();
+        }
+
+        @Override
+        public CompletableFuture<ConsistencyMarker> afterCommit(R commitResult) {
+            return delegate.afterCommit(commitResult);
+        }
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConflictDiagnosingEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/ConflictDiagnosingEventStorageEngine.java
@@ -37,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
  * It does so by sourcing the same {@link AppendCondition#criteria() criteria} used for the rejected append, starting
  * from the violated {@link AppendCondition#consistencyMarker() consistency marker}, and taking the first event
  * returned. Any event returned by that lookup matches the criteria beyond the marker, which is exactly what an append
- * rejection reports - so the lookup always identifies a genuine conflicting event, regardless of how many criteria
+ * rejection reports. The lookup always identifies a genuine conflicting event, regardless of how many criteria
  * the condition combines, and without needing any storage-engine-specific knowledge of how the conflict was detected.
  * Only the first match is fetched, closing the underlying read as soon as it is found, since a single example is
  * enough to confirm and reproduce a conflict.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -37,6 +37,7 @@ import org.axonframework.messaging.eventhandling.processing.streaming.token.Glob
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.axonframework.messaging.eventstreaming.EventsCondition;
 import org.axonframework.messaging.eventstreaming.StreamingCondition;
+import org.axonframework.messaging.eventstreaming.Tag;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,6 +58,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 
 import static org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException.conflictingEventsDetected;
 import static org.axonframework.messaging.core.MessageStreamUtils.NO_OP_CALLBACK;
@@ -116,7 +118,9 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
                                                                 List<TaggedEventMessage<?>> events) {
         if (containsConflicts(condition)) {
             // early failure, since we know conflicts already exist at insert-time
-            return CompletableFuture.failedFuture(conflictingEventsDetected(condition.consistencyMarker()));
+            return CompletableFuture.failedFuture(
+                    conflictingEventsDetected(condition.consistencyMarker(), tagsOf(condition))
+            );
         }
 
         return CompletableFuture.completedFuture(new AppendTransaction<ConsistencyMarker>() {
@@ -132,7 +136,9 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
                 appendLock.lock();
                 try {
                     if (containsConflicts(condition)) {
-                        return CompletableFuture.failedFuture(conflictingEventsDetected(condition.consistencyMarker()));
+                        return CompletableFuture.failedFuture(
+                                conflictingEventsDetected(condition.consistencyMarker(), tagsOf(condition))
+                        );
                     }
                     ConsistencyMarker newLatest =
                             events.stream()
@@ -185,6 +191,14 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
      */
     private boolean isVisible(long position) {
         return position <= lastVisiblePosition.get() && eventStorage.containsKey(position);
+    }
+
+    private static Set<Tag> tagsOf(AppendCondition condition) {
+        return condition.criteria()
+            .flatten()
+            .stream()
+            .flatMap(criterion -> criterion.tags().stream())
+            .collect(Collectors.toSet());
     }
 
     private boolean containsConflicts(AppendCondition condition) {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConflictDiagnosingEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/ConflictDiagnosingEventStorageEngineTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.eventsourcing.eventstore;
+
+import org.axonframework.eventsourcing.eventstore.EventStorageEngine.AppendTransaction;
+import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.EventTestUtils;
+import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.messaging.eventstreaming.Tag;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import static org.axonframework.common.FutureUtils.joinAndUnwrap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ConflictDiagnosingEventStorageEngineTest {
+
+    private static final Tag CONFLICTING_TAG = Tag.of("id", "42");
+
+    private final InMemoryEventStorageEngine delegate = new InMemoryEventStorageEngine();
+    private final ConflictDiagnosingEventStorageEngine testSubject = new ConflictDiagnosingEventStorageEngine(delegate);
+
+    @Test
+    void identifiesAConflictingEventWhenTheDelegateRejectsEagerlyDuringAppend() {
+        // given a pre-existing event carrying the tag the new append's criteria will be checked against
+        EventMessage conflictingEvent = appendUnconditionally(EventTestUtils.createEvent(0), CONFLICTING_TAG);
+
+        // when appending with a condition that conflicts with it right away
+        AppendCondition condition = AppendCondition.withCriteria(EventCriteria.havingTags(CONFLICTING_TAG));
+
+        // then
+        assertThatThrownBy(() -> joinAndUnwrap(
+                testSubject.appendEvents(condition, null,
+                                         List.of(new GenericTaggedEventMessage<>(EventTestUtils.createEvent(1), Set.of())))
+        )).isInstanceOf(AppendEventsTransactionRejectedException.class)
+          .satisfies(exception -> {
+              AppendEventsTransactionRejectedException rejection = (AppendEventsTransactionRejectedException) exception;
+              assertThat(rejection.tags()).contains(CONFLICTING_TAG);
+              assertThat(rejection.conflictingEvent())
+                      .map(EventMessage::identifier)
+                      .contains(conflictingEvent.identifier());
+          });
+    }
+
+    @Test
+    void identifiesAConflictingEventWhenTheDelegateRejectsLaterDuringCommit() {
+        // given an append that does not conflict yet when started
+        AppendCondition condition = AppendCondition.withCriteria(EventCriteria.havingTags(CONFLICTING_TAG));
+        AppendTransaction<?> transaction = joinAndUnwrap(
+                testSubject.appendEvents(condition, null,
+                                         List.of(new GenericTaggedEventMessage<>(EventTestUtils.createEvent(1), Set.of())))
+        );
+
+        // and a conflicting event appended and committed by someone else afterward
+        EventMessage conflictingEvent = appendUnconditionally(EventTestUtils.createEvent(0), CONFLICTING_TAG);
+
+        // when committing the original, now-conflicting, transaction
+        assertThatThrownBy(() -> joinAndUnwrap(transaction.commit()))
+                .isInstanceOf(AppendEventsTransactionRejectedException.class)
+                .satisfies(exception -> {
+                    AppendEventsTransactionRejectedException rejection = (AppendEventsTransactionRejectedException) exception;
+                    assertThat(rejection.tags()).contains(CONFLICTING_TAG);
+                    assertThat(rejection.conflictingEvent())
+                            .map(EventMessage::identifier)
+                            .contains(conflictingEvent.identifier());
+                });
+    }
+
+    private EventMessage appendUnconditionally(EventMessage event, Tag tag) {
+        AppendTransaction<?> transaction = joinAndUnwrap(
+                delegate.appendEvents(AppendCondition.none(), null,
+                                      List.of(new GenericTaggedEventMessage<>(event, Set.of(tag))))
+        );
+        Object commitResult = joinAndUnwrap(uncheckedCommit(transaction));
+        joinAndUnwrap(uncheckedAfterCommit(transaction, commitResult));
+        return event;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CompletableFuture<Object> uncheckedCommit(AppendTransaction<?> transaction) {
+        return ((AppendTransaction<Object>) transaction).commit();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CompletableFuture<ConsistencyMarker> uncheckedAfterCommit(AppendTransaction<?> transaction,
+                                                                              Object commitResult) {
+        return ((AppendTransaction<Object>) transaction).afterCommit(commitResult);
+    }
+}


### PR DESCRIPTION
Also adds a ConflictDiagnosingEventStorageEngine that can be used as a temporary decorator if you want to know exactly which event conflicted.

This should be backported to 5.3.2