### PR TITLE
[#3728] Finalize `AnnotatedSaga` `EventHandlingComponent` implementations

### DIFF
--- a/legacy/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
+++ b/legacy/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
@@ -102,7 +102,7 @@ public class AnnotatedSaga<T> implements Saga<T>, SagaLifecycle {
 
     @Override
     public Set<QualifiedName> supportedEvents() {
-        throw new UnsupportedOperationException("TODO #3728");
+        return metaModel.supportedEvents();
     }
 
     @Override

--- a/legacy/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
+++ b/legacy/src/main/java/org/axonframework/modelling/saga/AnnotatedSaga.java
@@ -106,11 +106,6 @@ public class AnnotatedSaga<T> implements Saga<T>, SagaLifecycle {
     }
 
     @Override
-    public Object sequenceIdentifierFor(EventMessage event, ProcessingContext context) {
-        throw new UnsupportedOperationException("TODO #3728");
-    }
-
-    @Override
     public MessageStream.Empty<Message> handle(EventMessage event, ProcessingContext context) {
         if (!isActive) {
             return MessageStream.empty();

--- a/legacy/src/main/java/org/axonframework/modelling/saga/Saga.java
+++ b/legacy/src/main/java/org/axonframework/modelling/saga/Saga.java
@@ -18,17 +18,18 @@ package org.axonframework.modelling.saga;
 
 import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventHandlingComponent;
+import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.replay.ResetContext;
 import org.axonframework.messaging.eventhandling.replay.ResetNotSupportedException;
-import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 /**
- * Interface describing an implementation of a Saga. Sagas are instances that handle events and may possibly produce
- * new commands or have other side effects. Typically, Sagas are used to manage long running business transactions.
+ * Interface describing an implementation of a Saga. Sagas are instances that handle events and may possibly produce new
+ * commands or have other side effects. Typically, Sagas are used to manage long running business transactions.
  * <p/>
  * Multiple instances of a single type of Saga may exist. In that case, each Saga will be managing a different
  * transaction. Sagas need to be associated with concepts in order to receive specific events. These associations are
@@ -57,8 +58,8 @@ public interface Saga<T> extends EventHandlingComponent {
     /**
      * Execute the given {@code invocation} against the root object of this Saga instance.
      *
-     * @param invocation the function to invoke. The root object of the Saga is input to the function, the result is
-     *                   the result of the execution.
+     * @param invocation the function to invoke. The root object of the Saga is input to the function, the result is the
+     *                   result of the execution.
      * @param <R>        The type of return value expected
      * @return The result of the invocation on the Saga.
      */
@@ -78,6 +79,22 @@ public interface Saga<T> extends EventHandlingComponent {
      * @return {@code true} if this saga is active, {@code false} otherwise.
      */
     boolean isActive();
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * A single {@code Saga} instance never determines its own sequencing, as the component managing the sagas is in
+     * charge of the sequencing Hence, this method throws an {@link UnsupportedOperationException} whenever invoked.
+     *
+     * @throws UnsupportedOperationException since sequencing is dictated by the component managing the sagas, not the
+     *                                       saga itself
+     */
+    @Override
+    default Object sequenceIdentifierFor(EventMessage event, ProcessingContext context) {
+        throw new UnsupportedOperationException(
+                "Sequencing is a concern of the component managing Saga instances, not the Saga itself."
+        );
+    }
 
     @Override
     default boolean supportsReset() {

--- a/legacy/src/main/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactory.java
+++ b/legacy/src/main/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactory.java
@@ -16,8 +16,10 @@
 
 package org.axonframework.modelling.saga.metamodel;
 
+import org.axonframework.common.StringUtils;
 import org.axonframework.messaging.core.ClassBasedMessageTypeResolver;
 import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
 import org.axonframework.messaging.core.annotation.ClasspathParameterResolverFactory;
@@ -27,12 +29,14 @@ import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.annotation.EventHandlingMember;
 import org.axonframework.modelling.saga.AssociationValue;
 import org.axonframework.modelling.saga.SagaMethodMessageHandlingMember;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -117,11 +121,24 @@ public class AnnotationSagaMetaModelFactory implements SagaMetaModelFactory {
     private class InspectedSagaModel<T> implements SagaModel<T> {
 
         private final List<MessageHandlingMember<? super T>> handlers;
+        private final Set<QualifiedName> supportedEvents;
 
         public InspectedSagaModel(
                 List<MessageHandlingMember<? super T>> handlers
         ) {
             this.handlers = handlers;
+            this.supportedEvents = handlers.stream()
+                                           .filter(handler -> handler.canHandleMessageType(EventMessage.class))
+                                           .map(this::qualifiedNameOf)
+                                           .collect(Collectors.toUnmodifiableSet());
+        }
+
+        private QualifiedName qualifiedNameOf(MessageHandlingMember<? super T> handler) {
+            return handler.unwrap(EventHandlingMember.class)
+                          .map(EventHandlingMember::eventName)
+                          .filter(StringUtils::nonEmpty)
+                          .map(QualifiedName::new)
+                          .orElseGet(() -> MESSAGE_TYPE_RESOLVER.resolveOrThrow(handler.payloadType()).qualifiedName());
         }
 
         @Override
@@ -155,6 +172,11 @@ public class AnnotationSagaMetaModelFactory implements SagaMetaModelFactory {
         @Override
         public SagaMetaModelFactory modelFactory() {
             return AnnotationSagaMetaModelFactory.this;
+        }
+
+        @Override
+        public Set<QualifiedName> supportedEvents() {
+            return supportedEvents;
         }
     }
 }

--- a/legacy/src/main/java/org/axonframework/modelling/saga/metamodel/SagaModel.java
+++ b/legacy/src/main/java/org/axonframework/modelling/saga/metamodel/SagaModel.java
@@ -17,12 +17,14 @@
 package org.axonframework.modelling.saga.metamodel;
 
 import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.saga.AssociationValue;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Interface of a model that describes a Saga of type {@code T}. Use the SagaModel to obtain associations and
@@ -68,4 +70,14 @@ public interface SagaModel<T> {
      * @return The factory that made this model
      */
     SagaMetaModelFactory modelFactory();
+
+    /**
+     * Returns the {@link QualifiedName QualifiedNames} of all {@link EventMessage events} supported by the Saga
+     * described by this model, that is, the events for which the Saga declares a
+     * {@link org.axonframework.modelling.saga.SagaEventHandler @SagaEventHandler} method.
+     *
+     * @return the {@link QualifiedName QualifiedNames} of all {@link EventMessage events} supported by the Saga
+     * described by this model
+     */
+    Set<QualifiedName> supportedEvents();
 }

--- a/legacy/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
+++ b/legacy/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
@@ -290,6 +290,18 @@ class AnnotatedSagaTest {
     }
 
     @Nested
+    class Sequencing {
+
+        @Test
+        void sequenceIdentifierForThrowsUnsupportedOperationException() {
+            var event = new GenericEventMessage(new MessageType("event"), new RegularEvent("id"));
+
+            assertThatThrownBy(() -> testSubject.sequenceIdentifierFor(event, StubProcessingContext.forMessage(event)))
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    @Nested
     class SagaLifecycleScoping {
 
         @Test

--- a/legacy/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
+++ b/legacy/src/test/java/org/axonframework/modelling/saga/AnnotatedSagaTest.java
@@ -19,6 +19,7 @@ package org.axonframework.modelling.saga;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.Metadata;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.interception.annotation.NoMoreInterceptors;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -265,6 +266,26 @@ class AnnotatedSagaTest {
                     new AssociationValue("propertyName", "id"),
                     new AssociationValue("someOtherProperty", "3")
             );
+        }
+    }
+
+    @Nested
+    class SupportedEvents {
+
+        @Test
+        void returnsQualifiedNamesOfAllSagaEventHandlerAnnotatedMethods() {
+            assertThat(testSubject.supportedEvents()).containsExactlyInAnyOrder(
+                    new QualifiedName(RegularEvent.class),
+                    new QualifiedName(UniformAccessEvent.class),
+                    new QualifiedName(EventWithoutProperties.class),
+                    new QualifiedName(SagaEndEvent.class)
+            );
+        }
+
+        @Test
+        void supportsReflectsSupportedEvents() {
+            assertThat(testSubject.supports(new QualifiedName(RegularEvent.class))).isTrue();
+            assertThat(testSubject.supports(new QualifiedName(Object.class))).isFalse();
         }
     }
 

--- a/legacy/src/test/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactoryTest.java
+++ b/legacy/src/test/java/org/axonframework/modelling/saga/metamodel/AnnotationSagaMetaModelFactoryTest.java
@@ -18,6 +18,7 @@ package org.axonframework.modelling.saga.metamodel;
 
 import org.axonframework.common.AxonException;
 import org.axonframework.common.FutureUtils;
+import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
 import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
@@ -33,7 +34,9 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Optional;
+import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.axonframework.messaging.eventhandling.EventTestUtils.asEventMessage;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -100,6 +103,39 @@ class AnnotationSagaMetaModelFactoryTest {
         assertEquals(NoMoreInterceptors.class, testSubject.chainedInterceptor(MySaga.class).getClass());
     }
 
+    @Nested
+    class SupportedEvents {
+
+        @Test
+        void returnsAQualifiedNameForEverySagaEventHandlerAnnotatedMethod() {
+            SagaModel<MySaga> sagaModel = testSubject.modelOf(MySaga.class);
+
+            assertThat(sagaModel.supportedEvents()).containsExactlyInAnyOrder(
+                    new QualifiedName(MySagaStartEvent.class),
+                    new QualifiedName(MySagaUpdateEvent.class),
+                    new QualifiedName(MySagaEndEvent.class)
+            );
+        }
+
+        @Test
+        void returnsAnEmptySetForASagaWithoutEventHandlers() {
+            SagaModel<SagaWithoutEventHandlers> sagaModel = testSubject.modelOf(SagaWithoutEventHandlers.class);
+
+            assertThat(sagaModel.supportedEvents()).isEmpty();
+        }
+
+        @Test
+        void includesInheritedSagaEventHandlerAnnotatedMethods() {
+            SagaModel<MySagaWithErrorHandler> sagaModel = testSubject.modelOf(MySagaWithErrorHandler.class);
+
+            assertThat(sagaModel.supportedEvents()).containsExactlyInAnyOrder(
+                    new QualifiedName(MySagaStartEvent.class),
+                    new QualifiedName(MySagaUpdateEvent.class),
+                    new QualifiedName(MySagaEndEvent.class)
+            );
+        }
+    }
+
     public static class MySaga {
 
         @StartSaga
@@ -127,6 +163,10 @@ class AnnotationSagaMetaModelFactoryTest {
         public void on(Exception e) {
             logger.info("caught", e);
         }
+    }
+
+    public static class SagaWithoutEventHandlers {
+
     }
 
     public abstract static class MySagaEvent {


### PR DESCRIPTION
This PR finalizes the `AnnotatedSaga`, as it was ported by #4991, to be a working `EventHandlingComponent` according to this contract.
To that end, the `Saga#supportedEvents` and `Saga#sequenceIdentifierFor` methods have received their final implementation.

The `supportedEvents` operation delegates the request to the `SagaModel`, which is able to deduce the supported events through handlers given to the `InspectedSagaModel`.

The `sequenceIdentifierFor` still throws an `UnsupportedOperationException`, but now better documented.
This is desirable, as `Sagas`/`AnnotatedSagas` will **always** be managed by the `SagaManager`, which itself is an `EventHandlingComponent` dictates the sequencing entirely.
