### PR TITLE
Encode username header value for non-ascii characters

### DIFF
--- a/update/src/main/java/org/axonframework/update/UpdateCheckerHttpClient.java
+++ b/update/src/main/java/org/axonframework/update/UpdateCheckerHttpClient.java
@@ -81,7 +81,7 @@ public class UpdateCheckerHttpClient {
                     .timeout(Duration.ofSeconds(10))
                     .headers("User-Agent", updateCheckRequest.toUserAgent())
                     .headers("X-Machine-Id", updateCheckRequest.machineId())
-                    .headers("X-Machine-User-Name", updateCheckRequest.machineUserName())
+                    .headers("X-Machine-User-Name", updateCheckRequest.machineUserNameHeader())
                     .headers("X-Instance-Id", updateCheckRequest.instanceId())
                     .headers("X-Uptime", String.valueOf(ManagementFactory.getRuntimeMXBean().getUptime()))
                     .headers("X-First-Run", firstRequest ? "true" : "false")

--- a/update/src/main/java/org/axonframework/update/api/UpdateCheckRequest.java
+++ b/update/src/main/java/org/axonframework/update/api/UpdateCheckRequest.java
@@ -80,6 +80,21 @@ public record UpdateCheckRequest(
     }
 
     /**
+     * Returns the {@link #machineUserName()} percent-encoded as UTF-8, for use as an HTTP header value.
+     * <p>
+     * HTTP headers cannot carry anything outside ISO-8859-1, so a user name written in, for instance, Chinese or
+     * Cyrillic cannot be sent as-is: {@link java.net.http.HttpRequest.Builder#headers(String...)} rejects it and the
+     * whole update check fails. Encoding rather than stripping keeps the name intact and distinguishable, as every
+     * unrepresentable name would otherwise collapse onto the same placeholder. Names that are already unreserved
+     * ASCII pass through unchanged.
+     *
+     * @return the machine user name, percent-encoded as UTF-8
+     */
+    public String machineUserNameHeader() {
+        return encode(machineUserName).replace("+", "%20");
+    }
+
+    /**
      * Converts the usage request into a user agent string format.
      *
      * @return the user agent string representation of the usage request

--- a/update/src/test/java/org/axonframework/update/UpdateCheckRequestTest.java
+++ b/update/src/test/java/org/axonframework/update/UpdateCheckRequestTest.java
@@ -20,6 +20,8 @@ import org.axonframework.update.api.Artifact;
 import org.axonframework.update.api.UpdateCheckRequest;
 import org.junit.jupiter.api.*;
 
+import java.net.URI;
+import java.net.http.HttpRequest;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -83,5 +85,46 @@ class UpdateCheckRequestTest {
         String userAgent = request.toUserAgent();
         assertEquals("Axoniq UpdateChecker/5.0.1 (Java 17.0.2 AdoptOpenJDK; Linux; 6.11.0-26-generic; amd64)",
                      userAgent);
+    }
+
+    @Test
+    void machineUserNameHeaderLeavesPlainAsciiNamesUntouched() {
+        assertEquals("machine-user-name", requestForUserName("machine-user-name").machineUserNameHeader());
+    }
+
+    @Test
+    void machineUserNameHeaderPercentEncodesNonAsciiNames() {
+        assertEquals("%E6%9D%8E%E9%9B%B7", requestForUserName("李雷").machineUserNameHeader());
+        assertEquals("j%C3%B3zef", requestForUserName("józef").machineUserNameHeader());
+    }
+
+    @Test
+    void machineUserNameHeaderEncodesSpacesAsPercentTwentyRatherThanPlus() {
+        assertEquals("John%20Doe", requestForUserName("John Doe").machineUserNameHeader());
+    }
+
+    @Test
+    void machineUserNameHeaderIsAcceptedAsAHeaderValue() {
+        // HttpRequest.Builder rejects anything outside ISO-8859-1, which silenced the update check entirely for
+        // users whose operating system account name is not written in Latin script
+        assertDoesNotThrow(() -> HttpRequest.newBuilder()
+                                            .uri(URI.create("https://localhost"))
+                                            .headers("X-Machine-User-Name",
+                                                     requestForUserName("李雷").machineUserNameHeader())
+                                            .GET()
+                                            .build());
+    }
+
+    private static UpdateCheckRequest requestForUserName(String machineUserName) {
+        return new UpdateCheckRequest("machine-1234",
+                                      machineUserName,
+                                      "instance-5678",
+                                      "Linux",
+                                      "6.11.0-26-generic",
+                                      "amd64",
+                                      "17.0.2",
+                                      "AdoptOpenJDK",
+                                      "1.8.22",
+                                      Collections.emptyList());
     }
 }


### PR DESCRIPTION
The new X-Machine-User-Name header value recently introduced does not encode all non-latin characters, such as chinese and cyrillic, causing a rejection of the request, as these characters don't exist in the `ISO-8859-1` encoding.

This PR encodes this value in percent-values of UTF-8 before sending. The server is alreadyready to receive them.