### PR TITLE
Pin `actions/add-to-project` to `v2` instead of `main`

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - uses: actions/add-to-project@main
+      - uses: actions/add-to-project@v2
         with:
           project-url: https://github.com/orgs/Axoniq/projects/25
           github-token: ${{ secrets.ADD_PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary
- `actions/add-to-project` was pinned to `@main` (a branch ref) instead of a version tag, so Dependabot's `github-actions` ecosystem had no version to compare against and could never open an update PR for it
- switches it to `@v2`, matching the version-tag convention every other action in this repo's workflows already uses, so it stays on Dependabot's radar for future major bumps

## Verification
- confirmed v2.0.0's `action.yml` still exposes the three inputs this workflow uses (`project-url`, `github-token`, `labeled`) unchanged
- the v1 -> v2 major bump upstream was an internal Node 24 runtime upgrade, not an input/output breaking change

## Test plan
- [ ] trigger the workflow (label a PR with `Type: Dependency Upgrade`) and confirm the "Add PR to project" step still succeeds