### PR TITLE
Fix KotlinReflectPropertyAccessStrategy to yield instead of throwing NPE

### DIFF
--- a/common/src/main/java/org/axonframework/common/property/PropertyAccessStrategy.java
+++ b/common/src/main/java/org/axonframework/common/property/PropertyAccessStrategy.java
@@ -140,6 +140,6 @@ public abstract class PropertyAccessStrategy implements Comparable<PropertyAcces
      * @return the Property instance providing access to the property value, or {@code null} if property could not
      * be found.
      */
-    protected abstract <T> Property<T> propertyFor(Class<? extends T> targetClass, String property);
+    protected abstract <T> @Nullable Property<T> propertyFor(Class<? extends T> targetClass, String property);
 }
 

--- a/extensions/kotlin/kotlin/src/main/kotlin/common/KotlinReflectPropertyAccessStrategy.kt
+++ b/extensions/kotlin/kotlin/src/main/kotlin/common/KotlinReflectPropertyAccessStrategy.kt
@@ -63,9 +63,12 @@ class KotlinReflectPropertyAccessStrategy : PropertyAccessStrategy() {
     // needs increased priority to be able to override the default property access strategy
     override fun getPriority(): Int = 1000
 
+    // Returns null when this strategy cannot resolve the property (non-Kotlin class, or no single
+    // matching member property), so PropertyAccessStrategy.getProperty falls through to the next
+    // strategy instead of failing with a NullPointerException.
     override fun <T : Any> propertyFor(
         targetClass: Class<out T>,
         property: String
-    ): Property<T> = KotlinReflectProperty(kProperty(targetClass, property)!!)
+    ): Property<T>? = kProperty(targetClass, property)?.let { KotlinReflectProperty(it) }
 
 }

--- a/extensions/kotlin/kotlin/src/test/kotlin/common/KotlinReflectPropertyAccessStrategyTest.kt
+++ b/extensions/kotlin/kotlin/src/test/kotlin/common/KotlinReflectPropertyAccessStrategyTest.kt
@@ -44,4 +44,22 @@ class KotlinReflectPropertyAccessStrategyTest {
 
         assertThat(property?.getValue<PersonId>(person)).isEqualTo(PersonId(42))
     }
+
+    @Test
+    fun `falls through to another strategy for a non-kotlin class`() {
+        // RuntimeException is not a Kotlin class, so this strategy cannot resolve the property.
+        // It must yield (return null) so a lower-priority strategy can resolve "message" via getMessage().
+        val property = PropertyAccessStrategy.getProperty(RuntimeException::class.java, "message")
+
+        assertThat(property?.getValue<String>(RuntimeException("boom"))).isEqualTo("boom")
+    }
+
+    @Test
+    fun `returns null when the kotlin class has no such property`() {
+        data class Person(val id: Int, val name: String)
+
+        val property = PropertyAccessStrategy.getProperty(Person::class.java, "nonExisting")
+
+        assertThat(property).isNull()
+    }
 }


### PR DESCRIPTION
WORK IN PROGRESS....

## Summary

`KotlinReflectPropertyAccessStrategy` registers with priority `1000`, so `PropertyAccessStrategy` consults it first for every class. Its `propertyFor` used `kProperty(...)!!`, which throws `NullPointerException` when the target is not a Kotlin class, or when the name does not match exactly one member property.

`PropertyAccessStrategy.getProperty` walks the registered strategies by priority and moves on when one returns `null`, which is the documented contract of `propertyFor`:

```java
while (property == null && strategies.hasNext()) {
    property = strategies.next().propertyFor(targetClass, propertyName);
}
```

Because this strategy is consulted first, that NPE broke resolution for every consumer instead of letting a lower-priority strategy handle it. `propertyFor` now returns `null` in those cases so the chain falls through.

To let the Kotlin override return `null`, the abstract `PropertyAccessStrategy.propertyFor` is annotated `@Nullable`, making the existing "or null if the property could not be found" contract explicit.

## Tests

- A non-Kotlin class (`RuntimeException`) falls through so a lower-priority strategy resolves `message`.
- An unknown property on a Kotlin class resolves to `null`.

All extension module tests and the `common` property tests pass.
