### PR TITLE
 `SimpleQueryBus`  should wrap any subscription query update exception in `CompletableFuture`

### DIFF
--- a/docs/reference-guide/modules/configuration/examples/configuration/configuration-enhancer/TracingQueryBusDecorator.java
+++ b/docs/reference-guide/modules/configuration/examples/configuration/configuration-enhancer/TracingQueryBusDecorator.java
@@ -26,6 +26,7 @@ import org.axonframework.messaging.queryhandling.QueryResponseMessage;
 import org.axonframework.messaging.queryhandling.SubscriptionQueryUpdateMessage;
 import org.axonframework.messaging.tracing.Span;
 import org.axonframework.messaging.tracing.SpanFactory;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
@@ -42,49 +43,55 @@ class TracingQueryBusDecorator implements QueryBus {
         this.spanFactory = spanFactory;
     }
 
+    @NonNull
     @Override
-    public MessageStream<QueryResponseMessage> query(QueryMessage query, @Nullable ProcessingContext context) {
+    public MessageStream<QueryResponseMessage> query(@NonNull QueryMessage query, @Nullable ProcessingContext context) {
         Span span = spanFactory.createDispatchSpan(
                 "QueryBus.query " + query.type().qualifiedName().name(), query, context
         );
         return span.branchStream(context, ctx -> delegate.query(span.propagateContext(query), ctx));
     }
 
+    @NonNull
     @Override
-    public MessageStream<QueryResponseMessage> subscriptionQuery(QueryMessage query,
+    public MessageStream<QueryResponseMessage> subscriptionQuery(@NonNull QueryMessage query,
                                                                  @Nullable ProcessingContext context,
                                                                  int updateBufferSize) {
         return delegate.subscriptionQuery(query, context, updateBufferSize);
     }
 
+    @NonNull
     @Override
-    public MessageStream<SubscriptionQueryUpdateMessage> subscribeToUpdates(QueryMessage query,
+    public MessageStream<SubscriptionQueryUpdateMessage> subscribeToUpdates(@NonNull QueryMessage query,
                                                                             int updateBufferSize) {
         return delegate.subscribeToUpdates(query, updateBufferSize);
     }
 
+    @NonNull
     @Override
-    public CompletableFuture<Void> emitUpdate(Predicate<QueryMessage> filter,
-                                              Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
+    public CompletableFuture<Void> emitUpdate(@NonNull Predicate<QueryMessage> filter,
+                                              @NonNull Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
                                               @Nullable ProcessingContext context) {
         return delegate.emitUpdate(filter, updateSupplier, context);
     }
 
+    @NonNull
     @Override
-    public CompletableFuture<Void> completeSubscriptions(Predicate<QueryMessage> filter,
+    public CompletableFuture<Void> completeSubscriptions(@NonNull Predicate<QueryMessage> filter,
                                                          @Nullable ProcessingContext context) {
         return delegate.completeSubscriptions(filter, context);
     }
 
+    @NonNull
     @Override
-    public CompletableFuture<Void> completeSubscriptionsExceptionally(Predicate<QueryMessage> filter,
-                                                                      Throwable cause,
+    public CompletableFuture<Void> completeSubscriptionsExceptionally(@NonNull Predicate<QueryMessage> filter,
+                                                                      @NonNull Throwable cause,
                                                                       @Nullable ProcessingContext context) {
         return delegate.completeSubscriptionsExceptionally(filter, cause, context);
     }
 
     @Override
-    public QueryBus subscribe(QualifiedName name, QueryHandler queryHandler) {
+    public QueryBus subscribe(@NonNull QualifiedName name, @NonNull QueryHandler queryHandler) {
         delegate.subscribe(name, queryHandler);
         return this;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/QueryBus.java
@@ -126,15 +126,19 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * Emits the outcome of the {@code updateSupplier} to
      * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} matching the given
      * {@code queryName} and given {@code filter}.
+     * <p>
+     * Any exceptions that might occur as part of invoking the {@code updateSupplier} will result in this method
+     * returning an exceptional {@link CompletableFuture} carrying the {@code updateSupplier's} exception.
      *
      * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The {@code updateSupplier}
      *                       will only be sent to subscription queries matching this filter
      * @param updateSupplier the update supplier to emit for
      *                       {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription
      *                       queries} matching the given {@code filter}
-     * @param context        the processing context under which the updateSupplier is being emitted (can be
+     * @param context        the processing context under which the {@code updateSupplier} is being emitted (can be
      *                       {@code null})
-     * @return a future completing whenever the updateSupplier has been emitted
+     * @return a successful future completing whenever the {@code updateSupplier} has been emitted, or exceptional if
+     * the {@code updateSupplier} threw an exception
      */
     CompletableFuture<Void> emitUpdate(Predicate<QueryMessage> filter,
                                        Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
@@ -148,8 +152,11 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * <p>
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      * <p>
-     * A subscription query to which delivery of the update fails (for example due to a full update buffer) is
-     * excluded from this count, even though that failure still terminates the subscription.
+     * A subscription query to which delivery of the update fails (for example due to a full update buffer) is excluded
+     * from this count, even though that failure still terminates the subscription.
+     * <p>
+     * Any exceptions that might occur as part of invoking the {@code updateSupplier} will result in this method
+     * returning an exceptional {@link CompletableFuture} carrying the {@code updateSupplier's} exception.
      *
      * @param filter         a predicate filtering on {@link QueryMessage QueryMessages}. The {@code updateSupplier}
      *                       will only be sent to subscription queries matching this filter
@@ -158,8 +165,9 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      *                       queries} matching the given {@code filter}
      * @param context        the processing context under which the updateSupplier is being emitted (can be
      *                       {@code null})
-     * @return a future completing with the number of subscription queries the update was emitted to as an
-     * {@link OptionalInt}, which is empty when we couldn't match
+     * @return a successful future completing with the number of subscription queries the update was emitted to as an
+     * {@link OptionalInt}, which is empty when we couldn't match, or exceptional if the {@code updateSupplier} threw an
+     * exception
      */
     default CompletableFuture<OptionalInt> emitUpdateAndCount(Predicate<QueryMessage> filter,
                                                               Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
@@ -173,13 +181,16 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * <p>
      * To be used whenever there are no subsequent update to
      * {@link #emitUpdate(Predicate, Supplier, ProcessingContext) emit} left.
+     * <p>
+     * Any exceptions that might occur as part of invoking the {@code filter} will result in this method returning an
+     * exceptional {@link CompletableFuture} carrying the {@code filter's} exception.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed
      * @param context the processing context within which to complete subscription queries (can be {@code null})
-     * @return a future completing whenever all matching
+     * @return a successful future completing whenever all matching
      * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have been
-     * completed
+     * completed, or exceptional if the {@code filter} threw an exception
      */
     CompletableFuture<Void> completeSubscriptions(Predicate<QueryMessage> filter,
                                                   @Nullable ProcessingContext context);
@@ -191,12 +202,16 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      * <p>
      * A subscription query for which completion fails is excluded from this count.
+     * <p>
+     * Any exceptions that might occur as part of invoking the {@code filter} will result in this method returning an
+     * exceptional {@link CompletableFuture} carrying the {@code filter's} exception.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed
      * @param context the processing context within which to complete subscription queries (can be {@code null})
-     * @return a future completing with the number of subscription queries that were completed as an
-     * {@link OptionalInt}, which is empty when we couldn't match
+     * @return a successful future completing with the number of subscription queries that were completed as an
+     * {@link OptionalInt}, which is empty when we couldn't match, or exceptional if the {@code filter} threw an
+     * exception
      */
     default CompletableFuture<OptionalInt> completeSubscriptionsAndCount(Predicate<QueryMessage> filter,
                                                                          @Nullable ProcessingContext context) {
@@ -209,15 +224,18 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * <p>
      * To be used whenever {@link #emitUpdate(Predicate, Supplier, ProcessingContext) emitting update} should be stopped
      * due to some exception.
+     * <p>
+     * Any exceptions that might occur as part of invoking the {@code filter} will result in this method returning an
+     * exceptional {@link CompletableFuture} carrying the {@code filter's} exception.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed exceptionally
      * @param cause   the cause of an error
      * @param context the processing context within which to complete subscription queries exceptionally (can be
      *                {@code null})
-     * @return a future completing whenever all matching
+     * @return a successful future completing whenever all matching
      * {@link QueryBus#subscriptionQuery(QueryMessage, ProcessingContext, int) subscription queries} have been completed
-     * exceptionally
+     * exceptionally, or exceptional if the {@code filter} threw an exception
      */
     CompletableFuture<Void> completeSubscriptionsExceptionally(Predicate<QueryMessage> filter,
                                                                Throwable cause,
@@ -231,14 +249,18 @@ public interface QueryBus extends QueryHandlerRegistry<QueryBus>, DescribableCom
      * Implementations that cannot determine this number return {@link OptionalInt#empty} instead.
      * <p>
      * A subscription query for which the exceptional completion fails to be delivered is excluded from this count.
+     * <p>
+     * Any exceptions that might occur as part of invoking the {@code filter} will result in this method returning an
+     * exceptional {@link CompletableFuture} carrying the {@code filter's} exception.
      *
      * @param filter  a predicate filtering on {@link QueryMessage QueryMessages}. Subscription queries matching this
      *                filter will be completed exceptionally
      * @param cause   the cause of an error
      * @param context the processing context within which to complete subscription queries exceptionally (can be
      *                {@code null})
-     * @return a future completing with the number of subscription queries that were completed exceptionally as an
-     * {@link OptionalInt}, which is empty when we couldn't match
+     * @return a successful future completing with the number of subscription queries that were completed exceptionally
+     * as an {@link OptionalInt}, which is empty when we couldn't match, or exceptional if the {@code filter} threw an
+     * exception
      */
     default CompletableFuture<OptionalInt> completeSubscriptionsExceptionallyAndCount(
             Predicate<QueryMessage> filter,

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
@@ -43,6 +43,8 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import static org.axonframework.common.FutureUtils.runFailing;
+
 /**
  * Implementation of the {@code QueryBus} that dispatches queries (through
  * {@link #query(QueryMessage, ProcessingContext)} or {@link #subscriptionQuery(QueryMessage, ProcessingContext, int)})
@@ -310,28 +312,28 @@ public class SimpleQueryBus implements QueryBus {
     }
 
     /**
-     * Runs the given {@code updateTask} immediately, or defers it until the given {@code context} commits,
-     * matching {@code updateTask}'s subscriptions to the given {@code filter}.
+     * Runs the given {@code updateTask} immediately, or defers it until the given {@code context} commits, matching
+     * {@code updateTask}'s subscriptions to the given {@code filter}.
      * <p>
-     * When run immediately, the returned count reflects the actual outcome of the {@code updateTask} - e.g. the
-     * number of subscribers an update was successfully delivered to, as opposed to the number of subscribers merely
-     * matching the {@code filter} before delivery was attempted.
+     * When run immediately, the returned count reflects the actual outcome of the {@code updateTask} - e.g. the number
+     * of subscribers an update was successfully delivered to, as opposed to the number of subscribers merely matching
+     * the {@code filter} before delivery was attempted.
      * <p>
-     * When deferred to after commit, the {@code updateTask} itself runs later and its outcome is not available to
-     * this method. In that case, the returned count is a match count against the given {@code filter}, computed at
-     * call time - not the outcome of the eventual {@code updateTask} run - since waiting for that outcome would
-     * require blocking until after the given {@code context} commits, which could deadlock a caller invoking this
-     * from within that same commit pipeline.
+     * When deferred to after commit, the {@code updateTask} itself runs later and its outcome is not available to this
+     * method. In that case, the returned count is a match count against the given {@code filter}, computed at call time
+     * - not the outcome of the eventual {@code updateTask} run - since waiting for that outcome would require blocking
+     * until after the given {@code context} commits, which could deadlock a caller invoking this from within that same
+     * commit pipeline.
      * <p>
-     * The match count is only computed when the {@code updateTask} will actually run (now or after commit) - not
-     * for an already-errored {@code context}, since the update is silently dropped in that case and the
-     * {@code filter} must not observe any side effects.
+     * The match count is only computed when the {@code updateTask} will actually run (now or after commit) - not for an
+     * already-errored {@code context}, since the update is silently dropped in that case and the {@code filter} must
+     * not observe any side effects.
      */
     private CompletableFuture<OptionalInt> runAfterCommitOrImmediately(@Nullable ProcessingContext context,
                                                                        Predicate<QueryMessage> filter,
                                                                        IntSupplier updateTask) {
         if (context == null || context.isCommitted()) {
-            return CompletableFuture.completedFuture(OptionalInt.of(updateTask.getAsInt()));
+            return runFailing(() -> CompletableFuture.completedFuture(OptionalInt.of(updateTask.getAsInt())));
         } else if (!context.isCompleted()) {
             int matchCount = matchCount(filter);
             context.computeResourceIfAbsent(
@@ -342,7 +344,16 @@ public class SimpleQueryBus implements QueryBus {
                                return subscriptionQueryTasks;
                            }
                    )
-                   .add(updateTask::getAsInt);
+                   .add(() -> runFailing(
+                                () -> CompletableFuture.completedFuture(OptionalInt.of(updateTask.getAsInt()))
+                        ).whenComplete((result, exception) -> {
+                            if (exception != null) {
+                                logger.warn(
+                                        "An error occurred while delivering a deferred subscription query update.",
+                                        exception);
+                            }
+                        })
+                   );
             return CompletableFuture.completedFuture(OptionalInt.of(matchCount));
         }
         // else: context completed with error - drop the update

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -15,6 +15,7 @@
  */
 package org.axonframework.messaging.queryhandling;
 
+import org.axonframework.common.FutureUtils;
 import org.axonframework.common.infra.MockComponentDescriptor;
 import org.axonframework.common.util.MockException;
 import org.axonframework.messaging.core.FluxUtils;
@@ -53,6 +54,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.*;
@@ -746,6 +748,55 @@ class SimpleQueryBusTest {
                                                 .orElseThrow();
             // then only the subscription with buffer room actually received the update...
             assertThat(deliveredCount).isEqualTo(1);
+        }
+
+        @Test
+        void emitUpdateWithThrowingUpdateSupplierAndNoProcessingContextCompletesFutureExceptionallyInsteadOfThrowing() {
+            // given...
+            QueryMessage testQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            testSubject.subscriptionQuery(testQuery, null, Queues.SMALL_BUFFER_SIZE);
+            MockException expected = new MockException("Mock");
+            Supplier<SubscriptionQueryUpdateMessage> throwingSupplier = () -> {
+                throw expected;
+            };
+            // when - the call itself must not throw, the failure must surface through the returned future...
+            CompletableFuture<Void> result = testSubject.emitUpdate(query -> true, throwingSupplier, null);
+            // then...
+            assertThat(result).isCompletedExceptionally();
+            assertThatThrownBy(() -> FutureUtils.joinAndUnwrap(result, Duration.ofSeconds(1)))
+                    .isSameAs(expected);
+        }
+
+        @Test
+        void emitUpdateWithThrowingUpdateSupplierDeferredToAfterCommitDoesNotBlockOtherDeferredUpdates() {
+            // given...
+            QueryMessage failingQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            QueryMessage succeedingQuery = new GenericQueryMessage(QUERY_TYPE, QUERY_PAYLOAD);
+            testSubject.subscribe(QUERY_NAME, (query, context) -> MessageStream.empty().cast());
+            MessageStream<QueryResponseMessage> succeedingResponses =
+                    testSubject.subscriptionQuery(succeedingQuery, null, Queues.SMALL_BUFFER_SIZE);
+            testSubject.subscriptionQuery(failingQuery, null, Queues.SMALL_BUFFER_SIZE);
+            SubscriptionQueryUpdateMessage updateMessage =
+                    new GenericSubscriptionQueryUpdateMessage(UPDATE_PAYLOAD_TYPE, UPDATE_PAYLOAD);
+            Supplier<SubscriptionQueryUpdateMessage> throwingSupplier = () -> {
+                throw new MockException("Mock");
+            };
+            UnitOfWork uow = UnitOfWorkTestUtils.aUnitOfWork();
+            // when both updates are staged for after-commit, the first one bound to throw on delivery...
+            uow.onInvocation(context -> {
+                testSubject.emitUpdate(query -> query.identifier().equals(failingQuery.identifier()),
+                                       throwingSupplier,
+                                       context);
+                return testSubject.emitUpdate(query -> query.identifier().equals(succeedingQuery.identifier()),
+                                              () -> updateMessage,
+                                              context);
+            });
+            // then the UnitOfWork still commits normally, despite the deferred task throwing...
+            assertThatCode(() -> uow.execute().join()).doesNotThrowAnyException();
+            // and the unrelated, second deferred update was still delivered...
+            StepVerifier.create(FluxUtils.of(succeedingResponses).map(MessageStream.Entry::message))
+                        .expectNextMatches(response -> Objects.equals(response.payload(), UPDATE_PAYLOAD))
+                        .verifyTimeout(Duration.ofMillis(100));
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/tracing/TracingQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/tracing/TracingQueryBusTest.java
@@ -35,6 +35,7 @@ import org.axonframework.messaging.queryhandling.QueryMessage;
 import org.axonframework.messaging.queryhandling.QueryResponseMessage;
 import org.axonframework.messaging.queryhandling.SimpleQueryBus;
 import org.axonframework.messaging.queryhandling.SubscriptionQueryUpdateMessage;
+import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -305,52 +306,59 @@ class TracingQueryBusTest {
         private CompletableFuture<Void> completeResult = CompletableFuture.completedFuture(null);
         private CompletableFuture<Void> completeExceptionallyResult = CompletableFuture.completedFuture(null);
 
+        @NonNull
         @Override
-        public MessageStream<QueryResponseMessage> query(QueryMessage query, @Nullable ProcessingContext context) {
+        public MessageStream<QueryResponseMessage> query(@NonNull QueryMessage query, @Nullable ProcessingContext context) {
             return queryResult;
         }
 
+        @NonNull
         @Override
-        public MessageStream<QueryResponseMessage> subscriptionQuery(QueryMessage query,
+        public MessageStream<QueryResponseMessage> subscriptionQuery(@NonNull QueryMessage query,
                                                                      @Nullable ProcessingContext context,
                                                                      int updateBufferSize) {
             return subscriptionQueryResult;
         }
 
+        @NonNull
         @Override
-        public MessageStream<SubscriptionQueryUpdateMessage> subscribeToUpdates(QueryMessage query,
+        public MessageStream<SubscriptionQueryUpdateMessage> subscribeToUpdates(@NonNull QueryMessage query,
                                                                                 int updateBufferSize) {
             return MessageStream.empty().cast();
         }
 
+        @NonNull
         @Override
-        public CompletableFuture<Void> emitUpdate(Predicate<QueryMessage> filter,
-                                                  Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
+        public CompletableFuture<Void> emitUpdate(@NonNull Predicate<QueryMessage> filter,
+                                                  @NonNull Supplier<SubscriptionQueryUpdateMessage> updateSupplier,
                                                   @Nullable ProcessingContext context) {
             return emitResult;
         }
 
+        @NonNull
         @Override
-        public CompletableFuture<Void> completeSubscriptions(Predicate<QueryMessage> filter,
+        public CompletableFuture<Void> completeSubscriptions(@NonNull Predicate<QueryMessage> filter,
                                                              @Nullable ProcessingContext context) {
             return completeResult;
         }
 
+        @NonNull
         @Override
-        public CompletableFuture<Void> completeSubscriptionsExceptionally(Predicate<QueryMessage> filter,
-                                                                          Throwable cause,
+        public CompletableFuture<Void> completeSubscriptionsExceptionally(@NonNull Predicate<QueryMessage> filter,
+                                                                          @NonNull Throwable cause,
                                                                           @Nullable ProcessingContext context) {
             return completeExceptionallyResult;
         }
 
+        @NonNull
         @Override
-        public QueryBus subscribe(QualifiedName queryName, QueryHandler queryHandler) {
+        public QueryBus subscribe(@NonNull QualifiedName queryName, @NonNull QueryHandler queryHandler) {
             subscribedHandler.set(queryHandler);
             return this;
         }
 
         @Override
-        public void describeTo(ComponentDescriptor descriptor) {
+        public void describeTo(@NonNull ComponentDescriptor descriptor) {
             // not relevant
         }
     }
@@ -360,32 +368,32 @@ class TracingQueryBusTest {
         private @Nullable Object wrapped;
 
         @Override
-        public void describeWrapperOf(Object delegate) {
+        public void describeWrapperOf(@NonNull Object delegate) {
             this.wrapped = delegate;
         }
 
         @Override
-        public void describeProperty(String name, @Nullable Object object) {
+        public void describeProperty(@NonNull String name, @Nullable Object object) {
         }
 
         @Override
-        public void describeProperty(String name, @Nullable Collection<?> collection) {
+        public void describeProperty(@NonNull String name, @Nullable Collection<?> collection) {
         }
 
         @Override
-        public void describeProperty(String name, @Nullable Map<?, ?> map) {
+        public void describeProperty(@NonNull String name, @Nullable Map<?, ?> map) {
         }
 
         @Override
-        public void describeProperty(String name, @Nullable String value) {
+        public void describeProperty(@NonNull String name, @Nullable String value) {
         }
 
         @Override
-        public void describeProperty(String name, @Nullable Long value) {
+        public void describeProperty(@NonNull String name, @Nullable Long value) {
         }
 
         @Override
-        public void describeProperty(String name, @Nullable Boolean value) {
+        public void describeProperty(@NonNull String name, @Nullable Boolean value) {
         }
     }
 }


### PR DESCRIPTION
This PR ensures that **any** update task on the `SimpleQueryBus` results in a `CompletableFuture`, even it it throw an exception right away.
It does so by invoking the update task in `FutureUtils#runFailing`.