### PR TITLE
docs: correct the message-handler guide's link label

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ folders:
 - [
   `./identifier-generation-guide/`](identifier-generation-guide) : [Guide that covers several considerations with regard to identifier generation in Axon Framework-based applications.](https://docs.axoniq.io/identifier-generation-guide/latest)
 - [
-  `./message-handler-tunning-guide/`](message-handler-customization-guide) : [Guide that covers the message handler tuning in your Axon Framework applications.](https://docs.axoniq.io/message-handler-customization-guide/latest)
+  `./message-handler-customization-guide/`](message-handler-customization-guide) : [Guide that covers the message handler tuning in your Axon Framework applications.](https://docs.axoniq.io/message-handler-customization-guide/latest)
 - [
   `./meta-annotations-guide/`](meta-annotations-guide) : [Guide that covers several considerations with regard to creating Meta Annotations for Axon Framework-based applications.](https://docs.axoniq.io/meta-annotations-guide/latest)
 - [


### PR DESCRIPTION
`docs/README.md:15` labels the guide `\`./message-handler-tunning-guide/\`` while linking to `message-handler-customization-guide`.

Two things are off: `tunning` is misspelled, and more importantly the label names a directory that does not exist — the guide is `message-handler-customization-guide`, which is what the link target and the docs.axoniq.io URL on the same line both use.

Every sibling entry keeps label and target identical (`\`./identifier-generation-guide/\`](identifier-generation-guide)`, `\`./meta-annotations-guide/\`](meta-annotations-guide)`), so this one is the outlier. Corrected the label to match its target rather than only fixing the spelling.
