### PR TITLE
Expand `UpdateChecker` logic

### DIFF
--- a/update/src/main/java/org/axonframework/update/UpdateChecker.java
+++ b/update/src/main/java/org/axonframework/update/UpdateChecker.java
@@ -25,6 +25,8 @@ import org.axonframework.update.configuration.UsagePropertyProvider;
 import org.axonframework.update.detection.AxonVersionDetector;
 import org.axonframework.update.detection.KotlinVersion;
 import org.axonframework.update.detection.MachineId;
+import org.axonframework.update.detection.MachineUserName;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +68,7 @@ public class UpdateChecker implements Runnable {
     private boolean firstRequest = true;
     private final AtomicBoolean started = new AtomicBoolean(false);
     private int errorRetryBackoffFactor = 1;
+    @Nullable
     private DelayedTask delayedTask;
 
     /**
@@ -168,6 +171,7 @@ public class UpdateChecker implements Runnable {
 
         return new UpdateCheckRequest(
                 machineId.get(),
+                MachineUserName.get(),
                 installationId,
                 osName,
                 osVersion,

--- a/update/src/main/java/org/axonframework/update/UpdateCheckerHttpClient.java
+++ b/update/src/main/java/org/axonframework/update/UpdateCheckerHttpClient.java
@@ -81,6 +81,7 @@ public class UpdateCheckerHttpClient {
                     .timeout(Duration.ofSeconds(10))
                     .headers("User-Agent", updateCheckRequest.toUserAgent())
                     .headers("X-Machine-Id", updateCheckRequest.machineId())
+                    .headers("X-Machine-User-Name", updateCheckRequest.machineUserName())
                     .headers("X-Instance-Id", updateCheckRequest.instanceId())
                     .headers("X-Uptime", String.valueOf(ManagementFactory.getRuntimeMXBean().getUptime()))
                     .headers("X-First-Run", firstRequest ? "true" : "false")

--- a/update/src/main/java/org/axonframework/update/api/UpdateCheckRequest.java
+++ b/update/src/main/java/org/axonframework/update/api/UpdateCheckRequest.java
@@ -26,24 +26,26 @@ import java.util.List;
  * Represents an UpdateChecker request, including machine and instance identifiers, operating system details, JVM
  * information, Kotlin version, and a list of library versions.
  *
- * @param machineId  The unique identifier for the machine. This is a UUID that is generated and stored in the user's
- *                   home directory.
- * @param instanceId The unique identifier for the instance of the application. This is a UUID that is generated for
- *                   each JVM instance.
- * @param osName     The name of the operating system (e.g., "Linux", "Windows").
- * @param osVersion  The version of the operating system (e.g., "6.11.0-26-generic").
- * @param osArch     The architecture of the operating system (e.g., "amd64", "x86_64").
- * @param jvmVersion The version of the Java Virtual Machine (JVM) (e.g., "17.0.2").
- * @param jvmVendor  The vendor of the JVM (e.g., "AdoptOpenJDK", "Oracle").
- * @param kotlinVersion The version of Kotlin used in the application, or "none" if Kotlin is not used.
- * @param libraries  A list of library versions used in the application, each represented by a {@link Artifact}
- *                   object containing the group ID, artifact ID, and version of the library.
+ * @param machineId       the unique identifier for the machine. This is a UUID that is generated and stored in the
+ *                        user's home directory
+ * @param machineUserName the name of the operating system user account running the JVM
+ * @param instanceId      the unique identifier for the instance of the application. This is a UUID that is
+ *                        generated for each JVM instance
+ * @param osName          the name of the operating system (e.g., "Linux", "Windows")
+ * @param osVersion       the version of the operating system (e.g., "6.11.0-26-generic")
+ * @param osArch          the architecture of the operating system (e.g., "amd64", "x86_64")
+ * @param jvmVersion      the version of the Java Virtual Machine (JVM) (e.g., "17.0.2")
+ * @param jvmVendor       the vendor of the JVM (e.g., "AdoptOpenJDK", "Oracle")
+ * @param kotlinVersion   the version of Kotlin used in the application, or "none" if Kotlin is not used
+ * @param libraries       a list of library versions used in the application, each represented by a {@link Artifact}
+ *                        object containing the group ID, artifact ID, and version of the library
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
 @Internal
 public record UpdateCheckRequest(
         String machineId,
+        String machineUserName,
         String instanceId,
         String osName,
         String osVersion,
@@ -53,11 +55,12 @@ public record UpdateCheckRequest(
         String kotlinVersion,
         List<Artifact> libraries
 ) {
+
     /**
-     * Converts the usage request into a query string format suitable for HTTP requests.
-     * All values are properly URL encoded.
+     * Converts the usage request into a query string format suitable for HTTP requests. All values are properly URL
+     * encoded.
      *
-     * @return The query string representation of the usage request.
+     * @return the query string representation of the usage request
      */
     public String toQueryString() {
         StringBuilder sb = new StringBuilder();
@@ -65,7 +68,9 @@ public record UpdateCheckRequest(
           .append("&java=").append(encode(jvmVersion + "; " + jvmVendor))
           .append("&kotlin=").append(encode(kotlinVersion));
         for (Artifact library : libraries) {
-            sb.append("&lib-").append(library.shortGroupId()).append(".").append(library.artifactId()).append("=").append(encode(library.version()));
+            sb.append("&lib-").append(library.shortGroupId())
+              .append(".").append(library.artifactId())
+              .append("=").append(encode(library.version()));
         }
         return sb.toString();
     }
@@ -77,7 +82,7 @@ public record UpdateCheckRequest(
     /**
      * Converts the usage request into a user agent string format.
      *
-     * @return The user agent string representation of the usage request.
+     * @return the user agent string representation of the usage request
      */
     public String toUserAgent() {
         String axonBaseVersion = getAxonBaseVersion();
@@ -88,7 +93,7 @@ public record UpdateCheckRequest(
         );
     }
 
-        private String getAxonBaseVersion() {
+    private String getAxonBaseVersion() {
         return libraries.stream()
                         .filter(a -> a.groupId().equals("org.axonframework"))
                         .filter(a -> a.artifactId().equals("axon-messaging"))

--- a/update/src/main/java/org/axonframework/update/detection/MachineUserName.java
+++ b/update/src/main/java/org/axonframework/update/detection/MachineUserName.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.update.detection;
+
+import org.axonframework.common.ObjectUtils;
+import org.axonframework.common.annotation.Internal;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Detects the name of the operating system user account running the JVM.
+ * <p>
+ * The detected name is memoized after the first call, as it is not expected to change during the lifetime of the JVM.
+ * <p>
+ * If the {@code user.name} system property is not available, this falls back to {@code "unknown"}. This method never
+ * throws and never returns {@code null}.
+ *
+ * @author Steven van Beelen
+ * @since 5.3.2
+ */
+@Internal
+public class MachineUserName {
+
+    private static final Logger logger = LoggerFactory.getLogger(MachineUserName.class);
+
+    private static final String USER_NAME_PROPERTY = "user.name";
+
+    @Nullable
+    private static String machineUserName;
+
+    /**
+     * Returns the name of the operating system user account running the JVM. If it has not been detected yet, it will
+     * be detected first.
+     *
+     * @return the name of the operating system user account, or {@code "unknown"} if it could not be detected
+     */
+    public static String get() {
+        if (machineUserName == null) {
+            machineUserName = detect();
+        }
+        return machineUserName;
+    }
+
+    private static String detect() {
+        try {
+            return ObjectUtils.getOrDefault(System.getProperty(USER_NAME_PROPERTY), "unknown");
+        } catch (Exception e) {
+            logger.debug("Failed to detect machine user name.", e);
+            return "unknown";
+        }
+    }
+
+    private MachineUserName() {
+        // Utility class
+    }
+}

--- a/update/src/test/java/org/axonframework/update/LoggingUpdateCheckerReporterTest.java
+++ b/update/src/test/java/org/axonframework/update/LoggingUpdateCheckerReporterTest.java
@@ -42,6 +42,7 @@ class LoggingUpdateCheckerReporterTest {
 
     private final UpdateCheckRequest sampleRequest = new UpdateCheckRequest(
             "my-machine-id-1234",
+            "my-machine-user-name",
             "my-instance-id-5678",
             "Linux",
             "6",

--- a/update/src/test/java/org/axonframework/update/UpdateCheckRequestTest.java
+++ b/update/src/test/java/org/axonframework/update/UpdateCheckRequestTest.java
@@ -31,6 +31,7 @@ class UpdateCheckRequestTest {
     void toQueryString() {
         UpdateCheckRequest request = new UpdateCheckRequest(
                 "machine-1234",
+                "machine-user-name",
                 "instance-5678",
                 "Linux",
                 "6.11.0-26-generic",
@@ -68,6 +69,7 @@ class UpdateCheckRequestTest {
     void toUserAgent() {
         UpdateCheckRequest request = new UpdateCheckRequest(
                 "machine-1234",
+                "machine-user-name",
                 "instance-5678",
                 "Linux",
                 "6.11.0-26-generic",

--- a/update/src/test/java/org/axonframework/update/api/UsageRequestTest.java
+++ b/update/src/test/java/org/axonframework/update/api/UsageRequestTest.java
@@ -29,6 +29,7 @@ class UpdateCheckRequestTest {
     void toQueryString() {
         UpdateCheckRequest request = new UpdateCheckRequest(
                 "machine-1234",
+                "machine-user-name",
                 "instance-5678",
                 "Linux",
                 "6.11.0-26-generic",
@@ -66,6 +67,7 @@ class UpdateCheckRequestTest {
     void toUserAgent() {
         UpdateCheckRequest request = new UpdateCheckRequest(
                 "machine-1234",
+                "machine-user-name",
                 "instance-5678",
                 "Linux",
                 "6.11.0-26-generic",

--- a/update/src/test/java/org/axonframework/update/detection/MachineUserNameTest.java
+++ b/update/src/test/java/org/axonframework/update/detection/MachineUserNameTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.update.detection;
+
+import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class validating the {@link MachineUserName}.
+ *
+ * @author Steven van Beelen
+ */
+class MachineUserNameTest {
+
+    @Test
+    void detectsNonBlankMachineUserName() {
+        String machineUserName = MachineUserName.get();
+
+        assertNotNull(machineUserName);
+        assertFalse(machineUserName.isBlank());
+    }
+
+    @Test
+    void resultIsMemoized() {
+        assertSame(MachineUserName.get(), MachineUserName.get());
+    }
+}


### PR DESCRIPTION
This pull request expands the `UpdadateChecker` to retrieve an additional value: the `user.name` of the JVM running Axon Framework.
For more information about the Update Checker's purpose and intent, please read up on it [here](https://docs.axoniq.io/axon-framework-update-checker/).