### PR TITLE
Fix for appending events in `SubscribingEventProcessor`

### DIFF
--- a/docs/reference-guide/modules/messaging-concepts/pages/processing-context.adoc
+++ b/docs/reference-guide/modules/messaging-concepts/pages/processing-context.adoc
@@ -84,6 +84,22 @@ The processing lifecycle consists of these phases, executed in order:
 * **Parallel actions**: Multiple actions within the same phase may execute in parallel.
 * **Phase completion**: All actions in a phase must complete before moving to the next phase.
 * **Failure handling**: If any action fails, subsequent phases are skipped and error handlers execute.
+* **Registering from within a phase**: An action may register further actions, but only for a phase with a higher order than the one it is running in. Registering for the phase currently running, or for one already passed, is rejected with an `IllegalStateException`.
+
+That last rule matters more often than it looks, because a handler is not always invoked in the phase it would expect. Events published with a `ProcessingContext` are delivered during that context's prepare-commit phase, and a subscribing event processor hands them to its handlers there. Such a handler runs *inside* prepare-commit and so cannot register for it.
+
+The way to attach work to the caller's lifecycle from that position is a custom phase in the gap above the one you are in. `Phase` is an interface over an arbitrary order, and the default phases leave 10000 between them, so there is always room:
+
+[source,java]
+----
+private static final ProcessingLifecycle.Phase AFTER_PREPARE_COMMIT =
+        () -> ProcessingLifecycle.DefaultPhases.PREPARE_COMMIT.order() + 5_000;
+
+// From a handler invoked during PREPARE_COMMIT:
+context.runOn(AFTER_PREPARE_COMMIT, ctx -> { /* still inside the caller's transaction */ });
+----
+
+The action runs once every prepare-commit action is done and before the context commits. Two framework components use exactly this: an `axon-legacy` saga is written in such a phase, and the event store hands its appended events to the storage engine in another one, ordered last so that anything appending from an earlier custom phase is still included.
 
 === Registering lifecycle actions
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -22,6 +22,7 @@ import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.core.Context.ResourceKey;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.axonframework.messaging.eventstreaming.Tag;
@@ -50,9 +51,11 @@ import static org.axonframework.common.ObjectUtils.getOrDefault;
  * <p>
  * While {@link #source(SourcingCondition) sourcing} it will map the {@link SourcingCondition} into an
  * {@link AppendCondition} for {@link #appendEvent(EventMessage) appending}, taking into account several sourcing
- * invocation might have occurred in the same {@link ProcessingContext}. During
- * {@link #appendEvent(EventMessage) appending} it will pass along a collection of {@link EventMessage events} to an
- * {@link EventStorageEngine} is part of the prepare commit phase of the {@link ProcessingContext}.
+ * invocation might have occurred in the same {@link ProcessingContext}. Every event that is
+ * {@link #appendEvent(EventMessage) appended} is collected, and the collection is handed to the
+ * {@link EventStorageEngine} as a single batch during the {@link Phases#APPEND_EVENTS} phase of the
+ * {@code ProcessingContext}. That phase follows prepare-commit, so a component invoked during prepare-commit can
+ * still append. Appending after it has run is rejected.
  *
  * @author Steven van Beelen
  * @author John Hendrikx
@@ -155,6 +158,14 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
 
     @Override
     public void appendEvent(EventMessage eventMessage) {
+        if (Boolean.TRUE.equals(processingContext.getResource(prepareCommitExecuted))) {
+            throw new IllegalStateException(
+                    "Cannot append event [" + eventMessage.identifier() + "], as the events of this ProcessingContext "
+                            + "were already handed to the EventStorageEngine during the "
+                            + Phases.APPEND_EVENTS + " phase. Append events no later than the "
+                            + ProcessingLifecycle.DefaultPhases.PREPARE_COMMIT + " phase."
+            );
+        }
         List<TaggedEventMessage<?>> eventQueue = processingContext.computeResourceIfAbsent(
                 eventQueueKey,
                 () -> {
@@ -195,8 +206,20 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
         return ObjectUtils.getOrDefault(processingContext.getResource(EntityMetamodel.CREATE_WITHOUT_LOAD), false);
     }
 
+    /**
+     * Registers the step handing every event appended within this {@link ProcessingContext} to the
+     * {@link EventStorageEngine}, as a single batch.
+     * <p>
+     * It runs in {@link Phases#APPEND_EVENTS}, the last phase before
+     * {@link ProcessingLifecycle.DefaultPhases#COMMIT COMMIT}, rather than during
+     * {@link ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}, so that everything able to append has
+     * run by the time the batch is handed over. {@link org.axonframework.messaging.eventhandling.SimpleEventBus}
+     * delivers events published with a context during prepare-commit and a subscribing event processor hands them to
+     * its handlers there, so those handlers would otherwise be appending into a batch the engine already received.
+     */
     private void attachAppendEventsStep() {
-        processingContext.onPrepareCommit(
+        processingContext.on(
+                Phases.APPEND_EVENTS,
                 context -> {
                     AppendCondition appendCondition = resolveAppendCondition(context);
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransaction.java
@@ -162,7 +162,7 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
             throw new IllegalStateException(
                     "Cannot append event [" + eventMessage.identifier() + "], as the events of this ProcessingContext "
                             + "were already handed to the EventStorageEngine during the "
-                            + Phases.APPEND_EVENTS + " phase. Append events no later than the "
+                            + EventStoreTransaction.APPEND_EVENTS + " phase. Append events no later than the "
                             + ProcessingLifecycle.DefaultPhases.PREPARE_COMMIT + " phase."
             );
         }
@@ -210,7 +210,7 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
      * Registers the step handing every event appended within this {@link ProcessingContext} to the
      * {@link EventStorageEngine}, as a single batch.
      * <p>
-     * It runs in {@link Phases#APPEND_EVENTS}, the last phase before
+     * It runs in {@link EventStoreTransaction#APPEND_EVENTS}, the last phase before
      * {@link ProcessingLifecycle.DefaultPhases#COMMIT COMMIT}, rather than during
      * {@link ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}, so that everything able to append has
      * run by the time the batch is handed over. {@link org.axonframework.messaging.eventhandling.SimpleEventBus}
@@ -219,7 +219,7 @@ public class DefaultEventStoreTransaction implements EventStoreTransaction {
      */
     private void attachAppendEventsStep() {
         processingContext.on(
-                Phases.APPEND_EVENTS,
+                EventStoreTransaction.APPEND_EVENTS,
                 context -> {
                     AppendCondition appendCondition = resolveAppendCondition(context);
 

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -61,7 +61,8 @@ public interface EventStorageEngine extends DescribableComponent {
      * By default, this method creates a {@link List} of the offered events and then invokes
      * {@link #appendEvents(AppendCondition, ProcessingContext, List)}.
      * <p>
-     * Called during the {@link org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT} phase.
+     * Called during the {@link EventStoreTransaction.Phases#APPEND_EVENTS APPEND_EVENTS} phase, which follows
+     * {@link org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}.
      *
      * @param condition The condition describing the transactional requirements for the append transaction
      * @param context   The current {@link ProcessingContext}, if any.
@@ -85,7 +86,8 @@ public interface EventStorageEngine extends DescribableComponent {
      * future will complete exceptionally, indicating such conflict. Other implementations may delay such checks until
      * the {@link AppendTransaction#commit()} is called.
      * <p>
-     * Called during the {@link org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT} phase.
+     * Called during the {@link EventStoreTransaction.Phases#APPEND_EVENTS APPEND_EVENTS} phase, which follows
+     * {@link org.axonframework.messaging.core.unitofwork.ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}.
      *
      * @param condition The condition describing the transactional requirements for the append transaction
      * @param context   The current {@link ProcessingContext}, if any.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStoreTransaction.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventstreaming.EventCriteria;
 import org.jspecify.annotations.Nullable;
@@ -154,4 +155,43 @@ public interface EventStoreTransaction {
      * transaction.
      */
     ConsistencyMarker appendPosition();
+
+    /**
+     * The {@link ProcessingLifecycle.Phase phases} an {@code EventStoreTransaction} uses on top of the
+     * {@link ProcessingLifecycle.DefaultPhases default phases}.
+     *
+     * @author Mateusz Nowak
+     * @since 5.0.0
+     */
+    enum Phases implements ProcessingLifecycle.Phase {
+
+        /**
+         * Phase in which the events {@link #appendEvent(EventMessage) appended} within a
+         * {@link org.axonframework.messaging.core.unitofwork.ProcessingContext} are handed to the
+         * {@link EventStorageEngine} as a single batch. Has an order of {@code 29000}.
+         * <p>
+         * It is deliberately the last phase before {@link ProcessingLifecycle.DefaultPhases#COMMIT COMMIT}, so that
+         * everything able to append in this context has run by the time the batch is handed over. That includes the
+         * actions of {@link ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}, where a subscribing
+         * event processor invokes its components, and any phase callers put in the gap above it, such as the write
+         * of an {@code axon-legacy} saga. Handing the batch over any earlier makes an append from one of those
+         * phases arrive too late to be stored.
+         * <p>
+         * Appending is no longer possible once this phase has run. Doing so is rejected rather than silently
+         * queued, since the batch has been handed to the {@code EventStorageEngine} at that point and an engine
+         * that flushes what it was given will never see the addition.
+         */
+        APPEND_EVENTS(29000);
+
+        private final int order;
+
+        Phases(int order) {
+            this.order = order;
+        }
+
+        @Override
+        public int order() {
+            return order;
+        }
+    }
 }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStoreTransaction.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStoreTransaction.java
@@ -40,6 +40,24 @@ import java.util.function.UnaryOperator;
 public interface EventStoreTransaction {
 
     /**
+     * Phase in which the events {@link #appendEvent(EventMessage) appended} within a
+     * {@link org.axonframework.messaging.core.unitofwork.ProcessingContext} are handed to the
+     * {@link EventStorageEngine} as a single batch. Has an order of {@code 29000}.
+     * <p>
+     * It is deliberately the last phase before {@link ProcessingLifecycle.DefaultPhases#COMMIT COMMIT}, so that
+     * everything able to append in this context has run by the time the batch is handed over. That includes the
+     * actions of {@link ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}, where a subscribing
+     * event processor invokes its components, and any phase callers put in the gap above it, such as the write
+     * of an {@code axon-legacy} saga. Handing the batch over any earlier makes an append from one of those
+     * phases arrive too late to be stored.
+     * <p>
+     * Appending is no longer possible once this phase has run. Doing so is rejected rather than silently
+     * queued, since the batch has been handed to the {@code EventStorageEngine} at that point and an engine
+     * that flushes what it was given will never see the addition.
+     */
+    ProcessingLifecycle.Phase APPEND_EVENTS = () -> 29000;
+
+    /**
      * Sources a {@link MessageStream} of type {@link EventMessage} based on the given {@code condition} that can be
      * used to rehydrate a model.
      * <p>
@@ -155,43 +173,4 @@ public interface EventStoreTransaction {
      * transaction.
      */
     ConsistencyMarker appendPosition();
-
-    /**
-     * The {@link ProcessingLifecycle.Phase phases} an {@code EventStoreTransaction} uses on top of the
-     * {@link ProcessingLifecycle.DefaultPhases default phases}.
-     *
-     * @author Mateusz Nowak
-     * @since 5.0.0
-     */
-    enum Phases implements ProcessingLifecycle.Phase {
-
-        /**
-         * Phase in which the events {@link #appendEvent(EventMessage) appended} within a
-         * {@link org.axonframework.messaging.core.unitofwork.ProcessingContext} are handed to the
-         * {@link EventStorageEngine} as a single batch. Has an order of {@code 29000}.
-         * <p>
-         * It is deliberately the last phase before {@link ProcessingLifecycle.DefaultPhases#COMMIT COMMIT}, so that
-         * everything able to append in this context has run by the time the batch is handed over. That includes the
-         * actions of {@link ProcessingLifecycle.DefaultPhases#PREPARE_COMMIT PREPARE_COMMIT}, where a subscribing
-         * event processor invokes its components, and any phase callers put in the gap above it, such as the write
-         * of an {@code axon-legacy} saga. Handing the batch over any earlier makes an append from one of those
-         * phases arrive too late to be stored.
-         * <p>
-         * Appending is no longer possible once this phase has run. Doing so is rejected rather than silently
-         * queued, since the batch has been handed to the {@code EventStorageEngine} at that point and an engine
-         * that flushes what it was given will never see the addition.
-         */
-        APPEND_EVENTS(29000);
-
-        private final int order;
-
-        Phases(int order) {
-            this.order = order;
-        }
-
-        @Override
-        public int order() {
-            return order;
-        }
-    }
 }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -793,24 +793,18 @@ class DefaultEventStoreTransactionTest {
         @Test
         void appendingOnceTheBatchWasHandedToTheStorageEngineIsRejected() {
             // given a unit of work appending during INVOCATION, and again from a commit-phase action
-            var failure = new AtomicReference<Throwable>();
             var uow = aUnitOfWork();
             uow.runOnInvocation(context -> defaultEventStoreTransactionFor(context).appendEvent(eventMessage(0)));
             uow.runOnCommit(context -> {
-                try {
-                    defaultEventStoreTransactionFor(context).appendEvent(eventMessage(1));
-                } catch (RuntimeException e) {
-                    failure.set(e);
-                }
+                assertThatThrownBy(() -> defaultEventStoreTransactionFor(context).appendEvent(eventMessage(1)))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("already handed to the EventStorageEngine");
             });
 
             // when
             awaitSuccessfulCompletion(uow.execute());
 
             // then the second append is refused rather than queued into a batch that was already handed over
-            assertThat(failure.get())
-                    .isInstanceOf(IllegalStateException.class)
-                    .hasMessageContaining("already handed to the EventStorageEngine");
             assertThat(sourcedPayloads(eventStorageEngine)).containsExactly("event-0");
         }
     }

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/DefaultEventStoreTransactionTest.java
@@ -45,6 +45,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -747,6 +748,114 @@ class DefaultEventStoreTransactionTest {
             });
             awaitSuccessfulCompletion(uow.execute());
         }
+    }
+
+    @Nested
+    class AppendingDuringPrepareCommit {
+
+        @Test
+        void aFirstEventAppendedDuringPrepareCommitIsStored() {
+            // given a unit of work whose first append happens while PREPARE_COMMIT is already running, which is
+            // where every component a SubscribingEventProcessor invokes finds itself: SimpleEventBus drains its
+            // queue in that phase, and the processor handles those events in that same context
+            var uow = aUnitOfWork();
+            uow.runOnPrepareCommit(context -> defaultEventStoreTransactionFor(context).appendEvent(eventMessage(0)));
+
+            // when
+            awaitSuccessfulCompletion(uow.execute());
+
+            // then appendEvent could attach its append step for the phase it was already in, and that step ran as
+            // a further pass of the phase
+            assertThat(sourcedPayloads(eventStorageEngine)).containsExactly("event-0");
+        }
+
+        @Test
+        void anEventAppendedByALaterPrepareCommitActionJoinsTheSameBatch() {
+            // given a first append during INVOCATION, and a second append from a prepare-commit action registered
+            // behind it, as a subscribing event handler appends after the command handler already did
+            var engine = new EagerFlushEventStorageEngine();
+            var uow = aUnitOfWork();
+            uow.runOnInvocation(context -> {
+                transactionFor(context, engine).appendEvent(eventMessage(0));
+                context.runOnPrepareCommit(c -> transactionFor(c, engine).appendEvent(eventMessage(1)));
+            });
+
+            // when
+            awaitSuccessfulCompletion(uow.execute());
+
+            // then the engine was handed both events at once, so an engine that flushes exactly what it is given
+            // stores them both. Handing over early loses the second one on such an engine, while SimpleEventBus has
+            // already delivered it to every subscriber.
+            assertThat(engine.recordedBatches).containsExactly(List.of("event-0", "event-1"));
+            assertThat(sourcedPayloads(engine)).containsExactly("event-0", "event-1");
+        }
+
+        @Test
+        void appendingOnceTheBatchWasHandedToTheStorageEngineIsRejected() {
+            // given a unit of work appending during INVOCATION, and again from a commit-phase action
+            var failure = new AtomicReference<Throwable>();
+            var uow = aUnitOfWork();
+            uow.runOnInvocation(context -> defaultEventStoreTransactionFor(context).appendEvent(eventMessage(0)));
+            uow.runOnCommit(context -> {
+                try {
+                    defaultEventStoreTransactionFor(context).appendEvent(eventMessage(1));
+                } catch (RuntimeException e) {
+                    failure.set(e);
+                }
+            });
+
+            // when
+            awaitSuccessfulCompletion(uow.execute());
+
+            // then the second append is refused rather than queued into a batch that was already handed over
+            assertThat(failure.get())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("already handed to the EventStorageEngine");
+            assertThat(sourcedPayloads(eventStorageEngine)).containsExactly("event-0");
+        }
+    }
+
+    /**
+     * Stands in for a storage engine that flushes exactly the batch it is handed, as
+     * {@code AggregateBasedJpaEventStorageEngine} does by persisting and flushing inside {@code appendEvents}. The
+     * in-memory engine instead closes over the list it is given and re-reads it when committing, which hides a batch
+     * that was handed over too early.
+     */
+    private static class EagerFlushEventStorageEngine extends InMemoryEventStorageEngine {
+
+        private final List<List<String>> recordedBatches = new CopyOnWriteArrayList<>();
+
+        @Override
+        public CompletableFuture<AppendTransaction<?>> appendEvents(AppendCondition condition,
+                                                                    @Nullable ProcessingContext context,
+                                                                    List<TaggedEventMessage<?>> events) {
+            recordedBatches.add(events.stream().map(event -> (String) event.event().payload()).toList());
+            return super.appendEvents(condition, context, List.copyOf(events));
+        }
+    }
+
+    private List<String> sourcedPayloads(EventStorageEngine engine) {
+        var sourced = new AtomicReference<MessageStream<? extends EventMessage>>();
+        var uow = aUnitOfWork();
+        uow.runOnInvocation(context -> sourced.set(
+                transactionFor(context, engine).source(SourcingCondition.conditionFor(TEST_AGGREGATE_CRITERIA))
+        ));
+        awaitSuccessfulCompletion(uow.execute());
+
+        var payloads = new ArrayList<String>();
+        FluxUtils.of(sourced.get()).doOnNext(entry -> payloads.add((String) entry.message().payload())).blockLast();
+        return payloads;
+    }
+
+    private EventStoreTransaction transactionFor(ProcessingContext processingContext, EventStorageEngine engine) {
+        return processingContext.computeResourceIfAbsent(
+                testEventStoreTransactionKey,
+                () -> new DefaultEventStoreTransaction(
+                        engine,
+                        processingContext,
+                        event -> new GenericTaggedEventMessage<>(event, Set.of(AGGREGATE_ID_TAG))
+                )
+        );
     }
 
     private EventStoreTransaction defaultEventStoreTransactionFor(ProcessingContext processingContext) {

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SimpleEventStoreTest.java
@@ -413,7 +413,7 @@ class SimpleEventStoreTest {
         }
 
         @Test
-        void subscriberExceptionRollsBackTransaction() {
+        void subscriberExceptionPreventsTheEventsFromReachingTheStorageEngine() {
             // given
             EventStorageEngine.AppendTransaction<?> mockAppendTransaction = mock();
             when(mockStorageEngine.appendEvents(any(), any(ProcessingContext.class), anyList()))
@@ -430,12 +430,13 @@ class SimpleEventStoreTest {
             uow.onPreInvocation(context -> testSubject.publish(context, testEvent));
             CompletableFuture<Void> result = uow.execute();
 
-            // then
+            // then subscribers are notified during prepare-commit, and the batch is handed over only after that
+            // phase, so a failing subscriber means the storage engine is never asked for a transaction at all
             ExecutionException exception = assertThrows(ExecutionException.class, () -> result.get(5, TimeUnit.SECONDS));
             assertSame(subscriberException, exception.getCause());
             assertThat(listener.getInvocationCount()).isEqualTo(1);
-            verify(mockAppendTransaction, never()).commit();
-            verify(mockAppendTransaction).rollback();
+            verify(mockStorageEngine, never()).appendEvents(any(), any(ProcessingContext.class), anyList());
+            verifyNoInteractions(mockAppendTransaction);
         }
 
         @Test

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycle.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycle.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
  * <p/>
  * Throughout the lifecycle of any process, actions need to be taken in different phases. Numerous
  * {@link DefaultPhases default phases} are defined that are used throughout the framework for these actions. The
- * {@link ProcessingLifecycle} has shorthand operations corresponding to these {@code DefaultPhases}. For example, the
+ * {@code ProcessingLifecycle} has shorthand operations corresponding to these {@code DefaultPhases}. For example, the
  * {@link #onPreInvocation(Function)} uses the {@link DefaultPhases#PRE_INVOCATION} phase.
  * <p/>
  * When the {@link ProcessingLifecycle#isStarted() ProcessingLifecycle is started}, the phases are invoked beginning
@@ -49,34 +49,34 @@ import java.util.function.Function;
 public interface ProcessingLifecycle {
 
     /**
-     * Returns {@code true} when this {@link ProcessingLifecycle} is started, {@code false} otherwise.
+     * Returns {@code true} when this {@code ProcessingLifecycle} is started, {@code false} otherwise.
      *
-     * @return {@code true} when this {@link ProcessingLifecycle} is started, {@code false} otherwise.
+     * @return {@code true} when this {@code ProcessingLifecycle} is started, {@code false} otherwise
      */
     boolean isStarted();
 
     /**
-     * Returns {@code true} when this {@link ProcessingLifecycle} is in error, {@code false} otherwise.
+     * Returns {@code true} when this {@code ProcessingLifecycle} is in error, {@code false} otherwise.
      * <p>
      * When {@code true}, the {@link #onError(ErrorHandler) registered ErrorHandlers} will be invoked.
      *
-     * @return {@code true} when this {@link ProcessingLifecycle} is in error, {@code false} otherwise.
+     * @return {@code true} when this {@code ProcessingLifecycle} is in error, {@code false} otherwise
      */
     boolean isError();
 
     /**
-     * Returns {@code true} when this {@link ProcessingLifecycle} is committed, {@code false} otherwise.
+     * Returns {@code true} when this {@code ProcessingLifecycle} is committed, {@code false} otherwise.
      *
-     * @return {@code true} when this {@link ProcessingLifecycle} is committed, {@code false} otherwise.
+     * @return {@code true} when this {@code ProcessingLifecycle} is committed, {@code false} otherwise
      */
     boolean isCommitted();
 
     /**
-     * Returns {@code true} when this {@link ProcessingLifecycle} is completed, {@code false} otherwise.
+     * Returns {@code true} when this {@code ProcessingLifecycle} is completed, {@code false} otherwise.
      * <p>
      * Note that this {@code ProcessingLifecycle} is marked as completed for a successful and failed completion.
      *
-     * @return {@code true} when this {@link ProcessingLifecycle} is completed, {@code false} otherwise.
+     * @return {@code true} when this {@code ProcessingLifecycle} is completed, {@code false} otherwise
      */
     boolean isCompleted();
 
@@ -95,12 +95,12 @@ public interface ProcessingLifecycle {
      * interface over an arbitrary order and the {@link DefaultPhases} leave {@code 10000} between them, so such an
      * action still runs once the current {@code Phase} completed and before the next default one begins.
      *
-     * @param phase  The {@link Phase} to execute the given {@code action} in.
-     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
-     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
-     * @throws IllegalStateException when the given {@code phase} has an {@link Phase#order() order} at or below that
-     *                               of the {@code Phase} this {@link ProcessingLifecycle} is currently in
+     * @param phase  the {@link Phase} to execute the given {@code action} in
+     * @param action the {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when the given {@code phase} has an {@link Phase#order() order} at or below that of
+     *                               the {@code Phase} this {@code ProcessingLifecycle} is currently in
      */
     ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action);
 
@@ -110,8 +110,10 @@ public interface ProcessingLifecycle {
      * Use this operation when there is no need for a return value of the registered {@code action}.
      *
      * @param phase  The {@link Phase} to execute the given {@code action} in.
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return This {@code ProcessingLifecycle} instance for fluent interfacing.
+     * @throws IllegalStateException when the given {@code phase} has an {@link Phase#order() order} at or below that of
+     *                               the {@code Phase} this {@code ProcessingLifecycle} is currently in
      */
     default ProcessingLifecycle runOn(Phase phase, Consumer<ProcessingContext> action) {
         return on(phase, c -> {
@@ -126,9 +128,11 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when the return value of the {@code action} is important.
      *
-     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
-     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action the {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing.
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#PRE_INVOCATION} phase
      */
     default ProcessingLifecycle onPreInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.PRE_INVOCATION, action);
@@ -140,8 +144,10 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when there is no need for a return value of the registered {@code action}.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing.
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#PRE_INVOCATION} phase
      */
     default ProcessingLifecycle runOnPreInvocation(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.PRE_INVOCATION, action);
@@ -152,9 +158,11 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when the return value of the {@code action} is important.
      *
-     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
-     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action the {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#INVOCATION} phase
      */
     default ProcessingLifecycle onInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.INVOCATION, action);
@@ -165,8 +173,10 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when there is no need for a return value of the registered {@code action}.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#INVOCATION} phase
      */
     default ProcessingLifecycle runOnInvocation(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.INVOCATION, action);
@@ -178,9 +188,11 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when the return value of the {@code action} is important.
      *
-     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
-     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action the {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#POST_INVOCATION} phase
      */
     default ProcessingLifecycle onPostInvocation(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.POST_INVOCATION, action);
@@ -192,8 +204,10 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when there is no need for a return value of the registered {@code action}.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#POST_INVOCATION} phase
      */
     default ProcessingLifecycle runOnPostInvocation(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.POST_INVOCATION, action);
@@ -205,9 +219,11 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when the return value of the {@code action} is important.
      *
-     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
-     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action the {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#PREPARE_COMMIT} phase
      */
     default ProcessingLifecycle onPrepareCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.PREPARE_COMMIT, action);
@@ -219,8 +235,10 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when there is no need for a return value of the registered {@code action}.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#PREPARE_COMMIT} phase
      */
     default ProcessingLifecycle runOnPrepareCommit(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.PREPARE_COMMIT, action);
@@ -231,9 +249,11 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when the return value of the {@code action} is important.
      *
-     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
-     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action the {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#COMMIT} phase
      */
     default ProcessingLifecycle onCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.COMMIT, action);
@@ -244,8 +264,10 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when there is no need for a return value of the registered {@code action}.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#COMMIT} phase
      */
     default ProcessingLifecycle runOnCommit(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.COMMIT, action);
@@ -257,9 +279,11 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when the return value of the {@code action} is important.
      *
-     * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
-     *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action the {@link Function} that's given the active {@link ProcessingContext} and returns a
+     *               {@link CompletableFuture} for chaining purposes and to carry the action's result
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#AFTER_COMMIT} phase
      */
     default ProcessingLifecycle onAfterCommit(Function<ProcessingContext, CompletableFuture<?>> action) {
         return on(DefaultPhases.AFTER_COMMIT, action);
@@ -271,45 +295,47 @@ public interface ProcessingLifecycle {
      * <p>
      * Use this operation when there is no need for a return value of the registered {@code action}.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
+     * @throws IllegalStateException when this {@code ProcessingLifecycle's} phase is on or below the
+     *                               {@link DefaultPhases#AFTER_COMMIT} phase
      */
     default ProcessingLifecycle runOnAfterCommit(Consumer<ProcessingContext> action) {
         return runOn(DefaultPhases.AFTER_COMMIT, action);
     }
 
     /**
-     * Registers the provided {@code action} to be executed when this {@link ProcessingLifecycle} encounters an error
+     * Registers the provided {@code action} to be executed when this {@code ProcessingLifecycle} encounters an error
      * during the action of any {@link Phase}. This includes failures from actions registered through
      * {@link #whenComplete(Consumer)}.
      * <p>
      * When the given {@link ErrorHandler ErrorHandlers} are invoked {@link #isError()} and {@link #isCompleted()} will
      * return {@code true}.
      *
-     * @param action The error handler to execute when this {@link ProcessingLifecycle} encounters an error during phase
-     *               execution.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action the error handler to execute when this {@code ProcessingLifecycle} encounters an error during phase
+     *               execution
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
      */
     ProcessingLifecycle onError(ErrorHandler action);
 
     /**
-     * Registers the provided {@code action} to be executed when this {@link ProcessingLifecycle} completes <b>all</b>
+     * Registers the provided {@code action} to be executed when this {@code ProcessingLifecycle} completes <b>all</b>
      * registered actions.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
      */
     ProcessingLifecycle whenComplete(Consumer<ProcessingContext> action);
 
     /**
      * Registers the provided {@code action} to be executed {@link #onError(ErrorHandler) on error} of <b>and</b>
-     * {@link #whenComplete(Consumer) when completing} this {@link ProcessingLifecycle}.
+     * {@link #whenComplete(Consumer) when completing} this {@code ProcessingLifecycle}.
      * <p>
      * Note that if the given {@code action} throws an exception when completing this {@code ProcessingLifecycle} it
      * will be invoked <em>again</em> as an on {@link ErrorHandler}.
      *
-     * @param action A {@link Consumer} that's given the active {@link ProcessingContext} to perform its action.
-     * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @param action a {@link Consumer} that's given the active {@link ProcessingContext} to perform its action
+     * @return this {@code ProcessingLifecycle} instance for fluent interfacing
      */
     default ProcessingLifecycle doFinally(Consumer<ProcessingContext> action) {
         onError((c, p, e) -> action.accept(c));
@@ -319,7 +345,7 @@ public interface ProcessingLifecycle {
 
     /**
      * Functional interface describing an operation that's invoked when an error is detected within the
-     * {@link ProcessingLifecycle}.
+     * {@code ProcessingLifecycle}.
      *
      * @author Allard Buijze
      * @author Gerard Klijs
@@ -333,21 +359,21 @@ public interface ProcessingLifecycle {
     interface ErrorHandler {
 
         /**
-         * Invoked when an error is detected in a {@link ProcessingLifecycle} and it has been aborted.
+         * Invoked when an error is detected in a {@code ProcessingLifecycle} and it has been aborted.
          * <p>
          * In this state, the lifecycle will <b>always</b> return {@code true} for {@link ProcessingContext#isError()}
          * and {@link ProcessingContext#isCompleted()}.
          *
-         * @param processingContext The context in which the error occurred.
-         * @param phase             The phase used to register the handler which caused the {@link ProcessingLifecycle}
-         *                          to fail.
-         * @param error             The exception or error describing the cause.
+         * @param processingContext the context in which the error occurred
+         * @param phase             the phase used to register the handler which caused the {@code ProcessingLifecycle}
+         *                          to fail
+         * @param error             the exception or error describing the cause
          */
         void handle(ProcessingContext processingContext, Phase phase, Throwable error);
     }
 
     /**
-     * Interface describing a possible phase for the {@link ProcessingLifecycle} to perform steps in.
+     * Interface describing a possible phase for the {@code ProcessingLifecycle} to perform steps in.
      * <p>
      * Lifecycle actions are invoked in the {@link #order()} of their respective phase, where action in phases with the
      * same order may be invoked in parallel.
@@ -366,7 +392,7 @@ public interface ProcessingLifecycle {
          * The order of this phase compared to other phases. Phases with the same order are considered "simultaneous"
          * and may have their handlers invoked in parallel.
          *
-         * @return The {@code int} describing the relative order of this phase.
+         * @return the {@code int} describing the relative order of this phase
          */
         int order();
 
@@ -374,10 +400,10 @@ public interface ProcessingLifecycle {
          * Checks if the {@link Phase#order()} of {@code this Phase} is <b>smaller</b> than the order of the
          * {@code other}. Returns {@code true} if this is the case and {@code false} otherwise.
          *
-         * @param other The {@link Phase} to validate if its {@link Phase#order() order} is larger than the order of
-         *              {@code this Phase}.
+         * @param other the {@code Phase} to validate if its {@link Phase#order() order} is larger than the order of
+         *              {@code this Phase}
          * @return {@code true} if the {@link Phase#order()} of {@code this Phase} is <b>smaller</b> than the order of
-         * the {@code other Phase}.
+         * the {@code other Phase}
          */
         default boolean isBefore(Phase other) {
             return this.order() < other.order();
@@ -387,10 +413,10 @@ public interface ProcessingLifecycle {
          * Checks if the {@link Phase#order()} of {@code this Phase} is <b>larger</b> than the order of the
          * {@code other}. Returns {@code true} if this is the case and {@code false} otherwise.
          *
-         * @param other The {@link Phase} to validate if its {@link Phase#order() order} is smaller than the order of
-         *              {@code this Phase}.
+         * @param other the {@code Phase} to validate if its {@link Phase#order() order} is smaller than the order of
+         *              {@code this Phase}
          * @return {@code true} if the {@link Phase#order()} of {@code this Phase} is <b>larger</b> than the order of
-         * the {@code other Phase}.
+         * the {@code other Phase}
          */
         default boolean isAfter(Phase other) {
             return this.order() > other.order();
@@ -398,7 +424,7 @@ public interface ProcessingLifecycle {
     }
 
     /**
-     * Default phases used for the shorthand methods in the {@link ProcessingLifecycle}.
+     * Default phases used for the shorthand methods in the {@code ProcessingLifecycle}.
      *
      * @author Allard Buijze
      * @author Gerard Klijs
@@ -423,16 +449,16 @@ public interface ProcessingLifecycle {
          */
         POST_INVOCATION(10000),
         /**
-         * Phase used to contain actions to prepare the commit of the {@link ProcessingLifecycle}. Has an order of
+         * Phase used to contain actions to prepare the commit of the {@code ProcessingLifecycle}. Has an order of
          * {@code 20000}.
          */
         PREPARE_COMMIT(20000),
         /**
-         * Phase used to contain actions to commit of the {@link ProcessingLifecycle}. Has an order of {@code 30000}.
+         * Phase used to contain actions to commit of the {@code ProcessingLifecycle}. Has an order of {@code 30000}.
          */
         COMMIT(30000),
         /**
-         * Phase used to contain actions to execute after the commit of the {@link ProcessingLifecycle}. Has an order of
+         * Phase used to contain actions to execute after the commit of the {@code ProcessingLifecycle}. Has an order of
          * {@code 40000}.
          */
         AFTER_COMMIT(40000);

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycle.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/ProcessingLifecycle.java
@@ -85,11 +85,22 @@ public interface ProcessingLifecycle {
      * {@link CompletableFuture} returned by the {@code action} to compose actions and to carry the action's result.
      * <p>
      * Use this operation when the return value of the {@code action} is important.
+     * <p>
+     * An action may register further actions while it runs, but only for a {@code Phase} with a higher
+     * {@link Phase#order() order} than the one it is running in. Registering for the {@code Phase} currently running,
+     * or for one already passed, is rejected.
+     * <p>
+     * A component that is itself invoked from within a late {@code Phase} therefore cannot register for that same
+     * {@code Phase}. It can register for a custom {@code Phase} ordered in the gap above it: {@code Phase} is an
+     * interface over an arbitrary order and the {@link DefaultPhases} leave {@code 10000} between them, so such an
+     * action still runs once the current {@code Phase} completed and before the next default one begins.
      *
      * @param phase  The {@link Phase} to execute the given {@code action} in.
      * @param action The {@link Function} that's given the active {@link ProcessingContext} and returns a
      *               {@link CompletableFuture} for chaining purposes and to carry the action's result.
      * @return This {@link ProcessingLifecycle} instance for fluent interfacing.
+     * @throws IllegalStateException when the given {@code phase} has an {@link Phase#order() order} at or below that
+     *                               of the {@code Phase} this {@link ProcessingLifecycle} is currently in
      */
     ProcessingLifecycle on(Phase phase, Function<ProcessingContext, CompletableFuture<?>> action);
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventBus.java
@@ -88,6 +88,8 @@ import java.util.function.BiFunction;
 public class SimpleEventBus implements EventBus {
 
     private final Context.ResourceKey<List<EventMessage>> eventsKey = Context.ResourceKey.withLabel("EventBus_Events");
+    private final Context.ResourceKey<Boolean> eventsDeliveredKey =
+            Context.ResourceKey.withLabel("EventBus_EventsDelivered");
     private final EventSubscribers eventSubscribers = new EventSubscribers();
 
     /**
@@ -116,7 +118,15 @@ public class SimpleEventBus implements EventBus {
     }
 
     private void registerEventPublishingHooks(ProcessingContext context, List<? extends EventMessage> events) {
-        // Check if we're already in or past the commit phase - publishing is forbidden at this point
+        // Publishing is forbidden once the queue was drained: anything added now would never be delivered.
+        if (Boolean.TRUE.equals(context.getResource(eventsDeliveredKey))) {
+            throw new IllegalStateException(
+                    "It is not allowed to publish events after the events of this ProcessingContext were delivered "
+                            + "to their subscribers, which happens in the "
+                            + ProcessingLifecycle.DefaultPhases.PREPARE_COMMIT + " phase. Publish no later than that "
+                            + "phase, or start a new ProcessingContext."
+            );
+        }
         if (context.isCommitted()) {
             throw new IllegalStateException(
                     "It is not allowed to publish events when the ProcessingContext has already been committed. "
@@ -130,11 +140,20 @@ public class SimpleEventBus implements EventBus {
 
             context.onPrepareCommit(ctx -> {
                 List<EventMessage> queuedEvents = ctx.getResource(eventsKey);
-                return processEventsInPhase(queuedEvents, ctx, eventSubscribers::notifySubscribers);
+                CompletableFuture<Void> delivery =
+                        processEventsInPhase(queuedEvents, ctx, eventSubscribers::notifySubscribers);
+                // processEventsInPhase returns once its drain loop exhausted the queue, so no later addition to it
+                // will be picked up. Recording that here, rather than when the delivery completes, is what makes a
+                // publish from a still-running asynchronous subscriber fail instead of vanish.
+                ctx.putResource(eventsDeliveredKey, Boolean.TRUE);
+                return delivery;
             });
 
             // Clean up events resource on completion or error to free memory
-            context.doFinally(ctx -> ctx.removeResource(eventsKey));
+            context.doFinally(ctx -> {
+                ctx.removeResource(eventsKey);
+                ctx.removeResource(eventsDeliveredKey);
+            });
 
             return queue;
         });

--- a/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/StubProcessingContext.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/unitofwork/StubProcessingContext.java
@@ -49,6 +49,14 @@ import java.util.function.UnaryOperator;
  * <p>
  * The {@code putResource}/{@code updateResource}/{@code removeResource} operations mutate this instance, while
  * {@link #withResource(ResourceKey, Object)} branches: it returns a new context and leaves this one untouched.
+ * <p>
+ * {@link #moveToPhase(Phase)} mirrors {@link UnitOfWork} in entering a phase before running that phase's actions, and
+ * {@link #on(Phase, Function)} rejects the same registrations with the same exception, so that a test using this stub
+ * sees the phase rules production applies. In particular, an action running in a phase cannot register another action
+ * for that same phase, exactly as it cannot in a real {@code UnitOfWork}.
+ * <p>
+ * It remains a stub: actions of one phase are chained rather than run in parallel, and an action registered for a
+ * later phase that this call is already past building is not picked up.
  *
  * @author Allard Buijze
  */
@@ -110,15 +118,21 @@ public class StubProcessingContext implements ProcessingContext {
             return CompletableFuture.completedFuture(null);
         }
         ProcessingLifecycle.Phase initialPhase = currentPhase;
-        CompletableFuture<Object> result = phaseActions.keySet().stream()
-                                                       .filter(p -> p.isAfter(initialPhase)
-                                                               && p.order() <= phase.order())
-                                                       .sorted(Comparator.comparing(ProcessingLifecycle.Phase::order))
-                                                       .flatMap(p -> phaseActions.get(p).stream())
-                                                       .reduce(CompletableFuture.completedFuture(null),
-                                                               (cf, action) -> cf.thenCompose(v -> (CompletableFuture<Object>) action.apply(
-                                                                       this)),
-                                                               (cf1, cf2) -> cf2);
+        List<ProcessingLifecycle.Phase> phasesToRun =
+                phaseActions.keySet().stream()
+                            .filter(p -> p.isAfter(initialPhase) && p.order() <= phase.order())
+                            .sorted(Comparator.comparing(ProcessingLifecycle.Phase::order))
+                            .toList();
+
+        CompletableFuture<Object> result = CompletableFuture.completedFuture(null);
+        for (ProcessingLifecycle.Phase phaseToRun : phasesToRun) {
+            // Enter the phase before running its actions, as UnitOfWork does, so that an action asking to register
+            // another one is judged against the phase it is actually running in.
+            currentPhase = phaseToRun;
+            for (Function<ProcessingContext, CompletableFuture<?>> action : phaseActions.get(phaseToRun)) {
+                result = result.thenCompose(v -> (CompletableFuture<Object>) action.apply(this));
+            }
+        }
         currentPhase = phase;
         return result;
     }
@@ -127,7 +141,11 @@ public class StubProcessingContext implements ProcessingContext {
     public @NonNull ProcessingLifecycle on(@NonNull Phase phase,
                                   @NonNull Function<ProcessingContext, CompletableFuture<?>> action) {
         if (phase.order() <= currentPhase.order()) {
-            throw new IllegalArgumentException("Cannot register an action for a phase that has already passed");
+            throw new IllegalStateException(
+                    "Failed to register handler in phase " + phase + " (" + phase.order() + "). "
+                            + "ProcessingContext is already in phase " + currentPhase + " (" + currentPhase.order()
+                            + ")."
+            );
         }
         phaseActions.computeIfAbsent(phase, p -> new CopyOnWriteArrayList<>()).add(action);
         return this;

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
@@ -364,10 +364,10 @@ class SimpleEventBusTest {
             StubProcessingContext context = new StubProcessingContext();
             context.moveToPhase(DefaultPhases.COMMIT);
 
-            // when / then
+            // when / then the bus cannot register the prepare-commit hook that would deliver the events
             assertThatThrownBy(() -> testSubject.publish(context, List.of(newEvent("event1"))))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessageContaining("phase that has already passed");
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("ProcessingContext is already in phase COMMIT");
         }
     }
 

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/SimpleEventBusTest.java
@@ -532,6 +532,34 @@ class SimpleEventBusTest {
                                               "registered-work",
                                               "commit");
         }
+
+        @Test
+        void publishingOnceTheQueueWasDrainedIsRejectedRatherThanQueuedAgain() {
+            // given a context that already published, so the queue and the hook draining it both exist
+            RecordingEventListener listener = new RecordingEventListener();
+            testSubject.subscribe(listener);
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+            UnitOfWork uow = unitOfWorkFactory.create();
+            uow.runOnInvocation(ctx -> testSubject.publish(ctx, List.of(newEvent("event1"))));
+            uow.runOnCommit(ctx -> {
+                try {
+                    testSubject.publish(ctx, List.of(newEvent("event2")));
+                } catch (RuntimeException e) {
+                    failure.set(e);
+                }
+            });
+
+            // when
+            FutureUtils.joinAndUnwrap(uow.execute(), TIMEOUT);
+
+            // then the late publish fails, instead of landing in a queue nothing will read again
+            assertThat(failure.get())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("were delivered to their subscribers");
+            assertThat(listener.getReceivedEvents())
+                    .extracting(msg -> msg.type().qualifiedName().toString())
+                    .containsExactly("event1");
+        }
     }
 
     // Helper methods


### PR DESCRIPTION
While reviewing *why* the saga was stuck during #5009 development, the same root cause turned out to hit two other components that also register for `PREPARE_COMMIT` lazily. **One of them loses events silently on JPA.** This PR fixes those two, and repairs the test double that was hiding them.

No change to `UnitOfWork` or to the phase rule itself.

---

## Background: the rule, and who trips over it

`ProcessingContext` rejects a registration for a phase whose order is at or below the phase currently running:

```java
// UnitOfWork.UnitOfWorkProcessingContext#on
if (current != null && phase.order() <= current.order()) {
    throw new IllegalStateException("Failed to register handler in phase ...");
}
```

That rule is fine. The problem is that **a handler is not always invoked in the phase it thinks it is**. Events published with a `ProcessingContext` are queued by `SimpleEventBus` and drained during `PREPARE_COMMIT`, and `SubscribingEventProcessor` hands them to its components in that same context:

```mermaid
sequenceDiagram
    participant CH as Command handler
    participant UoW as UnitOfWork
    participant Bus as SimpleEventBus
    participant SEP as SubscribingEventProcessor
    participant H as Your event handler

    CH->>Bus: publish(context, events)
    Note over Bus: queued, hook registered for PREPARE_COMMIT
    UoW->>Bus: PREPARE_COMMIT
    Bus->>SEP: notify(events, context)
    SEP->>H: handle(event, context)
    Note over H: running INSIDE PREPARE_COMMIT
```

So any component reached that way cannot register for `PREPARE_COMMIT`. That is what blocked the saga write, and PR #5009 fixes it by registering for `SAGA_WRITE` instead. But the saga is not the only component that registers for `PREPARE_COMMIT` lazily.

---

## Bug 1: the event store hands its batch over too early, and JPA loses the events

`DefaultEventStoreTransaction` collects appended events in a queue and hands the whole queue to the `EventStorageEngine` in a step registered on **first append**, for `PREPARE_COMMIT`. Two things go wrong.

### 1a. First append during `PREPARE_COMMIT` throws

`attachAppendEventsStep()` registers lazily, so a component whose *first* append happens in that phase hits the identical rejection the saga hit. No saga involved, plain event append.

### 1b. Append after the step already ran is silently dropped

If something appended earlier, the queue exists, `computeResourceIfAbsent` short-circuits, and the event is added to a list the engine **already received**. Whether it survives depends entirely on how the engine treats that list:

| Engine | Behaviour | Result |
|---|---|---|
| `InMemoryEventStorageEngine` | closes over the list, re-reads it in `commit()` | late event **is** stored (by luck) |
| `AggregateBasedJpaEventStorageEngine` | `forEach(em::persist)` then `em.flush()` **inside** `appendEvents`; `commit()` is a no-op | late event **is silently lost** |

Meanwhile `SimpleEventBus.processEventsInPhase` has already delivered that event to every subscriber. **Store and subscribers diverge, with nothing logged.**

```mermaid
sequenceDiagram
    participant H as Subscribing handler
    participant Tx as DefaultEventStoreTransaction
    participant Q as event queue
    participant E as JPA storage engine

    Note over Tx,E: PREPARE_COMMIT
    Tx->>Q: read queue [e0]
    Tx->>E: appendEvents([e0])
    E->>E: persist + flush  (e0 only)
    H->>Tx: appendEvent(e1)
    Tx->>Q: add e1  (queue now [e0, e1])
    Note over E: never called again. e1 is gone.
    Note over H: subscribers already saw e1
```

This is why no existing test caught it: the in-memory engine hides it.

### The fix

The batch is handed over in a phase of its own, `EventStoreTransaction.Phases.APPEND_EVENTS`, at order **29000**.

That is deliberately the **last** slot before `COMMIT`, not the first one above `PREPARE_COMMIT`. `SAGA_WRITE` sits at 25000, and a saga is exactly the kind of component that may append events. Placing the hand-off last means every phase a caller puts in the gap still gets to append.

```mermaid
graph LR
    A["PRE_INVOCATION<br/>-10000"] --> B["INVOCATION<br/>0"]
    B --> C["POST_INVOCATION<br/>10000"]
    C --> D["PREPARE_COMMIT<br/>20000<br/><i>event delivery, token store</i>"]
    D --> E["SAGA_WRITE<br/>25000<br/><i>saga written</i>"]
    E --> F["APPEND_EVENTS<br/>29000<br/><i>batch to storage engine</i>"]
    F --> G["COMMIT<br/>30000<br/><i>transaction commits</i>"]
    G --> H["AFTER_COMMIT<br/>40000"]
```

Appending after that phase is now **refused** rather than queued into a batch that is already gone.

### How it was proved

`DefaultEventStoreTransactionTest.AppendingDuringPrepareCommit`.

The key move is that the test asserts **what the engine was handed**, not only what ended up stored, and runs against `EagerFlushEventStorageEngine` (an `InMemoryEventStorageEngine` that snapshots its batch with `List.copyOf`, modelling what the JPA engine does).

`anEventAppendedByALaterPrepareCommitActionJoinsTheSameBatch` before the fix:

```
Expecting actual:
  [["event-0"]]
to contain exactly (and in same order):
  [["event-0", "event-1"]]
```

The engine received one event. `event-1` was dropped, after subscribers had seen it.

`aFirstEventAppendedDuringPrepareCommitIsStored` before the fix:

```
java.lang.IllegalStateException: Failed to register handler in phase PREPARE_COMMIT (20000).
ProcessingContext is already in phase PREPARE_COMMIT (20000).
```

Both green after. A third test, `appendingOnceTheBatchWasHandedToTheStorageEngineIsRejected`, pins the new loud failure.

### Alternative that was rejected

Opening a **second** `AppendTransaction` for the late events does not work: its consistency marker predates the first batch, so `InMemoryEventStorageEngine` reports a false conflict and `AggregateBasedJpaEventStorageEngine` restarts sequence numbers and collides on its own primary key. Nothing can produce a fresh marker mid-context, because the append position is only updated after commit.

### One assertion moved

`SimpleEventStoreTest.subscriberExceptionRollsBackTransaction` became `subscriberExceptionPreventsTheEventsFromReachingTheStorageEngine`. A failing subscriber used to leave an append transaction to roll back; it now leaves none, because the engine is not asked for one until every subscriber has been notified. The test asserts that directly, which is the stronger claim.

---

## Bug 2: `SimpleEventBus` accepts a publish it can never deliver

```java
if (context.isCommitted()) { throw new IllegalStateException("... already been committed ..."); }
```

`isCommitted()` is `status == COMPLETED`, true only once **every** phase has finished. During `COMMIT` and `AFTER_COMMIT` it is `false`, so the guard never fires where it was written to fire.

What happened instead depended on whether anything had published earlier in the same context:

- **First publish:** queue absent, so the bus tries to register its prepare-commit hook and the context rejects it. An error about phase registration rather than about publishing, but at least an error.
- **Later publish:** queue exists, `computeResourceIfAbsent` returns it, events are added, **and nothing ever reads them again**. Accepted and silently dropped.

### The fix

The right question is not which phase the context is in, but **whether the queue has already been drained**, and only the bus knows that. It now records it, the same way `DefaultEventStoreTransaction` records `prepareCommitExecuted`.

The placement matters:

```java
context.onPrepareCommit(ctx -> {
    CompletableFuture<Void> delivery = processEventsInPhase(queuedEvents, ctx, ...);
    ctx.putResource(eventsDeliveredKey, Boolean.TRUE);   // <- right here
    return delivery;
});
```

`processEventsInPhase` loops while the queue keeps growing, so it catches anything a **synchronous** subscriber publishes. The instant it returns, that loop is over and no later addition will be picked up, even though subscribers may still be running. Setting the flag at that exact point is what turns a publish from a still-running **asynchronous** subscriber into a failure rather than a second silent drop. Setting it in `whenComplete` would have left that case as broken as before.

Note this deliberately does **not** need a public phase accessor. The phase would not be precise enough: during `PREPARE_COMMIT` publishing is fine while the drain is running and wrong once it is not, and no phase can tell those apart.

`isCommitted()` stays as the coarser case, since it still gives a better message for a publish from a completion handler in a context that never published anything.

### How it was proved

`SimpleEventBusTest.publishingOnceTheQueueWasDrainedIsRejectedRatherThanQueuedAgain` publishes during `INVOCATION`, then again from a `COMMIT`-phase action. Before the fix:

```
java.lang.AssertionError:
Expecting actual not to be null
```

That is the captured throwable being `null`: **no exception at all**. The publish was accepted and the event vanished. After the fix it throws `IllegalStateException`, and the recording listener confirms only `event1` was ever delivered.

---

## Bug 3: `StubProcessingContext` did not apply the rules it claims to

Both the saga work and this PR had to write their phase tests against a real `UnitOfWork`. The reason is recorded in `8a6e44f753`'s commit message: the stub assigns `currentPhase` **after** running that phase's actions, so during a `PREPARE_COMMIT` action it still reports the earlier phase and accepts registrations production rejects. It also threw `IllegalArgumentException` with its own wording, so a test asserting on that pinned the stub instead of the framework.

Working around a broken test double once is fine; leaving it broken means everyone after has to know to work around it too.

It now enters a phase **before** running its actions, and rejects the same registrations with the same exception type and message as `UnitOfWork`. Behaviour is otherwise unchanged and the whole messaging suite passes, so nothing was leaning on the old leniency.

The javadoc now states where the stub still stops, so the next reader does not have to find out by experiment: a phase's actions are chained rather than run in parallel, and a registration for a later phase that a `moveToPhase` call is already past is not picked up.

`publishingAfterContextCommittedThrowsException` changes with it. The behaviour it describes is unchanged, but the reason is now visible: the bus cannot register the prepare-commit hook that would have delivered the events, and the message names the phase that blocked it.

---

## Documentation

The rule had no documentation anywhere: no `@throws` on `ProcessingLifecycle.on`, no comment at the throw, nothing in the reference guide. A caller could only discover it by hitting the exception, and could not check beforehand either, since Axon Framework 5 has no public equivalent of Axon Framework 4's `UnitOfWork.phase()`.

Both the javadoc and `processing-context.adoc` now state the rule **and the way out of it**: a component invoked from within a late phase registers for a custom phase in the gap above it. The reference guide names the saga write and the event store hand-off as the two users, so the pattern reads as intended design rather than something invented twice.

---

## Verification

- Full reactor: green (4495 messaging tests)
- `-Pintegration-test verify -pl integrationtests`: green (84 + 83)
- `-Pexamples verify`: green

One pre-existing failure is unrelated to this PR: `AnnotatedEventHandlerInterceptorTest.interceptorIsInvokedBeforeEventHandler` (handler invoked three times, interceptor once). It fails identically on `411a58bd2e` with none of these commits applied.

---

## Open question for the reviewer

Moving the hand-off to 29000 surfaces an asymmetry that was previously invisible: the event **store** now accepts appends up to 29000, but the event **bus** stops delivering at 20000. An event appended from a gap phase such as `SAGA_WRITE` would therefore be stored but never reach subscribers.

With Bug 2 fixed that case now throws instead of diverging silently, which I believe is the right default. But if appending events from `SAGA_WRITE` is something a saga should be able to do, the bus's delivery hook needs to move up as well. I would rather agree that than decide it unilaterally.
