### PR TITLE
Document that the initial token is not a replay

### DIFF
--- a/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -314,6 +314,11 @@ Whenever this situation occurs, a Streaming Processor will construct an "initial
 Thus, the processor will begin at the start and handle every event present in the event source.
 This start position is configurable, as is described <<token_configuration,here>>.
 
+These events are handled as regular events, not as a replay.
+A processor starting for the first time has no previously built state to correct, so its first pass over the stream is a first pass rather than a repetition of one.
+Handlers therefore observe `ReplayStatus.REGULAR` throughout, handlers that opt out of replaying still handle this initial stream, and no replay-concluded notification is published.
+If you do want this initial catch-up flagged as a replay, for example because your handlers suppress side effects while replaying, configure the initial token to conclude its replay at the latest position instead, as shown in the xref:migration:paths/projectors-event-processors.adoc#initial-token-replay-status[migration guide].
+
 Conceptually, there are a couple of scenarios when a processor builds an initial token on application startup.
 The obvious one is already shared, namely when a processor starts for the first time.
 There are, however, also other situations when a token is built that might be unexpected, like:

--- a/docs/reference-guide/modules/migration/examples/migration/paths/projectorseventprocessors/initialtoken/ReplayingInitialTokenExample.java
+++ b/docs/reference-guide/modules/migration/examples/migration/paths/projectorseventprocessors/initialtoken/ReplayingInitialTokenExample.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package migration.paths.projectorseventprocessors.initialtoken;
+
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+
+// tag::replaying-initial-token[]
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.axonframework.messaging.eventhandling.processing.streaming.token.ReplayToken;
+
+public class ReplayingInitialTokenExample {
+
+    public void configure(MessagingConfigurer configurer) {
+        configurer.eventProcessing(
+                eventProcessing -> eventProcessing.pooledStreaming(
+                        pooledStreaming -> pooledStreaming.processor(
+                                "my-processor",
+                                module -> module.eventHandlingComponents(
+                                                         components -> components.autodetected(
+                                                                 "my-projector",
+                                                                 cfg -> new MyProjector()
+                                                         )
+                                                 )
+                                                 .customized((cfg, processorConfig) -> processorConfig.initialToken(
+                                                         eventSource -> eventSource.latestToken(null)
+                                                                                   .thenApply(ReplayToken::createReplayToken)
+                                                 ))
+                        )
+                )
+        );
+    }
+}
+// end::replaying-initial-token[]
+
+class MyProjector {
+
+    @EventHandler
+    public void on(MyEvent event) {
+        // ...
+    }
+}
+
+record MyEvent() {
+
+}

--- a/docs/reference-guide/modules/migration/pages/paths/projectors-event-processors.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/projectors-event-processors.adoc
@@ -130,6 +130,68 @@ axon:
 In your code, you can customize these settings by providing `EventProcessorSettings` beans or using the `EventProcessorSettings.MapWrapper`.
 
 
+[#initial-token-replay-status]
+== Initial token no longer marks the first pass as a replay
+
+A streaming processor that starts without a stored token builds an xref:events:event-processors/streaming.adoc#initial_token[initial token].
+Both versions default to starting at the beginning of the event stream, so a fresh processor handles the entire history in both.
+What changed is the `ReplayStatus` under which that history is handled.
+
+Axon Framework 4 wrapped the initial token in a `ReplayToken` that concluded at the head of the stream, marking the whole catch-up as a replay:
+
+[source,java,role=axon4]
+----
+// AF4, PooledStreamingEventProcessor.Builder default
+initialToken = messageSource -> ReplayToken.createReplayToken(messageSource.createHeadToken());
+----
+
+Axon Framework 5 concludes that replay at the first position of the stream instead, which means it is already concluded by the first event handled:
+
+[source,java]
+----
+// AF5, PooledStreamingEventProcessorConfiguration default
+initialToken = eventSource -> eventSource.firstToken(null)
+                                         .thenApply(ReplayToken::createReplayToken);
+----
+
+[cols="1,1,1"]
+|===
+| | Axon Framework 4 | Axon Framework 5
+
+| Start position of a fresh processor
+| Beginning of the stream
+| Beginning of the stream
+
+| `ReplayStatus` while catching up
+| `REPLAY` until the head at initialization
+| `REGULAR` for every event
+
+| Handlers that opt out of replays
+| Skip the initial catch-up
+| Handle the initial catch-up
+
+| Replay-concluded notification
+| Published when the head at initialization is reached
+| Not published, as there is no replay to conclude
+|===
+
+This is the expected behavior for a brand-new processor, not an oversight.
+A processor starting for the first time has no previously built state to correct, so its first pass over the stream is a first pass, not a repetition of one.
+Replay semantics exist to signal "you are seeing these events again", which does not apply here.
+
+=== Restoring the Axon Framework 4 behavior
+
+Configure the initial token explicitly if your handlers rely on `ReplayStatus.REPLAY` to suppress side effects while a fresh deployment catches up on an existing event store.
+Passing the latest position as the token to conclude at reproduces the Axon Framework 4 default:
+
+[source,java]
+----
+include::example$migration/paths/projectorseventprocessors/initialtoken/ReplayingInitialTokenExample.java[tag=replaying-initial-token,indent=0]
+----
+
+Note that the position to conclude at is resolved once, when the processor initializes its tokens, and is stored inside the token itself.
+Events appended after that moment are handled as regular, live events.
+
 == `QueryUpdateEmitter` as a parameter
 
 In Axon Framework 4, the `QueryUpdateEmitter` was often injected as a class-level field in projectors.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
@@ -68,9 +68,10 @@ import static org.axonframework.common.BuilderUtils.assertStrictPositive;
  * <ul>
  *     <li>The {@link ErrorHandler} is defaulted to a {@link PropagatingErrorHandler}.</li>
  *     <li>The {@code initialSegmentCount} defaults to {@code 16}.</li>
- *     <li>The {@code initialToken} function defaults to a {@link ReplayToken} that starts streaming
- *          from the {@link StreamableEventSource#latestToken(ProcessingContext) tail} with the replay flag enabled until the
- *          {@link StreamableEventSource#firstToken(ProcessingContext) head} at the moment of initialization is reached.</li>
+ *     <li>The {@code initialToken} function defaults to the
+ *          {@link StreamableEventSource#firstToken(ProcessingContext) first position} of the event stream, handling
+ *          every event the source holds as a regular event rather than as a replay. See
+ *          {@link #initialToken(Function)} for the reasoning and for how to replay the existing stream instead.</li>
  *     <li>The {@code tokenClaimInterval} defaults to {@code 5000} milliseconds.</li>
  *     <li>The {@link MaxSegmentProvider} (used by {@link PooledStreamingEventProcessor#maxCapacity()}) defaults to {@link MaxSegmentProvider#maxShort()}.</li>
  *     <li>The {@code claimExtensionThreshold} defaults to {@code 5000} milliseconds.</li>
@@ -291,11 +292,26 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      * Specifies the {@link Function} used to generate the initial {@link TrackingToken}s. The function will be given
      * the configured {@link StreamableEventSource} so that its methods can be invoked for token creation.
      * <p>
-     * Defaults to an automatic replay since the start of the stream.
+     * Defaults to the {@link StreamableEventSource#firstToken(ProcessingContext) first position} of the event stream,
+     * so a processor starting for the first time handles every event the source holds, beginning at the oldest one.
      * <p>
-     * More specifically, it defaults to a {@link ReplayToken} that starts streaming from the
-     * {@link StreamableEventSource#latestToken(ProcessingContext) tail} with the replay flag enabled until the
-     * {@link StreamableEventSource#firstToken(ProcessingContext) head} at the moment of initialization is reached.
+     * More specifically, it defaults to a {@link ReplayToken} whose
+     * {@link ReplayToken#getTokenAtReset() token at reset} is that same first position. The replay it describes is
+     * therefore concluded by the very first event handled, which means all events are handled in
+     * {@link org.axonframework.messaging.eventhandling.replay.ReplayStatus#REGULAR REGULAR} status. This is intended:
+     * the initial catch-up of a brand-new processor is not a replay, as there is no previously built state to correct.
+     * Handlers that opt out of replaying, like
+     * {@link org.axonframework.messaging.eventhandling.replay.ReplayBlockingEventHandlingComponent}, thus still handle
+     * this initial stream, and no {@link org.axonframework.messaging.eventhandling.replay.ReplayStatusChanged} is
+     * published for it.
+     * <p>
+     * If your handlers rely on {@link org.axonframework.messaging.eventhandling.replay.ReplayStatus#REPLAY REPLAY}
+     * status to suppress side effects while a fresh processor catches up on an existing event store, configure the
+     * latest position as the token at reset so the entire catch-up towards it is flagged as a replay:
+     * <pre>{@code
+     * configuration.initialToken(source -> source.latestToken(null)
+     *                                            .thenApply(ReplayToken::createReplayToken));
+     * }</pre>
      *
      * @param initialToken The {@link Function} generating the initial {@link TrackingToken} based on a given
      *                     {@link StreamableEventSource}.


### PR DESCRIPTION
In Axon Framework 5 a streaming processor starting without a stored token handles its initial catch-up under `ReplayStatus.REGULAR` rather than as a replay, unlike Axon Framework 4. This documents that behavior and the reasoning behind it across the `PooledStreamingEventProcessorConfiguration` Javadoc, the streaming event processors reference page, and the projectors migration guide. It adds a migration section with an AF4-vs-AF5 comparison table and a runnable `ReplayingInitialTokenExample` showing how to restore the AF4 replay behavior by concluding the replay at the latest position. No behavioral code changes are included beyond Javadoc updates.