### PR TITLE
Make MessageStream completion status self-sufficient

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AbstractMessageStream.java
@@ -496,7 +496,90 @@ public abstract class AbstractMessageStream<M extends Message> implements Messag
 
     @Override
     public final synchronized boolean isCompleted() {
+        if (!completed && peekedEntry == null) {
+
+            /*
+             * The completed flag is set by a read that observes a terminal result, so it does not yet cover a
+             * stream whose source is exhausted but has not been read past. terminalState() covers that without
+             * a fetch, keeping this check free of side effects and independent of composition depth.
+             */
+
+            switch (terminalState()) {
+                case FetchResult.Completed() -> markTerminal(null);
+                case FetchResult.Error(Throwable throwable) -> markTerminal(throwable);
+                case FetchResult.Value(Entry<M> ignored) -> throw new IllegalStateException(
+                        "terminalState() returned a Value; it must never hand out entries.");
+                case FetchResult.NotReady() -> {
+                    // Not determinable without reading, so the stream stays open.
+                }
+            }
+        }
+
         return completed;
+    }
+
+    /**
+     * Determines, <b>without consuming from its source</b>, whether no further {@link Entry entries} will arrive.
+     * <p>
+     * A source-backed stream determines this from state it already holds: an iterator with no next element, a buffer
+     * that was sealed and drained, a future that resolved and was handed out. A composed stream determines it from
+     * the stream it wraps, for which {@link #terminalStateOf(MessageStream)} is provided.
+     * <p>
+     * Implementations must be cheap and free of side effects. In particular, they must not consume, buffer, or
+     * otherwise advance the source, and must not complete or close the stream: returning the terminal result is how
+     * termination is reported, exactly as in {@link #fetchNext()}.
+     * <p>
+     * The default implementation returns {@link FetchResult.NotReady}, leaving completion to be observed by a read.
+     *
+     * @return {@link FetchResult.Completed} or {@link FetchResult.Error} when this stream is terminal,
+     * {@link FetchResult.NotReady} when that cannot be determined without reading; never {@link FetchResult.Value}
+     */
+    protected FetchResult<Entry<M>> terminalState() {
+        return FetchResult.notReady();
+    }
+
+    /**
+     * Returns the terminal state of the given {@code delegate}, for a composed stream to return from its own
+     * {@link #terminalState()}.
+     *
+     * @param delegate the stream to report the terminal state of
+     * @param <T>      the entry type of the returned result
+     * @return the terminal state the given {@code delegate} reports, or {@link FetchResult.NotReady} when it is not
+     * terminal
+     */
+    protected static <T extends Entry<?>> FetchResult<T> terminalStateOf(MessageStream<?> delegate) {
+        if (!delegate.isCompleted()) {
+            return FetchResult.notReady();
+        }
+
+        return delegate.error()
+                       .<FetchResult<T>>map(FetchResult::error)
+                       .orElseGet(FetchResult::completed);
+    }
+
+    /**
+     * Records that this stream reached its terminal state, as observed by {@link #isCompleted()}. Callers must hold
+     * this stream's lock.
+     * <p>
+     * The notification recorded by {@link #complete()} is not flushed here, since the consumer reading the completion
+     * status receives it as the return value. It is flushed by the next consumer-side call.
+     *
+     * @param error the failure this stream completed with, or {@code null} when it completed normally
+     */
+    private void markTerminal(@Nullable Throwable error) {
+
+        /*
+         * Reaching a terminal state here counts as the interaction that initializes the stream, which is otherwise
+         * done by the first read.
+         */
+
+        this.initialized = true;
+
+        if (error == null) {
+            complete();
+        } else {
+            completeExceptionally(error);
+        }
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/core/CloseCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/CloseCallbackMessageStream.java
@@ -82,6 +82,11 @@ public class CloseCallbackMessageStream<M extends Message> extends AbstractMessa
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        return terminalStateOf(delegate);
+    }
+
+    @Override
     protected void onCompleted() {
         try {
             delegate.close();

--- a/messaging/src/main/java/org/axonframework/messaging/core/CompletionCallbackMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/CompletionCallbackMessageStream.java
@@ -58,6 +58,11 @@ class CompletionCallbackMessageStream<M extends Message> extends AbstractMessage
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        return terminalStateOf(delegate);
+    }
+
+    @Override
     protected void onCompleted() {
         delegate.close();
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/ConcatenatingMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/ConcatenatingMessageStream.java
@@ -95,6 +95,14 @@ class ConcatenatingMessageStream<M extends Message> extends AbstractMessageStrea
         return FetchResult.completed();
     }
 
+    @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        FetchResult<Entry<M>> state = terminalStateOf(active);
+
+        // With streams left to concatenate, only a failure ends this stream; exhaustion switches to the next.
+        return streams.isEmpty() || state instanceof FetchResult.Error ? state : FetchResult.notReady();
+    }
+
     private boolean switchStream() {
         if (active != null) {
             active.setCallback(() -> {

--- a/messaging/src/main/java/org/axonframework/messaging/core/FilteringMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/FilteringMessageStream.java
@@ -70,6 +70,11 @@ class FilteringMessageStream<M extends Message> extends AbstractMessageStream<M>
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        return terminalStateOf(delegate);
+    }
+
+    @Override
     protected final void onCompleted() {
         delegate.close();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/FlatMappedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/FlatMappedMessageStream.java
@@ -96,6 +96,11 @@ class FlatMappedMessageStream<M extends Message, N extends Message> extends Abst
     }
 
     @Override
+    protected FetchResult<Entry<N>> terminalState() {
+        return inner == null ? terminalStateOf(outer) : FetchResult.notReady();
+    }
+
+    @Override
     protected void onCompleted() {
         if (inner != null) {
             inner.close();

--- a/messaging/src/main/java/org/axonframework/messaging/core/FluxMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/FluxMessageStream.java
@@ -77,6 +77,17 @@ class FluxMessageStream<M extends Message> extends AbstractMessageStream<M> {
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        FetchResult<Entry<M>> head = peeked.peek();
+
+        if (head instanceof FetchResult.Error) {
+            return head;
+        }
+
+        return head == null && sealed.get() ? FetchResult.completed() : FetchResult.notReady();
+    }
+
+    @Override
     protected final void onCompleted() {
         seal();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/IgnoredEntriesMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/IgnoredEntriesMessageStream.java
@@ -74,6 +74,11 @@ class IgnoredEntriesMessageStream<M extends Message> extends AbstractMessageStre
     }
 
     @Override
+    protected FetchResult<Entry<Message>> terminalState() {
+        return terminalStateOf(delegate);
+    }
+
+    @Override
     protected void onCompleted() {
         delegate.close();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/IteratorMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/IteratorMessageStream.java
@@ -47,6 +47,11 @@ class IteratorMessageStream<M extends Message> extends AbstractMessageStream<M> 
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        return source.hasNext() ? FetchResult.notReady() : FetchResult.completed();
+    }
+
+    @Override
     protected final void onCompleted() {
         this.source = List.<Entry<M>>of().iterator();
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/MapMultiMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MapMultiMessageStream.java
@@ -99,6 +99,11 @@ class MapMultiMessageStream<M extends Message, N extends Message> extends Abstra
     }
 
     @Override
+    protected FetchResult<Entry<N>> terminalState() {
+        return buffer.isEmpty() ? terminalStateOf(delegate) : FetchResult.notReady();
+    }
+
+    @Override
     protected void onCompleted() {
         delegate.close();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageStream.java
@@ -378,6 +378,10 @@ public interface MessageStream<M extends Message> {
      * Indicates whether this stream has been completed. A completed stream will never return {@link Entry entries} from
      * {@link #next()}, and {@link #hasNextAvailable()} will always return {@code false}. If the stream completed with
      * an error, {@link #error()} will report so.
+     * <p>
+     * Returns {@code true} as soon as the stream determines that no further {@link Entry entries} will arrive,
+     * including directly after {@link #next()} returned the last one. Returns {@code false} while an {@link Entry} is
+     * available for reading, and for as long as the outcome cannot be determined without consuming entries.
      *
      * @return {@code true} if the stream completed, otherwise {@code false}.
      */

--- a/messaging/src/main/java/org/axonframework/messaging/core/OnErrorContinueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/OnErrorContinueMessageStream.java
@@ -67,6 +67,14 @@ class OnErrorContinueMessageStream<M extends Message> extends AbstractMessageStr
         return FetchResult.completed();
     }
 
+    @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        FetchResult<Entry<M>> state = terminalStateOf(current);
+
+        // An error on the current stream is not terminal while a continuation is still to be taken.
+        return !switchedToContinuation && state instanceof FetchResult.Error ? FetchResult.notReady() : state;
+    }
+
     private boolean switchToContinuation() {
         switchedToContinuation = true;
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/QueueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/QueueMessageStream.java
@@ -187,6 +187,19 @@ public class QueueMessageStream<M extends Message> extends AbstractMessageStream
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        if (!queue.isEmpty()) {
+            return FetchResult.notReady();
+        }
+
+        return switch (state.get()) {
+            case State(boolean sealed, Throwable error) when sealed && error == null -> FetchResult.completed();
+            case State(boolean sealed, Throwable error) when sealed -> FetchResult.error(error);
+            default -> FetchResult.notReady();
+        };
+    }
+
+    @Override
     protected final void onCompleted() {
         queue.clear();
         seal();

--- a/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/SingleValueMessageStream.java
@@ -91,6 +91,19 @@ class SingleValueMessageStream<M extends Message> extends AbstractMessageStream<
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        if (!source.isDone()) {
+            return FetchResult.notReady();
+        }
+
+        if (source.isCompletedExceptionally()) {
+            return FetchResult.error(source.exceptionNow());
+        }
+
+        return read.get() ? FetchResult.completed() : FetchResult.notReady();
+    }
+
+    @Override
     protected final void onCompleted() {
         if (!source.isDone()) {
             source.cancel(false);

--- a/messaging/src/main/java/org/axonframework/messaging/core/TruncateFirstMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/TruncateFirstMessageStream.java
@@ -63,6 +63,11 @@ class TruncateFirstMessageStream<M extends Message>
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        return consumed ? FetchResult.completed() : terminalStateOf(delegate);
+    }
+
+    @Override
     protected void onCompleted() {
         delegate.close();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/tracing/SpanScopedMessageStream.java
+++ b/messaging/src/main/java/org/axonframework/messaging/tracing/SpanScopedMessageStream.java
@@ -71,6 +71,11 @@ final class SpanScopedMessageStream<M extends Message> extends AbstractMessageSt
     }
 
     @Override
+    protected FetchResult<Entry<M>> terminalState() {
+        return terminalStateOf(delegate);
+    }
+
+    @Override
     protected void onCompleted() {
         delegate.close();
     }

--- a/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/AbstractMessageStreamTest.java
@@ -51,6 +51,8 @@ class AbstractMessageStreamTest {
 
         private RuntimeException thrownExceptionInOnCompleted;
         private int onCompletedCount;
+        private int fetchNextCount;
+        private FetchResult<Entry<Message>> terminalState = FetchResult.notReady();
 
         void enqueue(FetchResult<Entry<Message>> result) {
             results.add(result);
@@ -68,9 +70,24 @@ class AbstractMessageStreamTest {
             thrownExceptionInOnCompleted = e;
         }
 
+        void reportTerminalState(FetchResult<Entry<Message>> terminalState) {
+            this.terminalState = terminalState;
+        }
+
+        int fetchNextCount() {
+            return fetchNextCount;
+        }
+
+        @Override
+        protected FetchResult<Entry<Message>> terminalState() {
+            return terminalState;
+        }
+
         @NonNull
         @Override
         protected FetchResult<Entry<Message>> fetchNext() {
+            fetchNextCount++;
+
             FetchResult<Entry<Message>> result = results.poll();
 
             return result != null ? result : FetchResult.notReady();
@@ -755,6 +772,126 @@ class AbstractMessageStreamTest {
 
             thread.setDaemon(true);
             thread.start();
+        }
+    }
+
+    @Nested
+    class WhenCompletionStatusRequested {
+
+        ControllableStream stream = new ControllableStream();
+
+        @Test
+        void withTerminalStateCompletedThenReportsCompleted() {
+            // given: a source that knows it is exhausted, without anything having read from it
+            stream.reportTerminalState(FetchResult.completed());
+
+            // when / then
+            assertThat(stream.isCompleted()).isTrue();
+            assertThat(stream.error()).isEmpty();
+        }
+
+        @Test
+        void withTerminalStateErrorThenReportsTheError() {
+            // given
+            RuntimeException failure = new RuntimeException("source failed");
+
+            stream.reportTerminalState(FetchResult.error(failure));
+
+            // when / then
+            assertThat(stream.isCompleted()).isTrue();
+            assertThat(stream.error()).contains(failure);
+        }
+
+        @Test
+        void withTerminalStateNotReadyThenStaysOpen() {
+            assertThat(stream.isCompleted()).isFalse();
+            assertThat(stream.error()).isEmpty();
+        }
+
+        @Test
+        void withTerminalStateValueThenThrowsIllegalStateException() {
+            // given: reporting an entry as a terminal state is a programming error, entries come from fetchNext
+            stream.reportTerminalState(FetchResult.of(entryOf("msg")));
+
+            // when / then
+            assertThatThrownBy(() -> stream.isCompleted()).isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        void thenRunsTheOnCompletedHookExactlyOnce() {
+            // given: resources are released on the transition, wherever the transition is observed
+            stream.reportTerminalState(FetchResult.completed());
+
+            // when
+            stream.isCompleted();
+            stream.isCompleted();
+
+            // then
+            assertThat(stream.onCompletedCount()).isEqualTo(1);
+        }
+
+        @Test
+        void thenDoesNotReadFromTheSource() {
+            // given: a status check must not consume, buffer, or otherwise advance the source
+            stream.enqueue(FetchResult.of(entryOf("msg")));
+
+            // when
+            stream.isCompleted();
+
+            // then
+            assertThat(stream.fetchNextCount()).isZero();
+            assertThat(stream.next()).isPresent();
+        }
+
+        @Test
+        void withEntryAvailableThenStaysOpenWithoutConsumingIt() {
+            // given: an entry was read ahead and is waiting to be handed out
+            Entry<Message> entry = entryOf("msg");
+
+            stream.enqueue(FetchResult.of(entry));
+            stream.peek();
+
+            // when: the source says it has nothing left, but the buffered entry is still owed to the consumer
+            stream.reportTerminalState(FetchResult.completed());
+
+            // then
+            assertThat(stream.isCompleted()).isFalse();
+            assertThat(stream.next()).contains(entry);
+        }
+
+        @Test
+        void thenDoesNotInvokeTheCallback() {
+            // given: the consumer asking for the status is the one the callback would notify
+            AtomicInteger callbackCount = new AtomicInteger();
+
+            stream.setCallback(callbackCount::incrementAndGet);
+            stream.reportTerminalState(FetchResult.completed());
+
+            callbackCount.set(0);
+
+            // when
+            assertThat(stream.isCompleted()).isTrue();
+
+            // then
+            assertThat(callbackCount).hasValue(0);
+        }
+
+        @Test
+        void thenStillNotifiesAConsumerThatGoesOnReading() {
+            // given: the notification recorded by the transition is owed until the consumer interacts again
+            AtomicInteger callbackCount = new AtomicInteger();
+
+            stream.setCallback(callbackCount::incrementAndGet);
+            stream.reportTerminalState(FetchResult.completed());
+
+            callbackCount.set(0);
+
+            // when
+            stream.isCompleted();
+            stream.next();
+
+            // then
+            assertThat(callbackCount).hasValue(1);
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/DelayedMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/DelayedMessageStreamTest.java
@@ -223,9 +223,11 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message> {
             future.complete(MessageStream.just(createRandomMessage()));
 
             assertTrue(testSubject.next().isPresent());
-            assertFalse(testSubject.isCompleted());  // streams never complete on non-empty next() as more data could be available
-            assertFalse(testSubject.hasNextAvailable());  // perform action that must determine presence of next element
-            assertTrue(testSubject.isCompleted());  // completes as it was proven there is no next element
+
+            // the resolved stream handed out its single value, so it is completed
+            assertTrue(testSubject.isCompleted());
+            assertFalse(testSubject.hasNextAvailable());
+            assertTrue(testSubject.isCompleted());
         }
     }
 
@@ -383,9 +385,11 @@ class DelayedMessageStreamTest extends MessageStreamTest<Message> {
             future.complete(MessageStream.just(createRandomMessage()));
 
             assertTrue(testSubject.next().isPresent());
-            assertFalse(testSubject.isCompleted());  // streams never complete on non-empty next() as more data could be available
-            assertFalse(testSubject.hasNextAvailable());  // perform action that must determine presence of next element
-            assertTrue(testSubject.isCompleted());  // completes as it was proven there is no next element
+
+            // the resolved stream handed out its single value, so it is completed
+            assertTrue(testSubject.isCompleted());
+            assertFalse(testSubject.hasNextAvailable());
+            assertTrue(testSubject.isCompleted());
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/IteratorMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/IteratorMessageStreamTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.*;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * Test class validating the {@link IteratorMessageStream} through the {@link MessageStreamTest} suite.
  *
@@ -57,5 +59,44 @@ class IteratorMessageStreamTest extends MessageStreamTest<Message> {
     protected Message createRandomMessage() {
         return new GenericMessage(new MessageType("message"),
                                     "test-" + ThreadLocalRandom.current().nextInt(10000));
+    }
+
+    @Nested
+    class WhenCompletionStatusRequested {
+
+        @Test
+        void withAnEmptySourceThenReportsCompletedWithoutBeingRead() {
+            // given
+            MessageStream<Message> testSubject = MessageStream.fromIterable(List.of());
+
+            // when / then
+            assertThat(testSubject.isCompleted()).isTrue();
+        }
+
+        @Test
+        void withTheLastEntryHandedOutThenReportsCompletedWithoutBeingReadAgain() {
+            // given
+            Message message = createRandomMessage();
+            MessageStream<Message> testSubject = MessageStream.fromIterable(List.of(message));
+
+            // when
+            assertThat(testSubject.next()).isPresent();
+
+            // then
+            assertThat(testSubject.isCompleted()).isTrue();
+        }
+
+        @Test
+        void withEntriesLeftThenStaysOpen() {
+            // given
+            MessageStream<Message> testSubject =
+                    MessageStream.fromIterable(List.of(createRandomMessage(), createRandomMessage()));
+
+            // when
+            assertThat(testSubject.next()).isPresent();
+
+            // then
+            assertThat(testSubject.isCompleted()).isFalse();
+        }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/QueueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/QueueMessageStreamTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -152,11 +153,77 @@ class QueueMessageStreamTest extends MessageStreamTest<EventMessage> {
         assertFalse(testSubject.offer(msg3, Context.empty()));
 
         assertThat(testSubject.next()).map(Entry::message).contains(msg2);
-        assertFalse(testSubject.isCompleted());  // not yet completed, because haven't gone past end yet
 
-        assertThat(testSubject.hasNextAvailable()).isFalse();
-        assertTrue(testSubject.isCompleted());  // completed as next element was attempted to be accessed
-
+        // sealed and drained, so the stream is completed
         assertTrue(testSubject.isCompleted());
+        assertFalse(testSubject.hasNextAvailable());
+        assertTrue(testSubject.isCompleted());
+    }
+
+    @Nested
+    class WhenSealedWhileTheConsumerIsWaiting {
+
+        /*
+         * Sealing is the producer's only signal that the stream ended: it fires the callback once and never
+         * again. A consumer whose idle path does not read from the stream therefore has that one invocation
+         * to observe the end, and short-circuit evaluation is enough to skip a read.
+         */
+
+        @Test
+        void thenAConsumerThatOnlyChecksTheStatusObservesTheEnd() {
+            // given: a consumer woken by the seal, whose guard short-circuits before it reads
+            QueueMessageStream<EventMessage> testSubject = new QueueMessageStream<>();
+            AtomicBoolean observedEnd = new AtomicBoolean();
+
+            testSubject.setCallback(() -> {
+                if (testSubject.isCompleted() && !testSubject.hasNextAvailable()) {
+                    observedEnd.set(true);
+                }
+            });
+
+            // when: the producer ends the stream, which is the last signal the consumer receives
+            testSubject.seal();
+
+            // then
+            assertTrue(observedEnd.get());
+        }
+
+        @Test
+        void thenAConsumerThatDrainsFirstObservesTheEnd() {
+            // given: the same consumer, with entries left to hand out before the end
+            QueueMessageStream<EventMessage> testSubject = new QueueMessageStream<>();
+            EventMessage message = createRandomMessage();
+            AtomicBoolean observedEnd = new AtomicBoolean();
+
+            testSubject.offer(message, Context.empty());
+            testSubject.setCallback(() -> {
+                while (testSubject.hasNextAvailable()) {
+                    testSubject.next();
+                }
+                if (testSubject.isCompleted()) {
+                    observedEnd.set(true);
+                }
+            });
+
+            // when
+            testSubject.seal();
+
+            // then
+            assertTrue(observedEnd.get());
+        }
+
+        @Test
+        void thenASealedExceptionallyStreamReportsItsErrorWithoutBeingRead() {
+            // given
+            QueueMessageStream<EventMessage> testSubject = new QueueMessageStream<>();
+            RuntimeException failure = new RuntimeException("producer failed");
+
+            // when
+            testSubject.sealExceptionally(failure);
+
+            // then
+            assertTrue(testSubject.isCompleted());
+            assertThat(testSubject.error()).contains(failure);
+        }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/SingleValueMessageStreamTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/SingleValueMessageStreamTest.java
@@ -193,14 +193,12 @@ class SingleValueMessageStreamTest extends MessageStreamTest<Message> {
             assertThat(ms.hasNextAvailable()).isTrue();
             assertThat(ms.peek()).isNotEmpty();
             assertThat(ms.next()).isNotEmpty();
+        }
 
-            /*
-             * Expect that the stream has not completed at this point. Streams
-             * should never complete before returning their last element, even
-             * if they know it was the last element.
-             */
-
-            assertThat(ms.isCompleted()).isFalse();
+        @Test
+        void ensureStreamCompletesOnceTheSingleValueWasHandedOut() {
+            // the source resolved and its value was handed out, so the stream is completed
+            assertThat(ms.isCompleted()).isTrue();
         }
 
         @Test

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -177,8 +177,10 @@ class SimpleQueryBusTest {
             Optional<MessageStream.Entry<QueryResponseMessage>> nextResponse = result.next();
             assertThat(nextResponse).isPresent();
             assertThat(nextResponse.get().message().payload()).isEqualTo("query1234");
-            assertThat(result.isCompleted()).isFalse();  // not yet fully consumed, so not completed
-            assertThat(result.hasNextAvailable()).isFalse();  // results in full consumption
+
+            // the single response was handed out, so the stream is completed
+            assertThat(result.isCompleted()).isTrue();
+            assertThat(result.hasNextAvailable()).isFalse();
             assertThat(result.isCompleted()).isTrue();
         }
 


### PR DESCRIPTION
## Problem

`MessageStream#isCompleted()` only advanced as a side effect of reading. The `completed` flag was set from `nextInternal()` when `fetchNext()` reported a terminal result, so a stream that was exhausted at its source kept reporting `false` until a read happened to notice:

| | `isCompleted()` on `main` |
|---|---|
| `MessageStream.fromIterable(List.of())` | `false` |
| `MessageStream.fromItems(a)` after `next()` returned `a` | `false` |
| `MessageStream.just(a)` after `next()` returned `a` | `false` |

The requirement to read before trusting the status was never documented. Its only record was a changelog line and an inline comment in `ConcatenatingMessageStream`.

## Why it matters

Consumers that drain in a loop are unaffected: the loop's exit condition is itself the refreshing call, so the status is accurate immediately after.

```java
while (stream.hasNextAvailable()) { handle(stream.next()); }
if (stream.isCompleted()) { cleanup(); }   // correct today
```

Consumers whose idle path does not read are affected. A producer's completion signal fires the callback once and never again, so a guard that short-circuits past the read misses the end of the stream permanently:

```java
stream.setCallback(() -> {
    if (stream.isCompleted() && !stream.hasNextAvailable()) { finish(); }   // never finishes
});
stream.seal();
```

```java
    if (!stream.hasNextAvailable() && stream.isCompleted()) { finish(); }   // finishes
```

Two logically equivalent predicates, one of which hangs, with nothing in the contract to say which. `QueueMessageStreamTest` now covers both.

The same shape produced a spurious empty entry between two concatenated streams in #4355, fixed at the time by inserting a defensive read plus a comment. Two live sites remain where the status is asked once, before anything reads: `TracingQueryBus#respondScoped` and its subscription-query counterpart open a span for an already-finished handler result, contradicting their own javadoc. Nothing leaks, but the trace claims asynchronous response production that did not happen.

## Approach

The obvious fix is to have `isCompleted()` drive `fetchNext()`. Measured against a chain of `filter()` layers over a live source, that costs a full pass over the composition per call, and degrades `next()` too, because every wrapper reads its delegate and then asks its status:

| chain depth | source fetches per `next()` |
|---|---|
| | `main` / this PR / `isCompleted()` drives `fetchNext()` |
| 0 | 1 / 1 / 1 |
| 2 | 1 / 1 / 4 |
| 4 | 1 / 1 / 16 |
| 8 | 1 / 1 / 256 |

Instead, ask each stream what it already knows. `AbstractMessageStream#terminalState()` reports, without consuming, whether no further entries will arrive:

```java
// IteratorMessageStream
return source.hasNext() ? FetchResult.notReady() : FetchResult.completed();

// QueueMessageStream
if (!queue.isEmpty()) { return FetchResult.notReady(); }
return switch (state.get()) {
    case State(boolean sealed, Throwable error) when sealed && error == null -> FetchResult.completed();
    case State(boolean sealed, Throwable error) when sealed                  -> FetchResult.error(error);
    default -> FetchResult.notReady();
};
```

`SingleValueMessageStream` uses `source.isDone() && read.get()`, `FluxMessageStream` uses its buffer and sealed flag. Composed streams answer by asking the stream they wrap, through a `terminalStateOf(delegate)` helper. Returning a `FetchResult` rather than a boolean matters for sources that are terminal with an error: a boolean would report a failed stream as completed with an empty `error()`.

Observing the terminal state runs the regular completion transition, so `onCompleted()` still fires and resources are still released rather than the flag and the lifecycle drifting apart. The default implementation returns `NotReady`, leaving any stream that does not override it exactly as it behaves today.

## Notes for review

No callback is flushed when the status is observed this way. The consumer asking is the one the callback would notify, and it receives the answer as the return value; the notification stays recorded so a consumer that goes on reading is still told. This keeps `isCompleted()` a query rather than something that can re-enter the caller.

Streams that genuinely cannot tell keep reporting `false`, and this PR does not change that: `concat(exhausted, exhausted)` would have to switch streams to find out, and `fromItems(a, b).filter(e -> false)` would have to drain. Both are side effects a status check should not have. `DelayedMessageStream` likewise cannot know before its future resolves.

Six existing assertions spelled out the old behaviour and were rewritten, for example `"not yet completed, because haven't gone past end yet"` in `QueueMessageStreamTest` and `"streams never complete on non-empty next()"` in `DelayedMessageStreamTest`.

Full reactor is green, including Spring, Kotlin, Reactor, metrics, migration and integration tests.

## Why the wrappers are included

A smaller variant is possible: override `terminalState()` on the four source streams only and leave every wrapper untouched. That is 6 files and 142 lines instead of 16 and 198. It was measured rather than assumed, on a source holding one entry that had already been handed out:

| wrapper | `isCompleted()` with roots-only |
|---|---|
| none | `true` |
| `.map(...)` | `true` |
| `.onNext(...)` | `true` |
| `.filter(...)` | `false` |
| `.onComplete(...)` | `false` |
| `.concatWith(...)` | `false` |

The split follows the class hierarchy rather than anything a caller can see. `.map()` and `.onNext()` return `DelegatingMessageStream` subclasses, whose `isCompleted()` already forwards to the delegate, so they inherit the fix for free. The rest extend `AbstractMessageStream` and own the `completed` flag that only advances on a read.

Shipping that would make the documented guarantee hold for some operators and not others, which is harder to explain than the current uniform behaviour. Five of the ten wrapper overrides are the same one-line pass-through; the other five encode semantics nothing generic could derive, such as concatenation treating exhaustion as a switch rather than an end, and `onErrorContinue` treating a delegate error as non-terminal while a continuation is pending.
