### PR TITLE
Ensure returned `CommandResultMessage` is never `null`

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/CommandBus.java
@@ -16,12 +16,12 @@
 
 package org.axonframework.messaging.commandhandling;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -47,10 +47,11 @@ public interface CommandBus extends CommandHandlerRegistry<CommandBus>, Describa
      * {@link #subscribe(QualifiedName, CommandHandler) subscribed} to the given {@code command}'s name. The name is
      * typically deferred from the {@link Message#type()}, which contains a {@link MessageType#qualifiedName()}.
      *
-     * @param command           The command to dispatch.
-     * @param processingContext The processing context under which the command is being published (can be
-     *                          {@code null}).
-     * @return The {@code CompletableFuture} providing the result of the command, once finished.
+     * @param command           the command to dispatch
+     * @param processingContext the processing context under which the command is being published (can be {@code null})
+     * @return the {@code CompletableFuture} providing the {@link CommandResultMessage result of the command} once
+     * finished. The result message will contain a {@code null} {@link CommandResultMessage#payload()} if the
+     * {@link CommandHandler command handler} returned {@code null}
      * @throws NoHandlerForCommandException when no {@link CommandHandler command handler} is registered for the given
      *                                      {@code command}'s name.
      */

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/SimpleCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/SimpleCommandBus.java
@@ -17,6 +17,8 @@
 package org.axonframework.messaging.commandhandling;
 
 import org.axonframework.common.infra.ComponentDescriptor;
+import org.axonframework.messaging.core.MessageStream.Entry;
+import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.UnitOfWork;
@@ -104,24 +106,28 @@ public class SimpleCommandBus implements CommandBus {
         if (logger.isDebugEnabled()) {
             logger.debug("Handling command [{} ({})]", command.identifier(), command.type());
         }
-        UnitOfWork unitOfWork = unitOfWorkFactory.create(command.identifier());
 
-        var result = unitOfWork.executeWithResult(c -> handler.handle(command, c).first().asCompletableFuture());
+        UnitOfWork unitOfWork = unitOfWorkFactory.create(command.identifier());
+        CompletableFuture<@Nullable Entry<CommandResultMessage>> result = unitOfWork.executeWithResult(
+                context -> handler.handle(command, context)
+                                  .first()
+                                  .asCompletableFuture()
+        );
+
         if (logger.isDebugEnabled()) {
             result = result.whenComplete((r, e) -> {
                 if (e == null) {
-                    logger.debug("Command [{} ({})] completed successfully",
-                                 command.identifier(),
-                                 command.type());
+                    logger.debug("Command [{} ({})] completed successfully", command.identifier(), command.type());
                 } else {
-                    logger.debug("Command [{} ({})] completed exceptionally",
-                                 command.identifier(),
-                                 command.type(),
-                                 e);
+                    logger.debug("Command [{} ({})] completed exceptionally", command.identifier(), command.type(), e);
                 }
             });
         }
-        return result.thenApply(e -> e == null ? null : e.message());
+
+        return result.thenApply(e -> e != null
+                ? e.message()
+                : new GenericCommandResultMessage(new MessageType(Void.class), (Object) null)
+        );
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/commandhandling/SimpleCommandBusTest.java
@@ -75,13 +75,15 @@ class SimpleCommandBusTest {
     }
 
     @Test
-    void dispatchCommandHandlerSubscribedAndReturnEmpty() throws Exception {
+    void dispatchCommandHandlerSubscribedAndReturnEmptyResultsInMessageWithNullPayload() throws Exception {
         testSubject.subscribe(COMMAND_NAME, (m, c) -> MessageStream.empty().cast());
 
         CompletableFuture<? extends Message> actual =
                 testSubject.dispatch(TEST_COMMAND, StubProcessingContext.forMessage(TEST_COMMAND));
 
-        assertNull(actual.get());
+        Message actualMessage = actual.get();
+        assertNotNull(actualMessage);
+        assertNull(actualMessage.payload());
     }
 
     @Test

--- a/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/AxonTestFixtureMessagingTest.java
@@ -107,7 +107,7 @@ class AxonTestFixtureMessagingTest {
         }
 
         @Test
-        void whenCommandReturnsEmptyThenSuccessWithNullValue() {
+        void whenCommandReturnsEmptyThenSuccessWithNullPayload() {
             var configurer = messagingConfigurer();
             registerChangeStudentNameHandlerReturnsEmpty(configurer);
 
@@ -117,7 +117,7 @@ class AxonTestFixtureMessagingTest {
                    .command(new ChangeStudentNameCommand("my-studentId-1", "name-1"))
                    .then()
                    .success()
-                   .resultMessageSatisfies(Assertions::assertNull);
+                   .resultMessageSatisfies(resultMessage -> Assertions.assertNull(resultMessage.payload()));
         }
 
         @Test


### PR DESCRIPTION
This PR ensures the `CommandResultMessage` is never `null`. 
The `CommandBus` API dictates the `CommandResultMessage` returned from `dispatch` to not be `null`, but the `SimpleCommandBus` implementation **did** return `null` whenever a `MessageStream.Empty` was returned.
This PR rectifies this behavior, by checking if a `null` `MessageStream.Entry` is returned from a `CommandHandler`.
If it is, it's constructs a `CommandResultMessage` with `MessageType(Void.class)` and a `null` payload.
That way, users and the framework itself are assured there's a carrier **at all times**.

Note that this PR should be back-ported to `axon-5.3.x`.