### PR TITLE
[chore] Introduce spring-boot compatibility test matrix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
   directories:
     - "/"
     - "!/examples/university-java-springboot-4"
+    - "!/extensions/spring/spring-boot-compatibility-tests/spring-boot-4"
   schedule:
     interval: weekly
     day: "sunday"
@@ -50,6 +51,27 @@ updates:
 
 - package-ecosystem: maven
   directory: "/examples/university-java-springboot-4"
+  schedule:
+    interval: weekly
+    day: "sunday"
+  open-pull-requests-limit: 5
+  labels:
+    - "Type: Dependency Upgrade"
+    - "Priority 1: Must"
+  milestone: 138
+  groups:
+    maven-dependencies:
+      update-types:
+        - "patch"
+        - "minor"
+        - "major"
+
+# Excluded from the general "/" maven entry above (which ignores Spring Boot 4.x) so this Spring Boot 4
+# compatibility module's default version keeps getting bumped to new Spring Boot 4 patch/minor releases on
+# its own cadence. The spring-boot-compatibility CI workflow additionally tests other 4.x versions directly via
+# -Dspring.boot.version overrides in its matrix, independent of what this module's pom.xml defaults to.
+- package-ecosystem: maven
+  directory: "/extensions/spring/spring-boot-compatibility-tests/spring-boot-4"
   schedule:
     interval: weekly
     day: "sunday"

--- a/.github/workflows/spring-boot-compatibility.yml
+++ b/.github/workflows/spring-boot-compatibility.yml
@@ -1,0 +1,79 @@
+name: Spring Boot Compatibility Matrix
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'extensions/spring/**'
+      - '.github/workflows/spring-boot-compatibility.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: ${{ matrix.module }} @ Spring Boot ${{ matrix.version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: spring-boot-3
+            version: 3.5.16
+            allow-failure: false
+          - module: spring-boot-4
+            version: 4.0.8
+            allow-failure: false
+          # Spring Boot 4.1.0 shipped with a bug causing BeanCurrentlyInCreationException on
+          # applicationTaskExecutor whenever an app also has an Axon command/event/query handler
+          # (JpaBaseConfiguration#entityManagerFactoryBuilder() started resolving all
+          # AsyncTaskExecutor beans, racing Axon's own handler registration). Fixed upstream in
+          # Spring Boot 4.1.1 - this entry is intentionally kept, expected to permanently fail,
+          # as a regression witness proving this matrix would catch the bug's return.
+          - module: spring-boot-4
+            version: 4.1.0
+            allow-failure: true
+          - module: spring-boot-4
+            version: 4.1.1
+            allow-failure: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5.7.0
+        with:
+          distribution: 'zulu'
+          java-version: 21
+          cache: "maven"
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Build whole project (tests skipped)
+        run: |
+          ./mvnw -B -U -ntp -Pspring-boot-compatibility clean install -DskipTests \
+          -Dstyle.color=always
+
+      # No -am here: the previous step already installed the whole reactor (including
+      # axon-spring-boot-compatibility-tests-common) into the local repo, so this only needs to
+      # rebuild the one targeted module against the overridden Spring Boot version.
+      - name: Run ${{ matrix.module }} against Spring Boot ${{ matrix.version }}
+        continue-on-error: ${{ matrix.allow-failure }}
+        run: |
+          ./mvnw -B -ntp -Pspring-boot-compatibility verify \
+          -pl extensions/spring/spring-boot-compatibility-tests/${{ matrix.module }} \
+          -Dspring.boot.version=${{ matrix.version }} \
+          -Dstyle.color=always \
+          -Dsurefire.rerunFailingTestsCount=5
+
+      - name: Create test summary
+        uses: test-summary/action@v2
+        with:
+          paths: |
+            **/target/surefire-reports/TEST-*.xml
+          show: "fail, skip"
+        if: always() # This allows the build step to fail -- due to failing tests -- but still produce a test summary.

--- a/extensions/spring/spring-boot-compatibility-tests/common/pom.xml
+++ b/extensions/spring/spring-boot-compatibility-tests/common/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2026. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework.extensions.spring</groupId>
+        <artifactId>axon-spring-boot-compatibility-tests</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>axon-spring-boot-compatibility-tests-common</artifactId>
+
+    <name>Axon Extension - Spring - SpringBoot Compatibility Tests - Common</name>
+    <description>
+        Spring Boot version-agnostic application code (a minimal @SpringBootApplication plus a single command
+        handler) shared by every Spring Boot version module in this matrix. Only uses annotations and APIs that are
+        stable across the Spring Boot versions under test; the actual Spring Boot version used at compile time here
+        is irrelevant to consumers, which each pin their own version via their own dependencyManagement.
+    </description>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework.extensions.spring</groupId>
+            <artifactId>axon-spring-boot-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/spring/spring-boot-compatibility-tests/common/src/main/java/org/axonframework/extension/springboot/compatibility/CompatibilityTestApplication.java
+++ b/extensions/spring/spring-boot-compatibility-tests/common/src/main/java/org/axonframework/extension/springboot/compatibility/CompatibilityTestApplication.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.compatibility;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application relying entirely on the Axon Spring Boot starter's default auto-configuration
+ * (JPA event store, default JPA bootstrap mode) to start.
+ * <p>
+ * Shared, unmodified, across every Spring Boot version module in this matrix - only annotations and APIs that are
+ * stable across those versions are used here.
+ *
+ * @author Jakob Hatzl
+ * @since 5.4.0
+ */
+@SpringBootApplication
+public class CompatibilityTestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(CompatibilityTestApplication.class, args);
+    }
+}

--- a/extensions/spring/spring-boot-compatibility-tests/common/src/main/java/org/axonframework/extension/springboot/compatibility/PingHandler.java
+++ b/extensions/spring/spring-boot-compatibility-tests/common/src/main/java/org/axonframework/extension/springboot/compatibility/PingHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.compatibility;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * A single component-scanned command handler, present because virtually every real Axon application has one. Its
+ * presence is what makes the context-loads test in each Spring Boot version module exercise Axon's actual
+ * message-handling wiring (rather than only the JPA event store's auto-configuration in isolation), which is
+ * load-bearing for reproducing bean-creation-order-sensitive Spring Boot compatibility issues.
+ *
+ * @author Jakob Hatzl
+ * @since 5.4.0
+ */
+@Component
+public class PingHandler {
+
+    @CommandHandler
+    public String handle(String command) {
+        return "pong: " + command;
+    }
+}

--- a/extensions/spring/spring-boot-compatibility-tests/common/src/main/resources/application.yml
+++ b/extensions/spring/spring-boot-compatibility-tests/common/src/main/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:compat;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop

--- a/extensions/spring/spring-boot-compatibility-tests/pom.xml
+++ b/extensions/spring/spring-boot-compatibility-tests/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2026. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework.extensions.spring</groupId>
+        <artifactId>axon-spring-extension</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>axon-spring-boot-compatibility-tests</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Axon Extension - Spring - SpringBoot Compatibility Tests</name>
+    <description>
+        Regression suite that starts a minimal Spring Boot application using the Axon Spring Boot starter's default
+        auto-configuration (JPA event store, default JPA bootstrap mode) against a matrix of Spring Boot versions.
+        Not built as part of the default reactor - see the "spring-boot-compatibility" profile in the root pom.
+    </description>
+
+    <modules>
+        <module>common</module>
+        <module>spring-boot-3</module>
+        <module>spring-boot-4</module>
+    </modules>
+</project>

--- a/extensions/spring/spring-boot-compatibility-tests/spring-boot-3/pom.xml
+++ b/extensions/spring/spring-boot-compatibility-tests/spring-boot-3/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2026. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework.extensions.spring</groupId>
+        <artifactId>axon-spring-boot-compatibility-tests</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>axon-spring-boot-compatibility-tests-3</artifactId>
+
+    <name>Axon Extension - Spring - SpringBoot Compatibility Tests - Spring Boot 3</name>
+    <description>
+        Starts the shared compatibility test application against Spring Boot 3. Override the Spring Boot version tested
+        with
+        -Dspring.boot.version=X.Y.Z (any Spring Boot 3.x release: artifact IDs are stable within this major line).
+    </description>
+
+    <properties>
+        <spring.boot.version>3.5.16</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework.extensions.spring</groupId>
+            <artifactId>axon-spring-boot-compatibility-tests-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- explicitly re-declare, so this module's own BOM import wins version mediation over
+             axon-spring-boot-compatibility-tests-common's transitive version -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/spring/spring-boot-compatibility-tests/spring-boot-3/src/test/java/org/axonframework/extension/springboot/compatibility/ApplicationContextStartupTest.java
+++ b/extensions/spring/spring-boot-compatibility-tests/spring-boot-3/src/test/java/org/axonframework/extension/springboot/compatibility/ApplicationContextStartupTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.compatibility;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the {@link ApplicationContext} for {@link CompatibilityTestApplication} starts successfully with
+ * the Axon Spring Boot starter's default auto-configuration on this module's Spring Boot version.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class ApplicationContextStartupTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void applicationContextStartsSuccessfully() {
+        assertThat(applicationContext).isNotNull();
+    }
+}

--- a/extensions/spring/spring-boot-compatibility-tests/spring-boot-4/pom.xml
+++ b/extensions/spring/spring-boot-compatibility-tests/spring-boot-4/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2010-2026. Axon Framework
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.axonframework.extensions.spring</groupId>
+        <artifactId>axon-spring-boot-compatibility-tests</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>axon-spring-boot-compatibility-tests-4</artifactId>
+
+    <name>Axon Extension - Spring - SpringBoot Compatibility Tests - Spring Boot 4</name>
+    <description>
+        Starts the shared compatibility test application against Spring Boot 4. Override the
+        Spring Boot version tested with -Dspring.boot.version=X.Y.Z (any Spring Boot 4.x release: artifact IDs are
+        stable within this major line).
+    </description>
+
+    <properties>
+        <spring.boot.version>4.1.1</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.axonframework.extensions.spring</groupId>
+            <artifactId>axon-spring-boot-compatibility-tests-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- explicitly re-declare, so this module's own BOM import wins version mediation over
+             axon-spring-boot-compatibility-tests-common's transitive version -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/extensions/spring/spring-boot-compatibility-tests/spring-boot-4/src/test/java/org/axonframework/extension/springboot/compatibility/ApplicationContextStartupTest.java
+++ b/extensions/spring/spring-boot-compatibility-tests/spring-boot-4/src/test/java/org/axonframework/extension/springboot/compatibility/ApplicationContextStartupTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.compatibility;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the {@link ApplicationContext} for {@link CompatibilityTestApplication} starts successfully with
+ * the Axon Spring Boot starter's default auto-configuration on this module's Spring Boot version.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class ApplicationContextStartupTest {
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    void applicationContextStartsSuccessfully() {
+        assertThat(applicationContext).isNotNull();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,19 @@
         </profile>
 
         <profile>
+            <id>spring-boot-compatibility</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>spring-boot-compatibility</name>
+                </property>
+            </activation>
+            <modules>
+                <module>extensions/spring/spring-boot-compatibility-tests</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>javadoc</id>
             <build>
                 <plugins>


### PR DESCRIPTION
We currently have no regression coverage of `axon-spring-boot-starter`'s default auto-configuration against multiple Spring Boot versions. The framework's build pins to Spring Boot 3.5.x, so nothing exercises Spring Boot 4.x until an application hits a problem in production.

This gap is why #4974 was undetected: Spring Boot 4.1.0's `JpaBaseConfiguration#entityManagerFactoryBuilder()` change caused a `BeanCurrentlyInCreationException` on `applicationTaskExecutor` for any Axon application using the JPA event store with a command/event/query handler present, meaning virtually any real application using the JPA event store. It's fixed upstream in Spring Boot 4.1.1, but nothing in our own test suite would have shown the incompatibility.

This PR adds `extensions/spring/spring-boot-compatibility-tests`: a minimal Spring Boot application (one `@SpringBootApplication` plus a single command handler, shared via a `common` module) started against a matrix of Spring Boot versions, each in its own thin module (`spring-boot-3`, `spring-boot-4`) with the tested version overridable via `-Dspring.boot.version=X.Y.Z`. It's hidden behind a new `spring-boot-compatibility` Maven profile so it doesn't affect the default build, and only runs in CI via a dedicated workflow triggered on changes under `extensions/spring/**`.

The CI matrix covers Spring Boot 3.5.16, 4.0.8, and 4.1.1 (all required), plus 4.1.0 kept as a permanent regression witness for #4974  (`continue-on-error: true`, always expected to fail), proving this exact bug class would be caught again if it ever resurfaced.

a similar suite or extension to this existing suite might make sense on the Axoniq framework side