### PR TITLE
[#4619] Fix spelling in Saga Guide

### DIFF
--- a/docs/saga-guide/modules/ROOT/pages/vertical-slices.adoc
+++ b/docs/saga-guide/modules/ROOT/pages/vertical-slices.adoc
@@ -6,7 +6,7 @@ The other approaches keep the process in one class. This one asks whether it nee
 
 Often the answer is no. What looks like a saga is a handful of independent reactions, each of the form "when this
 happens, do that". In Vertical Slice Architecture each is a folder, and nothing outside it needs to know it exists. If
-you model with Event Modelling you will recognise these as automation slices, drawn between an event and the command it
+you model with Event Modelling you will recognize these as automation slices, drawn between an event and the command it
 triggers. This page treats the two as mostly the same thing.
 
 == When to use it

--- a/docs/saga-guide/modules/ROOT/pages/workflows.adoc
+++ b/docs/saga-guide/modules/ROOT/pages/workflows.adoc
@@ -11,7 +11,7 @@ top to bottom. The machinery that lets it survive a restart is provided rather t
 as a flow avoids the state-management concerns the other pages cover.
 
 The other approaches exist for cases where the reaction to events is not a single flow. A handful of independent
-reactions is better modelled as a handful of independent reactions; forcing them into one method gives them a centre
+reactions is better modelled as a handful of independent reactions; forcing them into one method gives them a center
 they do not need. Use this page when the process genuinely is one flow.
 
 [NOTE]
@@ -60,7 +60,7 @@ easier and stays easier, and the gap widens with every step.
 
 The deciding factor against a workflow is that the process is not a single flow. If what you have is a set of
 reactions that happen to share a subject, xref::vertical-slices.adoc[vertical slices] keep them independent; a
-workflow would give them a centre they do not need. That decision is about the shape of the work, not about the
+workflow would give them a center they do not need. That decision is about the shape of the work, not about the
 framework you are on.
 
 A preview dependency has to be acceptable in your build, and production use needs a licence. Neither affects trying
@@ -76,7 +76,7 @@ The other approaches differ in where the process lives and how it keeps its stat
 reconstructs the flow*.
 
 A process written as
-xref::vertical-slices.adoc[vertical slices] is the furthest from a workflow, because it has no centre. Converting
+xref::vertical-slices.adoc[vertical slices] is the furthest from a workflow, because it has no center. Converting
 it later means gathering the slices back into one flow. A process written as
 xref::state-from-process-events.adoc[state from its own events] is the closest, because it already records its own
 progress as facts. That is much the same information a workflow persists on your behalf.


### PR DESCRIPTION
The docs site publish pipeline (`axoniq-library-site`) runs Vale with proselint at error level. Its `Spelling` rule is a consistency check: it rejects a rendered page that mixes British and American forms from its pair list. The saga guide prose used "centre" (workflows page) and "recognise" (vertical-slices page), while the surrounding rendered site chrome uses the American forms, so those saga-guide pages failed the build on the inconsistency.

Reference failure: https://github.com/AxonIQ/axoniq-library-site/actions/runs/33851339475/job/100954614943

## Change

Switch the four proselint-list offenders to American spelling:

- `workflows.adoc`: "centre" -> "center" (x3)
- `vertical-slices.adoc`: "recognise" -> "recognize" (x1)

Only the words on proselint's consistency pair list are changed. Other British spellings in the guide (for example "modelled", "behaviour", "licence") produce `Google.Spelling` warnings that sit below the error failure level and do not block the build, so they are left untouched.

I checked the whole `docs/saga-guide/` against proselint's full consistency list (centre, colour, emphasise, finalise, focussed, labour, learnt, organise, recognise, signalling, adviser); these four were the only matches.
