### PR TITLE
Multi-Member entity event routing: docs, tests, and @EventTag recipe

### DIFF
--- a/docs/message-handler-customization-guide/antora.yml
+++ b/docs/message-handler-customization-guide/antora.yml
@@ -1,5 +1,5 @@
 name: message-handler-customization-guide
-title: Customizing Message Handlers
+title: Customizing message handlers
 version:
   axon-(?<version>+({0..9}).+({0..9})).*: $<version>
   '*': development

--- a/docs/meta-annotations-guide/antora.yml
+++ b/docs/meta-annotations-guide/antora.yml
@@ -1,5 +1,5 @@
 name: meta-annotations-guide
-title: Meta Annotations
+title: Meta annotations
 version:
   axon-(?<version>+({0..9}).+({0..9})).*: $<version>
   '*': development

--- a/docs/reference-guide/modules/migration/pages/paths/aggregates/multi-entity-migration.adoc
+++ b/docs/reference-guide/modules/migration/pages/paths/aggregates/multi-entity-migration.adoc
@@ -84,9 +84,9 @@ In Axon Framework 4, `@AggregateMember` had an `eventForwardingMode` attribute c
 * `ForwardNone`: no events were forwarded automatically.
 
 In Axon Framework 5, this attribute does not exist.
-The default behaviour is equivalent to `ForwardAll`: every event is offered to every child's `@EventSourcingHandler`.
+Delivery is controlled by the `eventTargetMatcher` on `@EntityMember`, which defaults to `RoutingKeyEventTargetMatcherDefinition`: a single child declared without a `routingKey` receives every event (equivalent to `ForwardAll`), while a `routingKey` (required for a collection) delivers an event only to the child whose routing key matches a field on the event (equivalent to `ForwardMatchingInstances`).
 
-To replicate `ForwardMatchingInstances`, configure `eventTargetMatcher` on `@EntityMember`:
+To set this matcher explicitly, configure `eventTargetMatcher` on `@EntityMember`:
 
 [source,java]
 ----
@@ -97,6 +97,17 @@ include::example$migration/paths/aggregates/multientitymigration/GiftCardWithExp
 
 There is no direct replacement for `ForwardNone`.
 If you need to suppress event forwarding entirely, do not declare `@EventSourcingHandler` methods on the child entity. Axon will offer events but nothing will handle them.
+
+[WARNING]
+.Child `@EventSourcingHandler` not called after migration?
+====
+An event only evolves a child if it passes two checks:
+
+. It is sourced into the parent: the parent loads only events tagged with its `tagKey`, so every event, parent-level and child-level, must carry that tag. The OpenRewrite migration adds these `@EventTag` annotations for you, leaving a `// TODO(axon4to5)` comment where it cannot determine the field with certainty.
+. It is routed to the child: with a `routingKey`, the event must carry a field named like the `routingKey` holding the child's value; for a single child, dropping the `routingKey` forwards every event.
+
+Because these are resolved separately, a child's `@CommandHandler` can run while its `@EventSourcingHandler` is skipped.
+====
 
 == See also
 

--- a/extensions/spring/spring-boot-starter-test/src/test/java/org/axonframework/extension/springboot/test/SpringEventSourcedChildEntityTest.java
+++ b/extensions/spring/spring-boot-starter-test/src/test/java/org/axonframework/extension/springboot/test/SpringEventSourcedChildEntityTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.springboot.test;
+
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.annotation.reflection.InjectEntityId;
+import org.axonframework.extension.spring.stereotype.EventSourced;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.TargetEntityId;
+import org.axonframework.modelling.entity.annotation.EntityMember;
+import org.axonframework.test.fixture.AxonTestFixture;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+import java.util.UUID;
+
+/**
+ * Verifies that the Spring {@link EventSourced} stereotype with a {@link UUID} identifier registers a single
+ * {@link EntityMember} child correctly, and that the child's {@link EventSourcingHandler} is invoked for events
+ * sourced into the parent stream.
+ * <p>
+ * Mirrors a migrated aggregate: the parent is keyed by {@code UUID} and tagged with a {@code tagKey} that differs
+ * from the identifier field name, the child carries no {@code routingKey} (so it receives every sourced event), and
+ * the child rejects a second save once already collecting, making the child's sourced state observable through the
+ * command outcome.
+ */
+@AxonSpringBootTest(
+        classes = SpringEventSourcedChildEntityTest.TestApplication.class,
+        properties = "axon.axonserver.enabled=false"
+)
+class SpringEventSourcedChildEntityTest {
+
+    private static final UUID CASE_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID TASK_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+
+    @Autowired
+    AxonTestFixture fixture;
+
+    // then: with a UUID id and a single child without a routingKey, a child event carrying the parent tag
+    // evolves the child, so the follow-up command succeeds.
+    @Test
+    void childEventWithParentTagEvolvesChild() {
+        fixture.given()
+               .events(new CaseOpened(CASE_ID),
+                       new TaskAdded(CASE_ID, TASK_ID),
+                       new CollectionStarted(CASE_ID, TASK_ID))
+               .when()
+               .command(new SaveCollectedData(CASE_ID, TASK_ID))
+               .then()
+               .success()
+               .events(new DataCollected(CASE_ID, TASK_ID));
+    }
+
+    // then: a child event that lacks the parent tag is never sourced, so the child stays un-evolved and the
+    // command is rejected.
+    @Test
+    void childEventWithoutParentTagIsNeverSourced() {
+        fixture.given()
+               .events(new CaseOpened(CASE_ID),
+                       new TaskAdded(CASE_ID, TASK_ID),
+                       new CollectionStartedUntagged(CASE_ID, TASK_ID))
+               .when()
+               .command(new SaveCollectedData(CASE_ID, TASK_ID))
+               .then()
+               .exception(IllegalStateException.class);
+    }
+
+    record SaveCollectedData(@TargetEntityId UUID caseId, UUID taskId) {
+
+    }
+
+    record CaseOpened(@EventTag(key = "caseId") UUID caseId) {
+
+    }
+
+    record TaskAdded(@EventTag(key = "caseId") UUID caseId, UUID taskId) {
+
+    }
+
+    record CollectionStarted(@EventTag(key = "caseId") UUID caseId, UUID taskId) {
+
+    }
+
+    record CollectionStartedUntagged(UUID caseId, @EventTag(key = "taskId") UUID taskId) {
+
+    }
+
+    record DataCollected(@EventTag(key = "caseId") UUID caseId, UUID taskId) {
+
+    }
+
+    @EventSourced(idType = UUID.class, tagKey = "caseId")
+    static class CaseAggregate {
+
+        @SuppressWarnings("unused")
+        private UUID caseId;
+
+        @EntityMember
+        private Task task;
+
+        @EventSourcingHandler
+        void on(CaseOpened event) {
+            this.caseId = event.caseId();
+        }
+
+        @EventSourcingHandler
+        void on(TaskAdded event) {
+            this.task = new Task(event.taskId());
+        }
+
+        @EntityCreator
+        CaseAggregate(@InjectEntityId UUID caseId) {
+            this.caseId = caseId;
+        }
+    }
+
+    static class Task {
+
+        @SuppressWarnings("unused")
+        private final UUID taskId;
+        private boolean collecting;
+
+        Task(UUID taskId) {
+            this.taskId = taskId;
+        }
+
+        @CommandHandler
+        public void handle(SaveCollectedData cmd, EventAppender appender) {
+            if (!collecting) {
+                throw new IllegalStateException("Task is not collecting");
+            }
+            appender.append(new DataCollected(cmd.caseId(), cmd.taskId()));
+        }
+
+        @EventSourcingHandler
+        void on(CollectionStarted event) {
+            this.collecting = true;
+        }
+
+        @EventSourcingHandler
+        void on(CollectionStartedUntagged event) {
+            this.collecting = true;
+        }
+    }
+
+    @EnableAutoConfiguration
+    @Import(CaseAggregate.class)
+    static class TestApplication {
+
+    }
+}

--- a/migration/src/main/java/org/axonframework/migration/AddEventTagAnnotation.java
+++ b/migration/src/main/java/org/axonframework/migration/AddEventTagAnnotation.java
@@ -65,6 +65,14 @@ import java.util.Map;
  *       {@code // TODO(axon4to5):} comment so a human reviewer can verify the choice.</li>
  * </ol>
  *
+ * <p>Child entities declared on a parent via {@code @AggregateMember}/{@code @EntityMember} are
+ * followed as well: each event used in a child entity's {@code @EventSourcingHandler} (or
+ * {@code apply(...)} call) is tagged with the <b>parent</b> entity's tag, so it is sourced into the
+ * parent's stream. This preserves the single event stream an Axon Framework 4 aggregate shared with
+ * its members. When the child event carries the parent identifier under the parent's field name it
+ * is tagged directly; otherwise the same first-field fallback and {@code // TODO(axon4to5):} comment
+ * apply.
+ *
  * <p><b>Must run before {@code @AggregateIdentifier} is removed</b> (i.e. before the
  * {@link org.openrewrite.java.RemoveAnnotation} step inside {@code Axon4ToAxon5Modelling}), so
  * that the annotation is still present for the scan.
@@ -96,6 +104,13 @@ public class AddEventTagAnnotation extends ScanningRecipe<AddEventTagAnnotation.
 
     private static final String EVENT_TAG_FQN =
             "org.axonframework.eventsourcing.annotation.EventTag";
+
+    // AF4 @AggregateMember / AF5 @EntityMember, used to follow a parent entity to its child
+    // entities so their events are tagged with the PARENT's boundary as well.
+    private static final String AGGREGATE_MEMBER_AF4 =
+            "org.axonframework.modelling.command.AggregateMember";
+    private static final String ENTITY_MEMBER_AF5 =
+            "org.axonframework.modelling.entity.annotation.EntityMember";
 
     private static final String AF4_AGGREGATE_LIFECYCLE =
             "org.axonframework.modelling.command.AggregateLifecycle";
@@ -130,6 +145,23 @@ public class AddEventTagAnnotation extends ScanningRecipe<AddEventTagAnnotation.
         }
 
         final Map<String, EventTagTarget> targets = new HashMap<>();
+
+        /**
+         * Maps a child-entity class FQN (declared via {@code @AggregateMember}/{@code @EntityMember}
+         * on a parent entity) to the PARENT entity's tag boundary. Child events are tagged with the
+         * parent's tag so they are sourced into the parent's stream.
+         */
+        final Map<String, EventTagTarget> memberChildBoundary = new HashMap<>();
+
+        /**
+         * Maps any class FQN to the non-framework event types it uses, via {@code @EventSourcingHandler}
+         * or {@code AggregateLifecycle.apply(...)}. Populated for every class so that child entities
+         * (which are not themselves entity classes) can be reconciled against their parent's boundary.
+         */
+        final Map<String, List<String>> classEventTypes = new HashMap<>();
+
+        /** Guards {@link AddEventTagAnnotation#reconcileMemberEvents} so it runs once. */
+        boolean reconciled = false;
     }
 
     @Override
@@ -156,6 +188,19 @@ public class AddEventTagAnnotation extends ScanningRecipe<AddEventTagAnnotation.
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl,
                                                             ExecutionContext ctx) {
+                // Record the events used in every class (entity or not). Child entities declared
+                // via @AggregateMember/@EntityMember are not entity classes themselves, so their
+                // events are captured here and later attributed to the parent's tag boundary.
+                if (classDecl.getType() != null) {
+                    List<String> events = collectClassEventTypes(classDecl);
+                    if (!events.isEmpty()) {
+                        acc.classEventTypes
+                           .computeIfAbsent(classDecl.getType().getFullyQualifiedName(),
+                                            k -> new java.util.ArrayList<>())
+                           .addAll(events);
+                    }
+                }
+
                 if (!isEntityClass(classDecl)) {
                     return super.visitClassDeclaration(classDecl, ctx);
                 }
@@ -243,6 +288,17 @@ public class AddEventTagAnnotation extends ScanningRecipe<AddEventTagAnnotation.
                     }
                 }.visit(classDecl, ctx);
 
+                // Follow @AggregateMember/@EntityMember fields to their child entity types, and
+                // record that those children belong to THIS entity's tag boundary. Their events are
+                // reconciled into `targets` before the edit phase, so a child event is tagged with
+                // the parent's tag and thus sourced into the parent's stream (as in Axon Framework 4,
+                // where an aggregate and its members shared one event stream).
+                for (String childFqn : findMemberChildFqns(classDecl)) {
+                    acc.memberChildBoundary.putIfAbsent(
+                            childFqn,
+                            new Accumulator.EventTagTarget(idFieldName, entitySimpleName));
+                }
+
                 return super.visitClassDeclaration(classDecl, ctx);
             }
         };
@@ -250,6 +306,7 @@ public class AddEventTagAnnotation extends ScanningRecipe<AddEventTagAnnotation.
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
+        reconcileMemberEvents(acc);
         return new JavaIsoVisitor<>() {
 
             @Override
@@ -759,5 +816,149 @@ public class AddEventTagAnnotation extends ScanningRecipe<AddEventTagAnnotation.
             }
         }
         return null;
+    }
+
+    /**
+     * Attributes every child-entity event to its parent's tag boundary. For each child discovered
+     * via {@code @AggregateMember}/{@code @EntityMember}, each event the child uses is added to
+     * {@link Accumulator#targets} with the parent's {@code idFieldName} and {@code tagKey}, unless
+     * the event already has a target. Runs once, after the scan has populated the accumulator.
+     */
+    private static void reconcileMemberEvents(Accumulator acc) {
+        if (acc.reconciled) {
+            return;
+        }
+        acc.reconciled = true;
+        for (Map.Entry<String, Accumulator.EventTagTarget> entry : acc.memberChildBoundary.entrySet()) {
+            List<String> events = acc.classEventTypes.get(entry.getKey());
+            if (events == null) {
+                continue;
+            }
+            for (String eventFqn : events) {
+                acc.targets.putIfAbsent(eventFqn, entry.getValue());
+            }
+        }
+    }
+
+    /**
+     * Collects the non-framework event types used in {@code classDecl}, from both the first
+     * parameter of each {@code @EventSourcingHandler} method and the first argument of every
+     * {@code AggregateLifecycle.apply(...)} call in the class body.
+     */
+    private static List<String> collectClassEventTypes(J.ClassDeclaration classDecl) {
+        List<String> events = new java.util.ArrayList<>();
+        if (classDecl.getBody() == null) {
+            return events;
+        }
+        for (Statement stmt : classDecl.getBody().getStatements()) {
+            if (!(stmt instanceof J.MethodDeclaration)) {
+                continue;
+            }
+            J.MethodDeclaration method = (J.MethodDeclaration) stmt;
+            if (!isEventSourcingHandler(method)) {
+                continue;
+            }
+            List<Statement> params = method.getParameters();
+            if (params.isEmpty() || !(params.get(0) instanceof J.VariableDeclarations)) {
+                continue;
+            }
+            J.VariableDeclarations firstParam = (J.VariableDeclarations) params.get(0);
+            if (firstParam.getTypeExpression() == null) {
+                continue;
+            }
+            JavaType.FullyQualified eventType =
+                    TypeUtils.asFullyQualified(firstParam.getTypeExpression().getType());
+            if (eventType != null
+                    && !eventType.getFullyQualifiedName().startsWith("org.axonframework")) {
+                events.add(eventType.getFullyQualifiedName());
+            }
+        }
+        new JavaIsoVisitor<List<String>>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation mi, List<String> collected) {
+                J.MethodInvocation invocation = super.visitMethodInvocation(mi, collected);
+                if (!APPLY_AF4.matches(invocation) && !APPLY_AF5.matches(invocation)) {
+                    return invocation;
+                }
+                if (invocation.getArguments().isEmpty()
+                        || invocation.getArguments().get(0) instanceof J.Empty) {
+                    return invocation;
+                }
+                JavaType.FullyQualified eventType =
+                        TypeUtils.asFullyQualified(invocation.getArguments().get(0).getType());
+                if (eventType != null
+                        && !eventType.getFullyQualifiedName().startsWith("org.axonframework")
+                        && !collected.contains(eventType.getFullyQualifiedName())) {
+                    collected.add(eventType.getFullyQualifiedName());
+                }
+                return invocation;
+            }
+        }.visit(classDecl, events);
+        return events;
+    }
+
+    /**
+     * Returns the FQNs of the child entity types declared on {@code cd} via
+     * {@code @AggregateMember}/{@code @EntityMember} fields. For {@code List<Child>},
+     * {@code Map<K, Child>}, or {@code Optional<Child>} fields the element (last type parameter) is
+     * returned.
+     */
+    private static List<String> findMemberChildFqns(J.ClassDeclaration cd) {
+        List<String> result = new java.util.ArrayList<>();
+        if (cd.getBody() == null) {
+            return result;
+        }
+        for (Statement stmt : cd.getBody().getStatements()) {
+            J.VariableDeclarations vd = unwrapVariableDeclarations(stmt);
+            if (vd == null || !isEntityMemberField(vd)) {
+                continue;
+            }
+            String childFqn = memberChildTypeFqn(vd);
+            if (childFqn != null
+                    && !childFqn.startsWith("org.axonframework")
+                    && !childFqn.startsWith("java.")) {
+                result.add(childFqn);
+            }
+        }
+        return result;
+    }
+
+    private static boolean isEntityMemberField(J.VariableDeclarations vd) {
+        for (J.Annotation ann : vd.getLeadingAnnotations()) {
+            if (TypeUtils.isOfClassType(ann.getType(), AGGREGATE_MEMBER_AF4)
+                    || TypeUtils.isOfClassType(ann.getType(), ENTITY_MEMBER_AF5)) {
+                return true;
+            }
+            if (ann.getAnnotationType() instanceof J.Identifier) {
+                String name = ((J.Identifier) ann.getAnnotationType()).getSimpleName();
+                if ("AggregateMember".equals(name) || "EntityMember".equals(name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Resolves the child entity FQN from an {@code @AggregateMember}/{@code @EntityMember} field's
+     * declared type, unwrapping the last type parameter for collection / map / optional fields.
+     */
+    private static @Nullable String memberChildTypeFqn(J.VariableDeclarations vd) {
+        if (vd.getTypeExpression() == null) {
+            return null;
+        }
+        JavaType type = vd.getTypeExpression().getType();
+        if (type instanceof JavaType.Parameterized) {
+            List<JavaType> typeParameters = ((JavaType.Parameterized) type).getTypeParameters();
+            if (!typeParameters.isEmpty()) {
+                JavaType.FullyQualified element =
+                        TypeUtils.asFullyQualified(typeParameters.get(typeParameters.size() - 1));
+                if (element != null) {
+                    return element.getFullyQualifiedName();
+                }
+            }
+        }
+        JavaType.FullyQualified fq = TypeUtils.asFullyQualified(type);
+        return fq == null ? null : fq.getFullyQualifiedName();
     }
 }

--- a/migration/src/test/java/org/axonframework/migration/AddEventTagAnnotationMemberTest.java
+++ b/migration/src/test/java/org/axonframework/migration/AddEventTagAnnotationMemberTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.migration;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * Verifies that {@link AddEventTagAnnotation} tags the events of a child entity declared via
+ * {@code @AggregateMember}/{@code @EntityMember}, not just the root aggregate's own events. The
+ * child event is tagged with the <b>parent</b> entity's tag, so it is sourced into the parent's
+ * stream, which is what an Axon Framework 4 aggregate and its members shared.
+ */
+class AddEventTagAnnotationMemberTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new AddEventTagAnnotation())
+            .typeValidationOptions(TypeValidation.none());
+    }
+
+    @Test
+    void tagsMemberChildEventWithParentTag() {
+        rewriteRun(
+                // parent aggregate with an @AggregateMember child
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.eventsourcing.EventSourcingHandler;
+                        import org.axonframework.modelling.command.AggregateIdentifier;
+                        import org.axonframework.modelling.command.AggregateMember;
+                        import org.axonframework.spring.stereotype.Aggregate;
+
+                        @Aggregate
+                        class GiftCard {
+                            @AggregateIdentifier
+                            private String cardId;
+
+                            @AggregateMember
+                            private Transaction transaction;
+
+                            @EventSourcingHandler
+                            void on(CardIssued event) {
+                            }
+                        }
+                        """
+                ),
+                // child entity with its own @EventSourcingHandler
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.eventsourcing.EventSourcingHandler;
+
+                        class Transaction {
+                            private String transactionId;
+
+                            @EventSourcingHandler
+                            void on(CardRedeemed event) {
+                            }
+                        }
+                        """
+                ),
+                // parent event: tagged with the aggregate id field (existing behaviour)
+                java(
+                        """
+                        package com.example;
+
+                        class CardIssued {
+                            String cardId;
+                            int amount;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.eventsourcing.annotation.EventTag;
+
+                        class CardIssued {
+                            @EventTag(key = "GiftCard")
+                            String cardId;
+                            int amount;
+                        }
+                        """
+                ),
+                // child event: carries the parent id field, must now be tagged with the parent tag
+                java(
+                        """
+                        package com.example;
+
+                        class CardRedeemed {
+                            String cardId;
+                            String transactionId;
+                            int amount;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.eventsourcing.annotation.EventTag;
+
+                        class CardRedeemed {
+                            @EventTag(key = "GiftCard")
+                            String cardId;
+                            String transactionId;
+                            int amount;
+                        }
+                        """
+                )
+        );
+    }
+
+    @Test
+    void tagsMemberChildEventForListMember() {
+        rewriteRun(
+                java(
+                        """
+                        package com.example;
+                        import java.util.List;
+                        import org.axonframework.eventsourcing.EventSourcingHandler;
+                        import org.axonframework.modelling.command.AggregateIdentifier;
+                        import org.axonframework.modelling.command.AggregateMember;
+                        import org.axonframework.spring.stereotype.Aggregate;
+
+                        @Aggregate
+                        class GiftCard {
+                            @AggregateIdentifier
+                            private String cardId;
+
+                            @AggregateMember
+                            private List<Transaction> transactions;
+
+                            @EventSourcingHandler
+                            void on(CardIssued event) {
+                            }
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+                        import org.axonframework.eventsourcing.EventSourcingHandler;
+
+                        class Transaction {
+                            private String transactionId;
+
+                            @EventSourcingHandler
+                            void on(CardRedeemed event) {
+                            }
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+
+                        class CardIssued {
+                            String cardId;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.eventsourcing.annotation.EventTag;
+
+                        class CardIssued {
+                            @EventTag(key = "GiftCard")
+                            String cardId;
+                        }
+                        """
+                ),
+                java(
+                        """
+                        package com.example;
+
+                        class CardRedeemed {
+                            String cardId;
+                            String transactionId;
+                        }
+                        """,
+                        """
+                        package com.example;
+
+                        import org.axonframework.eventsourcing.annotation.EventTag;
+
+                        class CardRedeemed {
+                            @EventTag(key = "GiftCard")
+                            String cardId;
+                            String transactionId;
+                        }
+                        """
+                )
+        );
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/ChildEntityEventTaggingTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/ChildEntityEventTaggingTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.TargetEntityId;
+import org.axonframework.modelling.entity.annotation.EntityMember;
+import org.junit.jupiter.api.*;
+
+/**
+ * Proves the second gate a child event must pass, separate from routing: an event only reaches a child's
+ * {@link EventSourcingHandler} if it is first sourced into the parent's event stream.
+ * <p>
+ * The parent is sourced with a single tag, {@code Tag.of(tagKey, id)}, built from {@link EventSourcedEntity#tagKey()}.
+ * The child adds nothing to that criteria. So a child-targeted event that does not carry the parent's tag is never
+ * loaded, and its handler never runs, even for a single child with no routing key where the event matcher is
+ * match-all.
+ * <p>
+ * Both scenarios use the same parent, the same single child with no {@code routingKey}, and a child event handler that
+ * flips the child to "collecting". The only difference is whether the child event carries the parent tag.
+ */
+class ChildEntityEventTaggingTest {
+
+    private static final String CASE_ID = "case-1";
+    private static final String TASK_ID = "task-1";
+
+    // Command handled by the child.
+    record SaveCollectedData(@TargetEntityId String caseId, String taskId) {
+
+    }
+
+    // Parent events, tagged with the parent tag key "caseId".
+    record CaseOpened(@EventTag(key = "caseId") String caseId) {
+
+    }
+
+    record CollectionTaskAdded(@EventTag(key = "caseId") String caseId, String taskId) {
+
+    }
+
+    // Child event tagged WITH the parent tag -> sourced into the parent stream.
+    record CollectionStartedTagged(@EventTag(key = "caseId") String caseId, String taskId) {
+
+    }
+
+    // Child event tagged only with its own task id, NOT the parent tag -> never sourced into the parent stream.
+    record CollectionStartedUntagged(String caseId, @EventTag(key = "taskId") String taskId) {
+
+    }
+
+    // Result event appended by the child command handler.
+    record DataCollected(@EventTag(key = "caseId") String caseId, String taskId) {
+
+    }
+
+    @EventSourcedEntity(tagKey = "caseId")
+    static class Case {
+
+        @SuppressWarnings("unused")
+        private String caseId;
+
+        @EntityMember
+        private Task task;
+
+        @EventSourcingHandler
+        void on(CaseOpened event) {
+            this.caseId = event.caseId();
+        }
+
+        @EventSourcingHandler
+        void on(CollectionTaskAdded event) {
+            this.task = new Task(event.taskId());
+        }
+
+        @EntityCreator
+        protected Case() {
+        }
+    }
+
+    // Single child with its own command handler and two event-sourcing handlers.
+    static class Task {
+
+        @SuppressWarnings("unused")
+        private final String taskId;
+        private boolean collecting;
+
+        Task(String taskId) {
+            this.taskId = taskId;
+        }
+
+        @CommandHandler
+        public void handle(SaveCollectedData cmd, EventAppender appender) {
+            if (!collecting) {
+                throw new IllegalStateException("Task is not collecting");
+            }
+            appender.append(new DataCollected(cmd.caseId(), cmd.taskId()));
+        }
+
+        @EventSourcingHandler
+        void on(CollectionStartedTagged event) {
+            this.collecting = true;
+        }
+
+        @EventSourcingHandler
+        void on(CollectionStartedUntagged event) {
+            this.collecting = true;
+        }
+    }
+
+    AxonTestFixture fixture() {
+        return AxonTestFixture.with(EventSourcingConfigurer.create().registerEntity(
+                EventSourcedEntityModule.autodetected(String.class, Case.class)));
+    }
+
+    // then: the child event carries the parent tag, so it is sourced and evolves the child.
+    @Test
+    void childEventTaggedWithParentTagReachesChild() {
+        fixture().given()
+                 .events(new CaseOpened(CASE_ID),
+                         new CollectionTaskAdded(CASE_ID, TASK_ID),
+                         new CollectionStartedTagged(CASE_ID, TASK_ID))
+                 .when()
+                 .command(new SaveCollectedData(CASE_ID, TASK_ID))
+                 .then()
+                 // child was evolved to "collecting", so the command succeeds
+                 .success()
+                 .events(new DataCollected(CASE_ID, TASK_ID));
+    }
+
+    // then: the child event lacks the parent tag, so it is never sourced and the child stays un-evolved.
+    @Test
+    void childEventWithoutParentTagNeverReachesChild() {
+        fixture().given()
+                 .events(new CaseOpened(CASE_ID),
+                         new CollectionTaskAdded(CASE_ID, TASK_ID),
+                         new CollectionStartedUntagged(CASE_ID, TASK_ID))
+                 .when()
+                 .command(new SaveCollectedData(CASE_ID, TASK_ID))
+                 .then()
+                 // child never saw the event, so it is still not collecting
+                 .exception(IllegalStateException.class);
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/EntityMemberMessageRoutingTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/EntityMemberMessageRoutingTest.java
@@ -1,0 +1,399 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.common.AxonConfigurationException;
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.TargetEntityId;
+import org.axonframework.modelling.entity.annotation.AnnotatedEntityMetamodel;
+import org.axonframework.modelling.entity.annotation.EntityMember;
+import org.axonframework.modelling.entity.annotation.EventTargetMatcherDefinition;
+import org.axonframework.modelling.entity.child.EventTargetMatcher;
+import org.junit.jupiter.api.*;
+
+import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Proves how Axon Framework 5 routes commands and events to child entities declared with {@link EntityMember}, the
+ * replacement for Axon Framework 4's {@code @AggregateMember}.
+ * <p>
+ * The child evolves its own state through an {@link EventSourcingHandler} and rejects a command once already confirmed.
+ * Whether the child's event handler ran is therefore observable through the command outcome:
+ * <ul>
+ *     <li>child event handled -> the child is already confirmed -> the follow-up command is rejected;</li>
+ *     <li>child event skipped -> the child is not confirmed -> the follow-up command succeeds and appends an event.</li>
+ * </ul>
+ * The scenarios show that the default {@code RoutingKeyEventTargetMatcherDefinition} is routing-key based, not a
+ * broadcast to every child, and that command routing and event routing are resolved separately.
+ */
+class EntityMemberMessageRoutingTest {
+
+    private static final String COURSE_ID = "course-1";
+    private static final String STUDENT_ONE = "student-1";
+    private static final String STUDENT_TWO = "student-2";
+
+    // Commands
+    record CreateCourse(@TargetEntityId String courseId) {
+
+    }
+
+    record ConfirmEnrollment(@TargetEntityId String courseId, String studentId) {
+
+    }
+
+    // Events
+    record CourseCreated(@EventTag String courseId) {
+
+    }
+
+    record StudentEnrolled(@EventTag String courseId, String studentId) {
+
+    }
+
+    record EnrollmentConfirmed(@EventTag String courseId, String studentId) {
+
+    }
+
+    @Nested
+    class SingleChildWithoutRoutingKey {
+
+        // No routing key on a single child -> RoutingKeyEventTargetMatcherDefinition falls back to MATCH_ANY.
+        @EventSourcedEntity(tagKey = "courseId")
+        static class Course {
+
+            @SuppressWarnings("unused")
+            private String courseId;
+
+            @EntityMember
+            private Enrollment enrollment;
+
+            @CommandHandler
+            public static void handle(CreateCourse cmd, EventAppender appender) {
+                appender.append(new CourseCreated(cmd.courseId()));
+            }
+
+            @EventSourcingHandler
+            void on(CourseCreated event) {
+                this.courseId = event.courseId();
+            }
+
+            @EventSourcingHandler
+            void on(StudentEnrolled event) {
+                this.enrollment = new Enrollment(event.studentId());
+            }
+
+            @EntityCreator
+            protected Course() {
+            }
+        }
+
+        AxonTestFixture fixture() {
+            return AxonTestFixture.with(EventSourcingConfigurer.create().registerEntity(
+                    EventSourcedEntityModule.autodetected(String.class, Course.class)));
+        }
+
+        // then: every event reaches the single child, even when its studentId does not match (ForwardAll equivalent).
+        @Test
+        void everyEventReachesTheSingleChild() {
+            fixture().given()
+                     .events(new CourseCreated(COURSE_ID),
+                             new StudentEnrolled(COURSE_ID, STUDENT_ONE),
+                             new EnrollmentConfirmed(COURSE_ID, "irrelevant-value"))
+                     .when()
+                     .command(new ConfirmEnrollment(COURSE_ID, STUDENT_ONE))
+                     .then()
+                     // child event handler ran, so the child rejects a second confirmation
+                     .exception(IllegalStateException.class);
+        }
+    }
+
+    @Nested
+    class SingleChildWithRoutingKey {
+
+        // Routing key on a single child -> events are routed by the "studentId" property.
+        @EventSourcedEntity(tagKey = "courseId")
+        static class Course {
+
+            @SuppressWarnings("unused")
+            private String courseId;
+
+            @EntityMember(routingKey = "studentId")
+            private Enrollment enrollment;
+
+            @CommandHandler
+            public static void handle(CreateCourse cmd, EventAppender appender) {
+                appender.append(new CourseCreated(cmd.courseId()));
+            }
+
+            @EventSourcingHandler
+            void on(CourseCreated event) {
+                this.courseId = event.courseId();
+            }
+
+            @EventSourcingHandler
+            void on(StudentEnrolled event) {
+                this.enrollment = new Enrollment(event.studentId());
+            }
+
+            @EntityCreator
+            protected Course() {
+            }
+        }
+
+        AxonTestFixture fixture() {
+            return AxonTestFixture.with(EventSourcingConfigurer.create().registerEntity(
+                    EventSourcedEntityModule.autodetected(String.class, Course.class)));
+        }
+
+        // then: a matching routing value reaches the child's @EventSourcingHandler.
+        @Test
+        void eventReachesChildWhenRoutingValueMatches() {
+            fixture().given()
+                     .events(new CourseCreated(COURSE_ID),
+                             new StudentEnrolled(COURSE_ID, STUDENT_ONE),
+                             new EnrollmentConfirmed(COURSE_ID, STUDENT_ONE))
+                     .when()
+                     .command(new ConfirmEnrollment(COURSE_ID, STUDENT_ONE))
+                     .then()
+                     .exception(IllegalStateException.class);
+        }
+
+        // then: a non-matching routing value silently skips the child (the reported migration symptom).
+        @Test
+        void eventSkippedWhenRoutingValueDiffers() {
+            fixture().given()
+                     .events(new CourseCreated(COURSE_ID),
+                             new StudentEnrolled(COURSE_ID, STUDENT_ONE),
+                             new EnrollmentConfirmed(COURSE_ID, "someone-else"))
+                     .when()
+                     .command(new ConfirmEnrollment(COURSE_ID, STUDENT_ONE))
+                     .then()
+                     // child event handler never ran, so the command succeeds and appends the event
+                     .events(new EnrollmentConfirmed(COURSE_ID, STUDENT_ONE));
+        }
+    }
+
+    @Nested
+    class CollectionChild {
+
+        // A collection child requires a routing key; each event reaches only the matching child.
+        @EventSourcedEntity(tagKey = "courseId")
+        static class Course {
+
+            @SuppressWarnings("unused")
+            private String courseId;
+
+            @EntityMember(routingKey = "studentId")
+            private final List<Enrollment> enrollments = new ArrayList<>();
+
+            @CommandHandler
+            public static void handle(CreateCourse cmd, EventAppender appender) {
+                appender.append(new CourseCreated(cmd.courseId()));
+            }
+
+            @EventSourcingHandler
+            void on(CourseCreated event) {
+                this.courseId = event.courseId();
+            }
+
+            @EventSourcingHandler
+            void on(StudentEnrolled event) {
+                this.enrollments.add(new Enrollment(event.studentId()));
+            }
+
+            @EntityCreator
+            protected Course() {
+            }
+        }
+
+        AxonTestFixture fixture() {
+            return AxonTestFixture.with(EventSourcingConfigurer.create().registerEntity(
+                    EventSourcedEntityModule.autodetected(String.class, Course.class)));
+        }
+
+        // then: only the child whose routing value matches receives the event.
+        @Test
+        void eventRoutedOnlyToMatchingChild() {
+            fixture().given()
+                     .events(new CourseCreated(COURSE_ID),
+                             new StudentEnrolled(COURSE_ID, STUDENT_ONE),
+                             new StudentEnrolled(COURSE_ID, STUDENT_TWO),
+                             // routed to student-1 only
+                             new EnrollmentConfirmed(COURSE_ID, STUDENT_ONE))
+                     .when()
+                     // student-1 is already confirmed
+                     .command(new ConfirmEnrollment(COURSE_ID, STUDENT_ONE))
+                     .then()
+                     .exception(IllegalStateException.class);
+        }
+
+        // then: the non-matching child was never evolved by the event, so its command still succeeds.
+        @Test
+        void otherChildNotEvolvedByEvent() {
+            fixture().given()
+                     .events(new CourseCreated(COURSE_ID),
+                             new StudentEnrolled(COURSE_ID, STUDENT_ONE),
+                             new StudentEnrolled(COURSE_ID, STUDENT_TWO),
+                             // routed to student-1 only
+                             new EnrollmentConfirmed(COURSE_ID, STUDENT_ONE))
+                     .when()
+                     // student-2 was not confirmed by the event above
+                     .command(new ConfirmEnrollment(COURSE_ID, STUDENT_TWO))
+                     .then()
+                     .events(new EnrollmentConfirmed(COURSE_ID, STUDENT_TWO));
+        }
+    }
+
+    @Nested
+    class CollectionChildWithoutRoutingKeyFailsFast {
+
+        // A collection child WITHOUT a routing key is a configuration error.
+        @EventSourcedEntity(tagKey = "courseId")
+        static class Course {
+
+            @SuppressWarnings("unused")
+            private String courseId;
+
+            @EntityMember
+            private final List<Enrollment> enrollments = new ArrayList<>();
+
+            @EventSourcingHandler
+            void on(CourseCreated event) {
+                this.courseId = event.courseId();
+            }
+
+            @EntityCreator
+            protected Course() {
+            }
+        }
+
+        // then: building the fixture fails at startup, because a routing key is mandatory for a collection child.
+        // The AxonConfigurationException surfaces wrapped in the lifecycle start-handler failure.
+        @Test
+        void missingRoutingKeyOnCollectionThrows() {
+            assertThatThrownBy(() -> AxonTestFixture.with(EventSourcingConfigurer.create().registerEntity(
+                    EventSourcedEntityModule.autodetected(String.class, Course.class))))
+                    .hasRootCauseInstanceOf(AxonConfigurationException.class)
+                    .rootCause()
+                    .hasMessageContaining("does not define a routing key");
+        }
+    }
+
+    @Nested
+    class CollectionChildWithBroadcastMatcher {
+
+        // A custom matcher that delivers every event to every child (the ForwardAll equivalent for collections).
+        @EventSourcedEntity(tagKey = "courseId")
+        static class Course {
+
+            @SuppressWarnings("unused")
+            private String courseId;
+
+            @EntityMember(routingKey = "studentId", eventTargetMatcher = BroadcastToAllChildren.class)
+            private final List<Enrollment> enrollments = new ArrayList<>();
+
+            @CommandHandler
+            public static void handle(CreateCourse cmd, EventAppender appender) {
+                appender.append(new CourseCreated(cmd.courseId()));
+            }
+
+            @EventSourcingHandler
+            void on(CourseCreated event) {
+                this.courseId = event.courseId();
+            }
+
+            @EventSourcingHandler
+            void on(StudentEnrolled event) {
+                this.enrollments.add(new Enrollment(event.studentId()));
+            }
+
+            @EntityCreator
+            protected Course() {
+            }
+        }
+
+        AxonTestFixture fixture() {
+            return AxonTestFixture.with(EventSourcingConfigurer.create().registerEntity(
+                    EventSourcedEntityModule.autodetected(String.class, Course.class)));
+        }
+
+        // then: even a child whose routing value does not match the event is evolved by it.
+        @Test
+        void broadcastReachesEveryChild() {
+            fixture().given()
+                     .events(new CourseCreated(COURSE_ID),
+                             new StudentEnrolled(COURSE_ID, STUDENT_ONE),
+                             new StudentEnrolled(COURSE_ID, STUDENT_TWO),
+                             // broadcast: confirms BOTH children despite naming only student-1
+                             new EnrollmentConfirmed(COURSE_ID, STUDENT_ONE))
+                     .when()
+                     // student-2 was also confirmed by the broadcast
+                     .command(new ConfirmEnrollment(COURSE_ID, STUDENT_TWO))
+                     .then()
+                     .exception(IllegalStateException.class);
+        }
+    }
+
+    // Custom event target matcher: delivers every event to every child, regardless of routing key.
+    static class BroadcastToAllChildren implements EventTargetMatcherDefinition {
+
+        @Override
+        public <E> EventTargetMatcher<E> createChildEntityMatcher(AnnotatedEntityMetamodel<E> entity, Member member) {
+            return (targetEntity, message, processingContext) -> true;
+        }
+    }
+
+    // Child entity with its own command handler AND event-sourcing handler.
+    static class Enrollment {
+
+        private final String studentId;
+        private boolean confirmed;
+
+        Enrollment(String studentId) {
+            this.studentId = studentId;
+        }
+
+        @SuppressWarnings("unused")
+        public String getStudentId() {
+            return studentId;
+        }
+
+        @CommandHandler
+        public void handle(ConfirmEnrollment cmd, EventAppender appender) {
+            if (confirmed) {
+                throw new IllegalStateException("Enrollment already confirmed");
+            }
+            appender.append(new EnrollmentConfirmed(cmd.courseId(), cmd.studentId()));
+        }
+
+        @EventSourcingHandler
+        void on(EnrollmentConfirmed event) {
+            this.confirmed = true;
+        }
+    }
+}

--- a/test/src/test/java/org/axonframework/test/fixture/UuidChildEntityEventSourcingTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/UuidChildEntityEventSourcingTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.eventsourcing.annotation.reflection.InjectEntityId;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.modelling.annotation.TargetEntityId;
+import org.axonframework.modelling.entity.annotation.EntityMember;
+import org.junit.jupiter.api.*;
+
+import java.util.UUID;
+
+/**
+ * Confirms the single-child routing and sourcing behaviour holds with {@link UUID} identifiers and a
+ * {@link EventSourcedEntity#tagKey() tagKey} that differs from the identifier field name, mirroring a typical
+ * migrated aggregate.
+ * <p>
+ * The parent is keyed by {@code UUID} and tagged with key {@code "myAggregate"}. The single child carries no
+ * {@code routingKey}, so it receives every sourced event. The child event handler flips the child to "collecting",
+ * and the child command handler rejects a second save, so the command outcome reveals whether the child was evolved.
+ */
+class UuidChildEntityEventSourcingTest {
+
+    private static final UUID PARENT_ID = UUID.fromString("00000000-0000-0000-0000-0000000000a1");
+    private static final UUID CHILD_ID = UUID.fromString("00000000-0000-0000-0000-0000000000b2");
+
+    record SaveCollectedData(@TargetEntityId UUID parentId, UUID childId) {
+
+    }
+
+    record ParentInitialized(@EventTag(key = "myAggregate") UUID parentId) {
+
+    }
+
+    record ChildAdded(@EventTag(key = "myAggregate") UUID parentId, UUID childId) {
+
+    }
+
+    // Child-targeted event carrying the parent tag, so it is sourced into the parent stream.
+    record CollectionStarted(@EventTag(key = "myAggregate") UUID parentId, UUID childId) {
+
+    }
+
+    // Child-targeted event tagged only with its own id, so it is never sourced into the parent stream.
+    record CollectionStartedUntagged(UUID parentId, @EventTag(key = "childId") UUID childId) {
+
+    }
+
+    record DataCollected(@EventTag(key = "myAggregate") UUID parentId, UUID childId) {
+
+    }
+
+    @EventSourcedEntity(tagKey = "myAggregate")
+    static class ParentAggregate {
+
+        @SuppressWarnings("unused")
+        private UUID parentId;
+
+        @EntityMember
+        private ChildEntity child;
+
+        @EventSourcingHandler
+        void on(ParentInitialized event) {
+            this.parentId = event.parentId();
+        }
+
+        @EventSourcingHandler
+        void on(ChildAdded event) {
+            this.child = new ChildEntity(event.childId());
+        }
+
+        @EntityCreator
+        protected ParentAggregate(@InjectEntityId UUID parentId) {
+            this.parentId = parentId;
+        }
+    }
+
+    static class ChildEntity {
+
+        @SuppressWarnings("unused")
+        private final UUID childId;
+        private boolean collecting;
+
+        ChildEntity(UUID childId) {
+            this.childId = childId;
+        }
+
+        @CommandHandler
+        public void handle(SaveCollectedData cmd, EventAppender appender) {
+            if (!collecting) {
+                throw new IllegalStateException("Child is not collecting");
+            }
+            appender.append(new DataCollected(cmd.parentId(), cmd.childId()));
+        }
+
+        @EventSourcingHandler
+        void on(CollectionStarted event) {
+            this.collecting = true;
+        }
+
+        @EventSourcingHandler
+        void on(CollectionStartedUntagged event) {
+            this.collecting = true;
+        }
+    }
+
+    AxonTestFixture fixture() {
+        return AxonTestFixture.with(EventSourcingConfigurer.create().registerEntity(
+                EventSourcedEntityModule.autodetected(UUID.class, ParentAggregate.class)));
+    }
+
+    // then: with UUID ids and no routingKey, a child event carrying the parent tag evolves the child,
+    // so the child is "collecting" and the command succeeds.
+    @Test
+    void childEventWithParentTagEvolvesChild() {
+        fixture().given()
+                 .events(new ParentInitialized(PARENT_ID),
+                         new ChildAdded(PARENT_ID, CHILD_ID),
+                         new CollectionStarted(PARENT_ID, CHILD_ID))
+                 .when()
+                 .command(new SaveCollectedData(PARENT_ID, CHILD_ID))
+                 .then()
+                 .success()
+                 .events(new DataCollected(PARENT_ID, CHILD_ID));
+    }
+
+    // then: a child event without the parent tag is never sourced, so the child stays un-evolved
+    // and the command is rejected.
+    @Test
+    void childEventWithoutParentTagIsNeverSourced() {
+        fixture().given()
+                 .events(new ParentInitialized(PARENT_ID),
+                         new ChildAdded(PARENT_ID, CHILD_ID),
+                         new CollectionStartedUntagged(PARENT_ID, CHILD_ID))
+                 .when()
+                 .command(new SaveCollectedData(PARENT_ID, CHILD_ID))
+                 .then()
+                 .exception(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
Corrects the multi-entity migration guide, which wrongly claimed the Axon Framework 5 default for delivering events to child entities is equivalent to `ForwardAll`; it is routing-key based (only a single child without a `routingKey` gets every event), and a troubleshooting note now explains the two gates an event must pass: it must be sourced into the parent (every event, parent-level and child-level, must carry the parent `tagKey`) and then routed to the child. Extends the `AddEventTagAnnotation` OpenRewrite recipe to follow `@AggregateMember`/`@EntityMember` fields (including `List`/`Map` elements) and tag child events with the parent's tag, so a migrated child `@EventSourcingHandler` is actually sourced instead of silently skipped. Adds `AxonTestFixture` tests covering single and collection routing, the fail-fast on a collection without a `routingKey`, a broadcast matcher, the tagging/sourcing gate, UUID identifiers, and the Spring `@EventSourced` stereotype, plus a recipe test for the member-tagging behaviour.