### PR TITLE
Invoke a before-interceptor's handler exactly once

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/core/interception/annotation/MessageHandlerInterceptorDefinition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/interception/annotation/MessageHandlerInterceptorDefinition.java
@@ -51,6 +51,14 @@ public class MessageHandlerInterceptorDefinition implements HandlerEnhancerDefin
     @Override
     public <T> MessageHandlingMember<T> wrapHandler(MessageHandlingMember<T> original) {
         if (original.attribute(HandlerAttributes.INTERCEPTOR_MESSAGE_TYPE).isPresent()) {
+            // Idempotency guard: this enhancer can be applied to the same interceptor member more than once, because
+            // the flattened handler-enhancer list is not de-duplicated and may contain this definition several times
+            // when enhancer definitions are composed more than once. Wrapping an already-wrapped member would nest
+            // MessageInterceptingMembers, and each before-style layer independently proceeds the chain -- invoking the
+            // actual handler once per redundant wrapping. Returning the existing wrapper keeps a single proceed.
+            if (original.unwrap(MessageInterceptingMember.class).isPresent()) {
+                return original;
+            }
             Optional<Class<?>> resultType = original.attribute(HandlerAttributes.RESULT_TYPE);
             return resultType.isPresent()
                     ? new ResultHandlingInterceptorMember<>(original, resultType.get())

--- a/messaging/src/main/java/org/axonframework/messaging/core/reflection/ClasspathHandlerDefinitionConfigurationEnhancer.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/reflection/ClasspathHandlerDefinitionConfigurationEnhancer.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.messaging.core.reflection;
 
+import org.axonframework.common.annotation.RegistrationScope;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.common.configuration.ConfigurationEnhancer;
 import org.axonframework.messaging.core.annotation.ClasspathHandlerDefinition;
@@ -35,10 +36,19 @@ import org.axonframework.messaging.core.configuration.reflection.HandlerEnhancer
  * injectable bean, is composed with these classpath-discovered defaults rather than replacing them, through
  * {@link HandlerDefinitionUtils#registerToComponentRegistry(ComponentRegistry, java.util.function.Function)} and
  * {@link HandlerEnhancerDefinitionUtils#registerToComponentRegistry(ComponentRegistry, java.util.function.Function)}.
+ * <p>
+ * Registered once at the root and not re-invoked in child module registries. The {@code HandlerDefinition} and
+ * {@code HandlerEnhancerDefinition} components are resolved through the parent chain, so nested modules reuse the
+ * root's classpath-discovered defaults. Re-invoking per nesting level would compose the classpath enhancer set into
+ * the resolved {@code HandlerDefinition} once per level (the {@code flatten} in {@code MultiHandlerEnhancerDefinition}
+ * does not de-duplicate), inflating the enhancer list and applying every enhancer once per level.
  *
  * @author Steven van Beelen
  * @since 5.3.2
  */
+@RegistrationScope("Register the classpath handler definitions once at the root; do not re-invoke in child module "
+        + "registries. They are resolved through the parent chain, and re-registering per nesting level would "
+        + "duplicate the classpath enhancer set in the composed HandlerDefinition.")
 public class ClasspathHandlerDefinitionConfigurationEnhancer implements ConfigurationEnhancer {
 
     @Override

--- a/test/src/test/java/org/axonframework/test/fixture/BeforeInterceptorSingleInvocationTest.java
+++ b/test/src/test/java/org/axonframework/test/fixture/BeforeInterceptorSingleInvocationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.test.fixture;
+
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.commandhandling.configuration.CommandHandlingModule;
+import org.axonframework.messaging.commandhandling.interception.annotation.CommandHandlerInterceptor;
+import org.axonframework.messaging.core.configuration.MessagingConfigurer;
+import org.junit.jupiter.api.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a before-style member {@link CommandHandlerInterceptor} -- a {@code void} method with no
+ * {@code MessageHandlerInterceptorChain} parameter -- invokes its target command handler exactly once.
+ * <p>
+ * This uses a plain {@link MessagingConfigurer} with a single {@link CommandHandlingModule}, exactly as an application
+ * would wire it, without any hand-built handler-enhancer composition. The defect it guards against is real under this
+ * ordinary configuration: the command handler was invoked multiple times per command while the interceptor ran once.
+ */
+class BeforeInterceptorSingleInvocationTest {
+
+    private final AtomicInteger handlerRuns = new AtomicInteger();
+    private final AtomicInteger interceptorRuns = new AtomicInteger();
+    private AxonTestFixture fixture;
+
+    @BeforeEach
+    void setUp() {
+        CommandHandlingModule.CommandHandlerPhase module =
+                CommandHandlingModule.named("component")
+                                     .commandHandlers()
+                                     .autodetectedCommandHandlingComponent(config -> new Handler(handlerRuns,
+                                                                                                 interceptorRuns));
+        MessagingConfigurer configurer = MessagingConfigurer.create().registerCommandHandlingModule(module);
+        fixture = AxonTestFixture.with(configurer);
+    }
+
+    @AfterEach
+    void tearDown() {
+        fixture.stop();
+    }
+
+    // given a component with a before-style @CommandHandlerInterceptor and a @CommandHandler
+    // when a single command is dispatched
+    // then the interceptor runs once and the command handler runs exactly once
+    @Test
+    void beforeInterceptorInvokesCommandHandlerExactlyOnce() {
+        fixture.given()
+               .noPriorActivity()
+               .when()
+               .command(new DoSomething("id-1"))
+               .then()
+               .success();
+
+        assertThat(interceptorRuns)
+                .as("interceptor should run once")
+                .hasValue(1);
+        assertThat(handlerRuns)
+                .as("before-interceptor must invoke the command handler exactly once")
+                .hasValue(1);
+    }
+
+    static class Handler {
+
+        private final AtomicInteger handlerRuns;
+        private final AtomicInteger interceptorRuns;
+
+        Handler(AtomicInteger handlerRuns, AtomicInteger interceptorRuns) {
+            this.handlerRuns = handlerRuns;
+            this.interceptorRuns = interceptorRuns;
+        }
+
+        @CommandHandlerInterceptor
+        void intercept() {
+            interceptorRuns.incrementAndGet();
+        }
+
+        @CommandHandler
+        void handle(DoSomething command) {
+            handlerRuns.incrementAndGet();
+        }
+    }
+
+    record DoSomething(String id) {
+
+    }
+}


### PR DESCRIPTION
## What was wrong

A **before-style** member interceptor -- a `@CommandHandlerInterceptor` / `@EventHandlerInterceptor` method that returns `void` and has no `InterceptorChain` parameter -- could invoke its target handler **more than once** for a single message.

The tell-tale symptom: the **interceptor ran once**, but the **handler ran N times** (for example, `["interceptor","handler","handler","handler"]`).

## Reproduction

`BeforeInterceptorSingleInvocationTest` (in the `test` module) reproduces the defect deterministically with an ordinary configuration: a plain `MessagingConfigurer` plus one `CommandHandlingModule`, with no hand-built enhancer composition. It dispatches one command and asserts that the handler runs exactly once:

| | handler runs | interceptor runs |
|---|---|---|
| **before fix** | **3** | 1 |
| **after fix** | **1** | 1 |

Because it uses synchronous command handling, the reproduction itself is stable. The commit history shows it red, then green.

### Original event-path failure

The problem first surfaced in [`AnnotatedEventHandlerInterceptorTest.interceptorIsInvokedBeforeEventHandler`](https://github.com/AxonIQ/AxonFramework/actions/runs/33565543385/job/100047757017).

The exact revisions matter:

- **Pre-fix framework commit:** [`9f1f0d02b4`](https://github.com/AxonIQ/AxonFramework/commit/9f1f0d02b4446cfd9198b19dfd60ff33f0bff5bb), the framework base of the failing CI merge commit [`c2bf8685c6`](https://github.com/AxonIQ/AxonFramework/commit/c2bf8685c67ed77da08d72c8192d2f6842871add). PR #4969 did not change the relevant framework or Spring code. Running only `AnnotatedEventHandlerInterceptorTest` on this revision reproduced `interceptor x1, handler x3` locally.
- **After the idempotency guard only:** the same isolated test passed. This corresponds to this PR at commit [`d0aef70337`](https://github.com/AxonIQ/AxonFramework/commit/d0aef703375d0f625f85a7a4e1624861a326150f), before the `@RegistrationScope` cleanup.
- **Current PR head:** [`f23763a704`](https://github.com/AxonIQ/AxonFramework/commit/f23763a704c09d98d35e2cd32b7e0f65af574697) passes the event test and the full JDK 21/JDK 25 builds.

The event test can appear intermittent because its latch releases after the first handler invocation, so its assertion can race the remaining duplicate invocations. The underlying failure is the same nested-interceptor defect; it is not caused by the event processor consuming or re-peeking the handler `MessageStream` more than once.

## Why it happened

Handler enhancers are combined with a compose-don't-replace pattern, and `MultiHandlerEnhancerDefinition.flatten()` never de-duplicates. `ClasspathHandlerDefinitionConfigurationEnhancer` is copied into and re-run in every nested module registry, so the full classpath enhancer set -- including `MessageHandlerInterceptorDefinition` -- ends up in the enhancer list once per registry level (3 copies / 24 enhancers in the reproduced configuration).

Applying `MessageHandlerInterceptorDefinition` N times **nests** the interceptor N deep. Each nested before-interceptor adds its own `chain.proceed()`, so draining the outer result reaches the real handler once per layer. Only the innermost layer invokes the interceptor method -- hence interceptor x1, handler xN.

```mermaid
flowchart TD
    subgraph Build["Config build"]
      A["root registry"] --> L
      B["child module registry"] --> L
      C["...per nesting level"] --> L
      L["enhancer list contains<br/>MessageHandlerInterceptorDefinition x3"]
    end

    L --> W["wrapHandler applied 3x -> nested interceptors"]

    subgraph Dispatch["One message dispatched"]
      W --> I1["before-interceptor layer #1 -> proceed"]
      I1 --> I2["before-interceptor layer #2 -> proceed"]
      I2 --> I3["before-interceptor layer #3 -> proceed"]
      I3 --> H["handler runs 3x"]
    end
```

The duplicate count is determined by the configuration topology. The apparent flakiness of the asynchronous event test comes from when it observes those invocations, not from `MessageStream` re-consumption.

## The fix

1. **`wrapHandler` is now idempotent.** If it receives a member that is already a `MessageInterceptingMember`, it returns it unchanged. Applying the enhancer any number of times therefore wraps the interceptor once and produces one `chain.proceed()` continuation.

2. **`ClasspathHandlerDefinitionConfigurationEnhancer` is `@RegistrationScope`d.** It registers once at the root instead of being re-run in every child registry, matching the existing tracing enhancers. Nested modules resolve the definitions through the parent chain, keeping one classpath enhancer set (8 enhancers instead of 24 in the reproduced configuration).

```mermaid
flowchart LR
    L["single enhancer set<br/>MessageHandlerInterceptorDefinition x1"] --> W["wrapHandler applied once"]
    W --> I["before-interceptor"] --> H["handler runs once"]
```

The two changes are complementary: the idempotency guard guarantees correctness under any duplicate registration, while `@RegistrationScope` removes the known duplication at its source.

## Tests

- New deterministic command-path reproduction: `BeforeInterceptorSingleInvocationTest` -- red before, green after.
- Existing Spring event-path test reproduced on `9f1f0d02b4`, then passed with the idempotency guard alone and at the current PR head.
- PR CI runs `clean verify` and explicitly executes `AnnotatedEventHandlerInterceptorTest`; it is green on JDK 21 and JDK 25.
- Local regression suites were green: messaging (4496), modelling (453), eventsourcing (634), and test (145).

## Note for reviewers

`@RegistrationScope` changes how nested registries obtain `HandlerDefinition` / `HandlerEnhancerDefinition`: they now rely on parent-chain resolution rather than re-registering the classpath defaults. The full PR builds, including Spring Boot autoconfigure and extension wiring, are green. The idempotency guard stands on its own if reviewers prefer to separate the scoping cleanup.
