### PR TITLE
Support Entity-specific (annotated) command handler interceptors

### DIFF
--- a/docs/reference-guide/modules/commands/pages/entities/index.adoc
+++ b/docs/reference-guide/modules/commands/pages/entities/index.adoc
@@ -42,5 +42,9 @@ This is the recommended approach for Vertical Slice Architecture.
 
 |xref:commands:entities/entity-polymorphism.adoc[Polymorphic entities]
 |How to model multiple concrete entity types sharing a common abstract parent, with type selection at creation time.
+
+|xref:messaging-concepts:component-message-intercepting.adoc#entity-command-handler-interceptors[Entity-specific command handler interceptors]
+|How to derive an interceptor that interceptors a command before it enters a specific entity, supporting interceptor tasks using that entity.
+
 |===
 

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/GiftCard.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/GiftCard.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.componentmessageintercepting.entityannotated;
+
+// tag::entity-command-interceptor[]
+import org.axonframework.eventsourcing.annotation.EventSourcedEntity;
+import org.axonframework.eventsourcing.annotation.EventSourcingHandler;
+import org.axonframework.eventsourcing.annotation.reflection.EntityCreator;
+import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.commandhandling.interception.annotation.CommandHandlerInterceptor;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+
+@EventSourcedEntity(tagKey = "cardId")
+public class GiftCard {
+
+    private String cardId;
+    private boolean redeemed;
+
+    @EntityCreator
+    public GiftCard() {
+    }
+
+    @CommandHandlerInterceptor
+    void rejectIfAlreadyRedeemed(CommandMessage command) {
+        if (redeemed) {
+            throw new IllegalStateException("Gift card already redeemed");
+        }
+    }
+
+    @CommandHandler
+    void handle(RedeemGiftCard command, EventAppender eventAppender) {
+        eventAppender.append(new GiftCardRedeemed(command.cardId()));
+    }
+
+    @EventSourcingHandler
+    void on(GiftCardRedeemed event) {
+        this.cardId = event.cardId();
+        this.redeemed = true;
+    }
+}
+// end::entity-command-interceptor[]

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/GiftCardRedeemed.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/GiftCardRedeemed.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.componentmessageintercepting.entityannotated;
+
+public record GiftCardRedeemed(String cardId) {
+
+}

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/GiftCardRedeemed.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/GiftCardRedeemed.java
@@ -15,6 +15,8 @@
  */
 package messagingconcepts.componentmessageintercepting.entityannotated;
 
-public record GiftCardRedeemed(String cardId) {
+import org.axonframework.eventsourcing.annotation.EventTag;
+
+public record GiftCardRedeemed(@EventTag String cardId) {
 
 }

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/RedeemGiftCard.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entityannotated/RedeemGiftCard.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.componentmessageintercepting.entityannotated;
+
+import org.axonframework.modelling.annotation.TargetEntityId;
+
+public record RedeemGiftCard(@TargetEntityId String cardId) {
+
+}

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/GiftCard.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/GiftCard.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.componentmessageintercepting.entitydeclarative;
+
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+
+public class GiftCard {
+
+    private String cardId;
+    private boolean redeemed;
+
+    public void redeem(RedeemGiftCard command, EventAppender eventAppender) {
+        eventAppender.append(new GiftCardRedeemed(command.cardId()));
+    }
+
+    void on(GiftCardRedeemed event) {
+        this.cardId = event.cardId();
+        this.redeemed = true;
+    }
+
+    public boolean isRedeemed() {
+        return redeemed;
+    }
+}

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/GiftCardEntityConfiguration.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/GiftCardEntityConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.componentmessageintercepting.entitydeclarative;
+
+import org.axonframework.eventsourcing.EventSourcedEntityFactory;
+import org.axonframework.eventsourcing.configuration.EventSourcedEntityModule;
+import org.axonframework.eventsourcing.configuration.EventSourcingConfigurer;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageTypeResolver;
+import org.axonframework.messaging.eventhandling.gateway.EventAppender;
+import org.axonframework.messaging.eventstreaming.EventCriteria;
+import org.axonframework.messaging.eventstreaming.Tag;
+import org.axonframework.modelling.annotation.AnnotationBasedEntityIdResolver;
+
+public class GiftCardEntityConfiguration {
+
+    public static EventSourcingConfigurer configure(EventSourcingConfigurer configurer) {
+        return configurer.registerEntity(
+                EventSourcedEntityModule.declarative(String.class, GiftCard.class)
+                                        .messagingModel((config, model) -> {
+                                            MessageTypeResolver resolver =
+                                                    config.getComponent(MessageTypeResolver.class);
+                                            return model
+                                                    .instanceCommandHandler(
+                                                            resolver.resolveOrThrow(RedeemGiftCard.class)
+                                                                    .qualifiedName(),
+                                                            (command, entity, context) -> {
+                                                                entity.redeem(
+                                                                        command.payloadAs(RedeemGiftCard.class),
+                                                                        EventAppender.forContext(context)
+                                                                );
+                                                                return MessageStream.empty().cast();
+                                                            }
+                                                    )
+                                                    // tag::entity-declarative-interceptor[]
+                                                    .commandHandlerInterceptor((command, entity, context, chain) -> {
+                                                        if (entity != null && entity.isRedeemed()) {
+                                                            return MessageStream.failed(new IllegalStateException(
+                                                                    "Gift card already redeemed"
+                                                            ));
+                                                        }
+                                                        return chain.proceed(command, entity, context);
+                                                    })
+                                                    // end::entity-declarative-interceptor[]
+                                                    .entityEvolver((entity, event, context) -> {
+                                                        entity.on(event.payloadAs(GiftCardRedeemed.class));
+                                                        return entity;
+                                                    })
+                                                    .build();
+                                        })
+                                        .entityFactory(c -> EventSourcedEntityFactory.fromNoArgument(GiftCard::new))
+                                        .criteriaResolver(c -> (id, ctx) -> EventCriteria.havingTags(
+                                                Tag.of("cardId", id)))
+                                        .entityIdResolver(c -> new AnnotationBasedEntityIdResolver<>())
+                                        .build()
+        );
+    }
+}

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/GiftCardRedeemed.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/GiftCardRedeemed.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.componentmessageintercepting.entitydeclarative;
+
+public record GiftCardRedeemed(String cardId) {
+
+}

--- a/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/RedeemGiftCard.java
+++ b/docs/reference-guide/modules/messaging-concepts/examples/messagingconcepts/componentmessageintercepting/entitydeclarative/RedeemGiftCard.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package messagingconcepts.componentmessageintercepting.entitydeclarative;
+
+public record RedeemGiftCard(String cardId) {
+
+}

--- a/docs/reference-guide/modules/messaging-concepts/pages/component-message-intercepting.adoc
+++ b/docs/reference-guide/modules/messaging-concepts/pages/component-message-intercepting.adoc
@@ -161,7 +161,8 @@ This makes it suitable for cross-cutting exception handling concerns such as log
 
 You can wire the exception and the full message (for example, `CommandMessage` or `EventMessage`) as parameters.
 The framework matches an exception handler based on which parameters it declares: the exception type must be assignable from the thrown exception, and the message type must be assignable from the message being handled.
-Omitting a parameter means it is not used for matching. Any value is accepted.
+Omitting a parameter means it is not used for matching.
+Any value is accepted.
 
 You can introduce `@ExceptionHandler` annotated methods in any message handling component.
 
@@ -194,8 +195,10 @@ include::example$messagingconcepts/componentmessageintercepting/exceptionproject
 An xref:commands:entities/index.adoc[entity's] own `@CommandHandler` methods can be intercepted the same way as any other component, both by an annotated method on the entity class and by a declarative interceptor registered on its `EntityMetamodelBuilder`.
 An interceptor registered on a parent entity runs before an interceptor registered on a child entity added through `@EntityMember` or `EntityMetamodelBuilder.addChild(...)`, and before the parent's own command handlers.
 
-Note that **only** command handling is covered.
-Hence, there is no interceptor support for `@EventSourcingHandler` methods.
+For a xref:commands:entities/entity-polymorphism.adoc[polymorphic entity], a concrete type's own interceptor runs before an interceptor declared on the super type, for every command reaching that concrete type's instance, whether the command is declared on the concrete type or on the super type itself.
+This is the opposite order from the `@EntityMember`/`addChild(...)` parent-before-child rule above; the two are unrelated mechanisms.
+
+Only command handling is covered: there is no interceptor support for `@EventSourcingHandler` methods.
 
 *Annotated `@CommandHandlerInterceptor` on the entity:*
 

--- a/docs/reference-guide/modules/messaging-concepts/pages/component-message-intercepting.adoc
+++ b/docs/reference-guide/modules/messaging-concepts/pages/component-message-intercepting.adoc
@@ -4,8 +4,7 @@ Component-level interceptors apply cross-cutting behavior within a single handli
 They complement bus-level interceptors, which apply globally to all messages on a bus, by targeting only the handlers within a specific component.
 Axon Framework supports two approaches: annotated interceptor methods placed directly on the component class, and declarative interceptors registered during module configuration.
 
-[[command-handler-interceptor-annotation]]
-== `@CommandHandlerInterceptor` annotation
+== Annotated handler interceptors
 
 Annotated interceptors are methods placed on a handling component class and marked with one of the interceptor annotations.
 The framework invokes these methods around the regular handler methods on the same component instance.
@@ -19,6 +18,7 @@ If the interceptor throws, the handler is not invoked.
 The method controls whether and when to call `chain.proceed(message, context)`.
 It can short-circuit processing entirely by returning without calling proceed, or by returning `MessageStream.failed(...)`.
 
+[[command-handler-interceptor-annotation]]
 === `@CommandHandlerInterceptor`
 
 The `@CommandHandlerInterceptor` annotation marks a method as an interceptor for command handlers on the same component.
@@ -187,3 +187,28 @@ If you need to handle exceptions from a static creation handler, handle them dir
 ----
 include::example$messagingconcepts/componentmessageintercepting/exceptionprojection/CardSummaryProjection.java[tag=exception-projection,indent=0]
 ----
+
+[[entity-command-handler-interceptors]]
+== Entity command handler interceptors
+
+An xref:commands:entities/index.adoc[entity's] own `@CommandHandler` methods can be intercepted the same way as any other component, both by an annotated method on the entity class and by a declarative interceptor registered on its `EntityMetamodelBuilder`.
+An interceptor registered on a parent entity runs before an interceptor registered on a child entity added through `@EntityMember` or `EntityMetamodelBuilder.addChild(...)`, and before the parent's own command handlers.
+
+Note that **only** command handling is covered.
+Hence, there is no interceptor support for `@EventSourcingHandler` methods.
+
+*Annotated `@CommandHandlerInterceptor` on the entity:*
+
+[source,java]
+----
+include::example$messagingconcepts/componentmessageintercepting/entityannotated/GiftCard.java[tag=entity-command-interceptor,indent=0]
+----
+
+*Declarative interceptor on the entity's `EntityMetamodelBuilder`:*
+
+[source,java]
+----
+include::example$messagingconcepts/componentmessageintercepting/entitydeclarative/GiftCardEntityConfiguration.java[tag=entity-declarative-interceptor,indent=0]
+----
+
+Unlike the generic `MessageHandlerInterceptor`, an entity command handler interceptor receives the targeted entity instance (or `null` for a creational command), so it can base its decision on the entity's current state.

--- a/modelling/src/main/java/org/axonframework/modelling/entity/ConcreteEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/ConcreteEntityMetamodel.java
@@ -22,7 +22,9 @@ import org.axonframework.messaging.commandhandling.CommandHandler;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.commandhandling.DuplicateCommandHandlerSubscriptionException;
+import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
 import org.axonframework.messaging.commandhandling.NoHandlerForCommandException;
+import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -62,15 +64,20 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
     private final List<EntityChildMetamodel<?, E>> children = new LinkedList<>();
     private final Map<QualifiedName, EntityCommandHandler<E>> instanceCommandHandlers = new HashMap<>();
     private final Map<QualifiedName, CommandHandler> creationalCommandHandlers = new HashMap<>();
+    private final List<EntityCommandHandlerInterceptor<E>> commandHandlerInterceptors;
+    private final EntityCommandHandlerInterceptorChain<E> creationalHandlerChain;
+    private final EntityCommandHandlerInterceptorChain<E> instanceHandlerChain;
     private final @Nullable EntityEvolver<E> entityEvolver;
     private final Set<QualifiedName> supportedCommandNames = new HashSet<>();
     private final Set<QualifiedName> supportedInstanceCommandNames = new HashSet<>();
     private final Set<QualifiedName> supportedCreationalCommandNames = new HashSet<>();
 
+    @SuppressWarnings("DataFlowIssue") // Suppresses non-null doHandleInstance, which always needs a non-null entity.
     private ConcreteEntityMetamodel(Class<E> entityType,
                                     Map<QualifiedName, EntityCommandHandler<E>> instanceCommandHandlers,
                                     Map<QualifiedName, CommandHandler> creationalCommandHandlers,
                                     List<EntityChildMetamodel<?, E>> children,
+                                    List<EntityCommandHandlerInterceptor<E>> commandHandlerInterceptors,
                                     @Nullable EntityEvolver<E> entityEvolver) {
         this.entityType = requireNonNull(entityType, "The entityType may not be null.");
         this.entityEvolver = entityEvolver;
@@ -78,6 +85,13 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
                                                            "The instanceCommandHandlers may not be null."));
         this.creationalCommandHandlers.putAll(requireNonNull(creationalCommandHandlers,
                                                              "The creationalCommandHandlers may not be null."));
+        this.commandHandlerInterceptors = List.copyOf(
+                requireNonNull(commandHandlerInterceptors, "The commandHandlerInterceptors may not be null.")
+        );
+        this.creationalHandlerChain = composeInterceptorChain(
+                (command, entity, context) -> doHandleCreate(command, context)
+        );
+        this.instanceHandlerChain = composeInterceptorChain(this::doHandleInstance);
 
         this.children.addAll(requireNonNull(children, "The children may not be null."));
 
@@ -88,6 +102,7 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
 
         supportedCommandNames.addAll(supportedCreationalCommandNames);
         supportedCommandNames.addAll(supportedInstanceCommandNames);
+
     }
 
     /**
@@ -122,6 +137,17 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
     @Override
     public MessageStream.Single<CommandResultMessage> handleCreate(CommandMessage message,
                                                                    ProcessingContext context) {
+        try {
+            return creationalHandlerChain.proceed(message, null, context)
+                                         .mapMessage(this::asCommandResultMessage)
+                                         .first()
+                                         .cast();
+        } catch (Exception e) {
+            return MessageStream.failed(e);
+        }
+    }
+
+    private MessageStream<?> doHandleCreate(CommandMessage message, ProcessingContext context) {
         if (isInstanceCommand(message) && !isCreationalCommand(message)) {
             return MessageStream.failed(new EntityMissingForInstanceCommandHandlerException(message));
         }
@@ -143,6 +169,17 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
             E entity,
             ProcessingContext context
     ) {
+        try {
+            return instanceHandlerChain.proceed(message, entity, context)
+                                       .mapMessage(this::asCommandResultMessage)
+                                       .first()
+                                       .cast();
+        } catch (Exception e) {
+            return MessageStream.failed(e);
+        }
+    }
+
+    private MessageStream<?> doHandleInstance(CommandMessage message, E entity, ProcessingContext context) {
         if (isCreationalCommand(message) && !isInstanceCommand(message)) {
             return MessageStream.failed(new EntityAlreadyExistsForCreationalCommandHandlerException(message, entity));
         }
@@ -165,6 +202,31 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
         }
 
         return MessageStream.failed(new NoHandlerForCommandException(message, entityType));
+    }
+
+    /**
+     * Composes the {@link #commandHandlerInterceptors} registered on this metamodel around the given
+     * {@code terminal}, in registration order (first registered is outermost). Since the interceptor list is fixed
+     * once this metamodel is built, the composed chain is built once and reused for every dispatch; only the entity
+     * passed to {@link EntityCommandHandlerInterceptorChain#proceed(CommandMessage, Object, ProcessingContext)}
+     * varies per invocation.
+     */
+    private EntityCommandHandlerInterceptorChain<E> composeInterceptorChain(
+            EntityCommandHandlerInterceptorChain<E> terminal
+    ) {
+        EntityCommandHandlerInterceptorChain<E> chain = terminal;
+        for (int i = commandHandlerInterceptors.size() - 1; i >= 0; i--) {
+            EntityCommandHandlerInterceptorChain<E> next = chain;
+            EntityCommandHandlerInterceptor<E> interceptor = commandHandlerInterceptors.get(i);
+            chain = (command, entity, context) -> interceptor.interceptOnHandle(command, entity, context, next);
+        }
+        return chain;
+    }
+
+    private CommandResultMessage asCommandResultMessage(Message result) {
+        return result instanceof CommandResultMessage commandResultMessage
+                ? commandResultMessage
+                : new GenericCommandResultMessage(result);
     }
 
     @Nullable
@@ -236,6 +298,7 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
         descriptor.describeProperty("supportedCreationalCommandNames", supportedCreationalCommandNames);
         descriptor.describeProperty("entityEvolver", entityEvolver);
         descriptor.describeProperty("children", children);
+        descriptor.describeProperty("commandHandlerInterceptors", commandHandlerInterceptors);
     }
 
     @Override
@@ -255,6 +318,7 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
         private final Map<QualifiedName, EntityCommandHandler<E>> commandHandlers = new HashMap<>();
         private final Map<QualifiedName, CommandHandler> creationalCommandHandlers = new HashMap<>();
         private final List<EntityChildMetamodel<?, E>> children = new ArrayList<>();
+        private final List<EntityCommandHandlerInterceptor<E>> commandHandlerInterceptors = new ArrayList<>();
         private @Nullable EntityEvolver<E> entityEvolver;
 
         private Builder(Class<E> entityType) {
@@ -308,6 +372,13 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
         }
 
         @Override
+        public Builder<E> commandHandlerInterceptor(EntityCommandHandlerInterceptor<E> interceptor) {
+            requireNonNull(interceptor, "The interceptor may not be null.");
+            commandHandlerInterceptors.add(interceptor);
+            return this;
+        }
+
+        @Override
         public EntityMetamodelBuilder<E> entityEvolver(@Nullable EntityEvolver<E> entityEvolver) {
             this.entityEvolver = entityEvolver;
             return this;
@@ -318,6 +389,7 @@ public class ConcreteEntityMetamodel<E> implements DescribableComponent, EntityM
                                                  commandHandlers,
                                                  creationalCommandHandlers,
                                                  children,
+                                                 commandHandlerInterceptors,
                                                  entityEvolver);
         }
     }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/EntityCommandHandlerInterceptor.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/EntityCommandHandlerInterceptor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity;
+
+import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Interceptor for {@link CommandMessage CommandMessages} dispatched to an entity through its {@link EntityMetamodel}.
+ * <p>
+ * Unlike the generic {@link org.axonframework.messaging.core.MessageHandlerInterceptor}, this interceptor is aware of
+ * the entity instance the command targets, allowing it to base its decision (proceed, short-circuit, or otherwise
+ * transform the outcome) on the entity's current state. This is comparable to an {@link EntityCommandHandler}, which
+ * for the same reason also receives the entity instance directly.
+ * <p>
+ * Interceptors are registered on an {@link EntityMetamodelBuilder} through
+ * {@link EntityMetamodelBuilder#commandHandlerInterceptor(EntityCommandHandlerInterceptor)}. Registration order defines
+ * invocation order: the first registered interceptor is the outermost, invoked before any interceptor registered after
+ * it, before this entity's own command handlers, and before any command is forwarded to a child entity. When this
+ * entity is itself a child of another entity, interceptors registered on the parent entity are invoked before this
+ * entity's own interceptors.
+ * <p>
+ * The
+ * {@link org.axonframework.messaging.commandhandling.interception.annotation.CommandHandlerInterceptor
+ * CommandHandlerInterceptor} annotation is the annotation-based counterpart of this interface. Methods annotated as
+ * such on an entity class are detected and registered through the declarative configuration API.
+ *
+ * @param <E> The type of the entity modeled by this interface.
+ * @author Steven van Beelen
+ * @see EntityMetamodelBuilder#commandHandlerInterceptor(EntityCommandHandlerInterceptor)
+ * @see EntityCommandHandler
+ * @since 5.3.2
+ */
+public interface EntityCommandHandlerInterceptor<E> {
+
+    /**
+     * Intercepts the given {@code command} before it reaches this entity's command handlers, or before it is forwarded
+     * to a child entity.
+     * <p>
+     * This method is responsible for continuation. To proceed with handling, invoke
+     * {@link EntityCommandHandlerInterceptorChain#proceed(CommandMessage, Object, ProcessingContext)} on the given
+     * {@code chain}. Not invoking {@code chain} short-circuits the dispatch process, and the {@link MessageStream}
+     * returned by this method becomes the result of handling the {@code command}.
+     *
+     * @param command the {@link CommandMessage} being intercepted
+     * @param entity  the entity instance the {@code command} targets, or {@code null} when the {@code command} is a
+     *                creational command for which no entity instance exists yet
+     * @param context the {@link ProcessingContext} the {@code command} is processed in
+     * @param chain   the chain to proceed dispatching the {@code command}
+     * @return the {@link MessageStream} resulting from either proceeding the {@code chain}, or a short-circuited result
+     * produced by this interceptor
+     */
+    MessageStream<?> interceptOnHandle(CommandMessage command,
+                                       @Nullable E entity,
+                                       ProcessingContext context,
+                                       EntityCommandHandlerInterceptorChain<E> chain);
+}

--- a/modelling/src/main/java/org/axonframework/modelling/entity/EntityCommandHandlerInterceptorChain.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/EntityCommandHandlerInterceptorChain.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity;
+
+import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Chain allowing an {@link EntityCommandHandlerInterceptor} to proceed dispatching a {@link CommandMessage} to an
+ * entity, either to the next interceptor in the chain, or to the entity's own command handlers.
+ * <p>
+ * Unlike the generic {@link org.axonframework.messaging.core.MessageHandlerInterceptorChain}, this chain threads the
+ * entity instance through {@link #proceed(CommandMessage, Object, ProcessingContext)} rather than capturing it by
+ * closure.
+ *
+ * @param <E> the type of the entity modeled by this interface
+ * @author Steven van Beelen
+ * @see EntityCommandHandlerInterceptor
+ * @since 5.3.2
+ */
+@FunctionalInterface
+public interface EntityCommandHandlerInterceptorChain<E> {
+
+    /**
+     * Signals this interceptor chain to continue dispatching the {@code command}.
+     *
+     * @param command the command to pass down the chain
+     * @param entity  the entity instance the {@code command} targets, or {@code null} when the {@code command} is a
+     *                creational command for which no entity instance exists yet
+     * @param context the {@link ProcessingContext} the {@code command} is processed in
+     * @return a {@link MessageStream} containing the result of processing the given {@code command}
+     */
+    MessageStream<?> proceed(CommandMessage command, @Nullable E entity, ProcessingContext context);
+}

--- a/modelling/src/main/java/org/axonframework/modelling/entity/EntityMetamodelBuilder.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/EntityMetamodelBuilder.java
@@ -16,7 +16,6 @@
 
 package org.axonframework.modelling.entity;
 
-import org.jspecify.annotations.Nullable;
 import org.axonframework.messaging.commandhandling.CommandHandler;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.core.QualifiedName;
@@ -24,6 +23,7 @@ import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.modelling.EntityEvolver;
 import org.axonframework.modelling.entity.child.EntityChildMetamodel;
 import org.axonframework.modelling.repository.Repository;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Builder for an {@link EntityMetamodel} instance, allowing the registration of command handlers, an entity evolver,
@@ -53,7 +53,7 @@ import org.axonframework.modelling.repository.Repository;
  *     {@link EntityAlreadyExistsForCreationalCommandHandlerException} will be thrown.</li>
  * </ul>
  *
- * @param <E> The type of the entity modeled by this interface.
+ * @param <E> the type of the entity modeled by this interface
  * @author Mitchell Herrijgers
  * @since 5.0.0
  */
@@ -69,11 +69,11 @@ public interface EntityMetamodelBuilder<E> {
      * {@code qualifiedName} when the entity is not yet created.
      * <p>
      * You can register the same {@link QualifiedName} for both instance and creational command handlers. See the
-     * {@link EntityMetamodelBuilder} class documentation for more information on how this works.
+     * {@code EntityMetamodelBuilder} class documentation for more information on how this works.
      *
-     * @param qualifiedName  The {@link QualifiedName} of the command this handler handles.
-     * @param messageHandler The {@link EntityCommandHandler} to handle the command.
-     * @return This builder for further configuration.
+     * @param qualifiedName  the {@link QualifiedName} of the command this handler handles
+     * @param messageHandler the {@link EntityCommandHandler} to handle the command
+     * @return this builder for further configuration
      */
     EntityMetamodelBuilder<E> instanceCommandHandler(QualifiedName qualifiedName,
                                                      EntityCommandHandler<E> messageHandler);
@@ -88,23 +88,23 @@ public interface EntityMetamodelBuilder<E> {
      * {@code qualifiedName} when the entity is not yet created.
      * <p>
      * You can register the same {@link QualifiedName} for both instance and creational command handlers. See the
-     * {@link EntityMetamodelBuilder} class documentation for more information on how this works.
+     * {@code EntityMetamodelBuilder} class documentation for more information on how this works.
      * <p>
      * Note: If this metamodel is added as a child to another entity metamodel and has a creational command handler, it
      * will result in an exception as child entities cannot be created through a creational command handler.
      *
-     * @param qualifiedName  The {@link QualifiedName} of the command this handler handles.
-     * @param messageHandler The {@link CommandHandler} to handle the command.
-     * @return This builder for further configuration.
+     * @param qualifiedName  the {@link QualifiedName} of the command this handler handles
+     * @param messageHandler the {@link CommandHandler} to handle the command
+     * @return this builder for further configuration
      */
     EntityMetamodelBuilder<E> creationalCommandHandler(QualifiedName qualifiedName,
                                                        CommandHandler messageHandler);
 
     /**
-     * Adds a {@link EntityChildMetamodel} to this metamodel. The child metamodel will be used to handle
-     * commands for the child entity. You can build a tree of entities by adding child metamodels to the parent
-     * metamodel. Children command handlers take precedence over the parent command handlers. Event handlers will be
-     * invoked on both the parent and child metamodels, but the child metamodels will be invoked first.
+     * Adds a {@link EntityChildMetamodel} to this metamodel. The child metamodel will be used to handle commands for
+     * the child entity. You can build a tree of entities by adding child metamodels to the parent metamodel. Children
+     * command handlers take precedence over the parent command handlers. Event handlers will be invoked on both the
+     * parent and child metamodels, but the child metamodels will be invoked first.
      * <p>
      * There are various types of children that can be added to an entity metamodel:
      * <ul>
@@ -117,10 +117,29 @@ public interface EntityMetamodelBuilder<E> {
      * with a matching entity. If no child can handle the command, an exception will be thrown. If after
      * filtering, multiple children can handle the command, an exception will be thrown.
      *
-     * @param child The {@link EntityChildMetamodel} to add.
-     * @return This builder for further configuration.
+     * @param child the {@link EntityChildMetamodel} to add
+     * @return this builder for further configuration
      */
     EntityMetamodelBuilder<E> addChild(EntityChildMetamodel<?, E> child);
+
+    /**
+     * Adds an {@link EntityCommandHandlerInterceptor} to this metamodel.
+     * <p>
+     * Registration order defines invocation order. The first registered interceptor is the outermost, invoked before
+     * any interceptor registered after it, before this entity's own command handlers (both
+     * {@link #instanceCommandHandler(QualifiedName, EntityCommandHandler) instance} and
+     * {@link #creationalCommandHandler(QualifiedName, CommandHandler) creational}), and before any command is forwarded
+     * to a child entity added through {@link #addChild(EntityChildMetamodel)}. When this metamodel is itself added as a
+     * child to another entity metamodel, interceptors registered on the parent entity are invoked before this entity's
+     * own interceptors.
+     * <p>
+     * Calling this method multiple times registers multiple interceptors. It does not override previously registered
+     * interceptors.
+     *
+     * @param interceptor the {@link EntityCommandHandlerInterceptor} to register
+     * @return this builder for further configuration
+     */
+    EntityMetamodelBuilder<E> commandHandlerInterceptor(EntityCommandHandlerInterceptor<E> interceptor);
 
     /**
      * Adds a {@link EntityEvolver} to this metamodel. This evolver will be called upon applying an event to the entity.
@@ -129,8 +148,8 @@ public interface EntityMetamodelBuilder<E> {
      * <p>
      * Calling this method a second time will override the previously set evolver.
      *
-     * @param entityEvolver The {@link EntityEvolver} to use.
-     * @return This builder for further configuration.
+     * @param entityEvolver the {@link EntityEvolver} to use
+     * @return this builder for further configuration
      */
     EntityMetamodelBuilder<E> entityEvolver(@Nullable EntityEvolver<E> entityEvolver);
 
@@ -138,7 +157,7 @@ public interface EntityMetamodelBuilder<E> {
      * Builds the {@link EntityMetamodel} instance based on the configuration of this builder. This method should be
      * called after all configuration is done.
      *
-     * @return The {@link EntityMetamodel} instance based on the configuration of this builder.
+     * @return the {@link EntityMetamodel} instance based on the configuration of this builder
      */
     EntityMetamodel<E> build();
 }

--- a/modelling/src/main/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodel.java
@@ -228,6 +228,11 @@ public class PolymorphicEntityMetamodel<E> implements EntityMetamodel<E>, Descri
             return this;
         }
 
+        @Override
+        public Builder<E> commandHandlerInterceptor(EntityCommandHandlerInterceptor<E> interceptor) {
+            superTypeBuilder.commandHandlerInterceptor(interceptor);
+            return this;
+        }
 
         @Override
         public Builder<E> entityEvolver(@Nullable EntityEvolver<E> entityEvolver) {

--- a/modelling/src/main/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodelBuilder.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodelBuilder.java
@@ -46,6 +46,9 @@ public interface PolymorphicEntityMetamodelBuilder<E> extends EntityMetamodelBui
     PolymorphicEntityMetamodelBuilder<E> addChild(EntityChildMetamodel<?, E> child);
 
     @Override
+    PolymorphicEntityMetamodelBuilder<E> commandHandlerInterceptor(EntityCommandHandlerInterceptor<E> interceptor);
+
+    @Override
     PolymorphicEntityMetamodelBuilder<E> entityEvolver(@Nullable EntityEvolver<E> entityEvolver);
 
     /**

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
@@ -27,6 +27,7 @@ import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
 import org.axonframework.messaging.commandhandling.annotation.CommandHandlingMember;
+import org.axonframework.messaging.core.Message;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.MessageTypeResolver;
@@ -36,11 +37,13 @@ import org.axonframework.messaging.core.annotation.HandlerDefinition;
 import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
 import org.axonframework.messaging.core.conversion.MessageConverter;
+import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.conversion.EventConverter;
 import org.axonframework.modelling.annotation.AnnotationBasedEntityEvolvingComponent;
 import org.axonframework.modelling.entity.ConcreteEntityMetamodel;
+import org.axonframework.modelling.entity.EntityCommandHandlerInterceptorChain;
 import org.axonframework.modelling.entity.EntityMetamodel;
 import org.axonframework.modelling.entity.EntityMetamodelBuilder;
 import org.axonframework.modelling.entity.PolymorphicEntityMetamodel;
@@ -279,6 +282,7 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
                 entityType, inspected, eventConverter, messageTypeResolver
         ));
         initializeDetectedHandlers(builder, inspected);
+        registerCommandInterceptors(builder, inspected);
         initializeChildren(builder);
         return builder.build();
     }
@@ -306,6 +310,7 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
         // Commands that are present on the parent entity should not be registered again on the concrete
         // types. So we tell concrete types to skip these commands.
         LinkedList<QualifiedName> registeredCommands = initializeDetectedHandlers(builder, inspected);
+        registerCommandInterceptors(builder, inspected);
         concreteTypes.forEach(concreteType -> {
             AnnotatedEntityMetamodel<? extends E> createdConcreteEntityModel = new AnnotatedEntityMetamodel<>(
                     concreteType, Set.of(), parameterResolverFactory, handlerDefinition, messageTypeResolver,
@@ -366,6 +371,74 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
                     .handle(command, context, entity)
                     .<CommandResultMessage>mapMessage(GenericCommandResultMessage::new)
                     .first()));
+        }
+    }
+
+    /**
+     * Bridges annotated {@code @CommandHandlerInterceptor}/{@code @MessageHandlerInterceptor} methods detected by the
+     * given {@code inspected} inspector into a single {@link org.axonframework.modelling.entity.EntityCommandHandlerInterceptor}
+     * registered on the declarative {@code builder}. This is the only entry point annotated interceptors have into
+     * entity command dispatch: ordering, before/surround-style handling, and comparator-based ordering between
+     * multiple annotated interceptor methods are all delegated to the existing
+     * {@link AnnotatedHandlerInspector#chainedInterceptor(Class)} machinery, which already backs
+     * {@code AnnotatedCommandHandlingComponent} for top-level annotated components.
+     */
+    private void registerCommandInterceptors(EntityMetamodelBuilder<E> builder, AnnotatedHandlerInspector<E> inspected) {
+        if (inspected.getAllInterceptors().getOrDefault(entityType, Collections.emptySortedSet()).isEmpty()) {
+            return;
+        }
+        MessageHandlerInterceptorMemberChain<E> memberChain = inspected.chainedInterceptor(entityType);
+        builder.commandHandlerInterceptor((command, entity, context, chain) ->
+                memberChain.handle(command, context, entity, new EntityDispatchHandlingMember<>(chain))
+                           .mapMessage(this::asCommandResultMessage)
+                           .first()
+                           .cast()
+        );
+    }
+
+    private CommandResultMessage asCommandResultMessage(Message result) {
+        return result instanceof CommandResultMessage commandResultMessage
+                ? commandResultMessage
+                : new GenericCommandResultMessage(result);
+    }
+
+    /**
+     * Bridges an entity's own {@link EntityCommandHandlerInterceptorChain} into the {@link MessageHandlingMember}
+     * shape that a {@link MessageHandlerInterceptorMemberChain} expects as its terminal: once every annotated
+     * interceptor has run (or short-circuited), the chain invokes this member, which simply proceeds the entity's own
+     * dispatch chain, passing the {@code target} threaded through the reflection-side chain along as the entity.
+     */
+    private static final class EntityDispatchHandlingMember<E> implements MessageHandlingMember<E> {
+
+        private final EntityCommandHandlerInterceptorChain<E> chain;
+
+        private EntityDispatchHandlingMember(EntityCommandHandlerInterceptorChain<E> chain) {
+            this.chain = chain;
+        }
+
+        @Override
+        public Class<?> payloadType() {
+            return Object.class;
+        }
+
+        @Override
+        public boolean canHandle(Message message, ProcessingContext context) {
+            return true;
+        }
+
+        @Override
+        public boolean canHandleMessageType(Class<? extends Message> messageType) {
+            return true;
+        }
+
+        @Override
+        public <HT> Optional<HT> unwrap(Class<HT> handlerType) {
+            return Optional.empty();
+        }
+
+        @Override
+        public MessageStream<?> handle(Message message, ProcessingContext context, @Nullable E target) {
+            return chain.proceed((CommandMessage) message, target, context);
         }
     }
 

--- a/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
+++ b/modelling/src/main/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodel.java
@@ -244,9 +244,13 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
      *                                 classes
      * @param eventConverter           the converter used to convert the {@link EventMessage#payload()} to the desired
      *                                 format
-     * @param commandsToSkip           the commands to skip when initializing the metamodel. This is useful to prevent
-     *                                 concrete implementations from registering commands that are already registered by
-     *                                 the abstract entity type, as this will lead to problems
+     * @param commandsToSkip           the creational commands to skip when initializing the metamodel. This prevents a
+     *                                 concrete implementation from re-registering a creational command handler already
+     *                                 registered by the polymorphic super type, which {@link PolymorphicEntityMetamodel}
+     *                                 would otherwise reject as a clash between concrete types. Instance command
+     *                                 handlers are never skipped: each concrete type re-registers any it inherits, so
+     *                                 that its own command handler interceptors still apply when it handles the
+     *                                 command directly
      */
     private AnnotatedEntityMetamodel(
             Class<E> entityType,
@@ -307,14 +311,14 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
                                                                            eventConverter,
                                                                            messageTypeResolver));
         initializeChildren(builder);
-        // Commands that are present on the parent entity should not be registered again on the concrete
-        // types. So we tell concrete types to skip these commands.
-        LinkedList<QualifiedName> registeredCommands = initializeDetectedHandlers(builder, inspected);
+        // Creational commands present on the super type must not be re-registered on a concrete type: see
+        // initializeDetectedHandlers and the commandsToSkip javadoc for why.
+        List<QualifiedName> registeredCreationalCommands = initializeDetectedHandlers(builder, inspected);
         registerCommandInterceptors(builder, inspected);
         concreteTypes.forEach(concreteType -> {
             AnnotatedEntityMetamodel<? extends E> createdConcreteEntityModel = new AnnotatedEntityMetamodel<>(
                     concreteType, Set.of(), parameterResolverFactory, handlerDefinition, messageTypeResolver,
-                    messageConverter, eventConverter, registeredCommands
+                    messageConverter, eventConverter, registeredCreationalCommands
             );
             concreteMetamodels.add(createdConcreteEntityModel);
             builder.addConcreteType(createdConcreteEntityModel);
@@ -326,40 +330,51 @@ public class AnnotatedEntityMetamodel<E> implements EntityMetamodel<E>, Describa
         return !ReflectionUtils.collectMatchingMethodsAndFields(type, isAnnotatedWith(EntityMember.class)).isEmpty();
     }
 
-    private LinkedList<QualifiedName> initializeDetectedHandlers(
+    private List<QualifiedName> initializeDetectedHandlers(
             EntityMetamodelBuilder<E> builder, AnnotatedHandlerInspector<E> inspected
     ) {
-        LinkedList<QualifiedName> registeredCommands = new LinkedList<>();
+        List<QualifiedName> registeredCreationalCommands = new LinkedList<>();
         Stream.concat(inspected.getUniqueHandlers(entityType, CommandMessage.class).stream(),
                       inspected.getUniqueHandlers(entityType, EventMessage.class).stream())
               .filter(h -> h.unwrap(Method.class).map(m -> !Modifier.isAbstract(m.getModifiers())).orElse(false))
               .forEach(handler -> {
                      QualifiedName qualifiedName = messageTypeResolver.resolveOrThrow(handler.payloadType())
                                                                       .qualifiedName();
-                     if (commandsToSkip.contains(qualifiedName)) {
+                     if (isCreationalCommandHandler(handler) && commandsToSkip.contains(qualifiedName)) {
+                         // Only creational handlers are skipped: a concrete type re-registering a creational
+                         // command already registered by the polymorphic super type would otherwise make
+                         // PolymorphicEntityMetamodelBuilder#addConcreteType reject it as a clashing creational
+                         // command. Instance commands have no such clash check, and inherited (non-overridden)
+                         // instance handlers must be re-registered here so this concrete type's own interceptors
+                         // (annotated or declarative) still wrap them when this concrete metamodel handles the
+                         // command directly, instead of only the super type's.
                          logger.debug(
-                                 "Skipping registration of command handler for [{}] on [{}] "
+                                 "Skipping registration of creational command handler for [{}] on [{}] "
                                          + "(already registered by parent)",
                                  qualifiedName,
                                  entityType);
                          return;
                      }
                      addPayloadTypeFromHandler(qualifiedName, handler);
-                     addCommandHandlerToModel(builder, handler, qualifiedName, registeredCommands);
+                     addCommandHandlerToModel(builder, handler, qualifiedName, registeredCreationalCommands);
                  });
-        return registeredCommands;
+        return registeredCreationalCommands;
+    }
+
+    private boolean isCreationalCommandHandler(MessageHandlingMember<? super E> handler) {
+        return handler instanceof CommandHandlingMember<? super E> commandMember && commandMember.isFactoryHandler();
     }
 
     private void addCommandHandlerToModel(EntityMetamodelBuilder<E> builder,
                                           MessageHandlingMember<? super E> handler,
                                           QualifiedName qualifiedName,
-                                          LinkedList<QualifiedName> registeredCommands
+                                          List<QualifiedName> registeredCreationalCommands
     ) {
         if (!(handler instanceof CommandHandlingMember<? super E> commandMember)) {
             return;
         }
-        registeredCommands.add(qualifiedName);
         if (commandMember.isFactoryHandler()) {
+            registeredCreationalCommands.add(qualifiedName);
             logger.debug("Registered creational command handler for [{}] on [{}]", qualifiedName, entityType);
             builder.creationalCommandHandler(qualifiedName, ((command, context) -> handler
                     .handle(command, context, null)

--- a/modelling/src/test/java/org/axonframework/modelling/entity/ConcreteEntityMetamodelInterceptorTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/ConcreteEntityMetamodelInterceptorTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity;
+
+import org.axonframework.messaging.commandhandling.CommandHandler;
+import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.messaging.commandhandling.CommandResultMessage;
+import org.axonframework.messaging.commandhandling.GenericCommandMessage;
+import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageStreamTestUtils;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.core.QualifiedName;
+import org.axonframework.messaging.core.unitofwork.ProcessingContext;
+import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.modelling.entity.child.ChildEntityFieldDefinition;
+import org.axonframework.modelling.entity.child.SingleEntityChildMetamodel;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * Test class validating the {@link EntityCommandHandlerInterceptor} support as provided in the
+ * {@link ConcreteEntityMetamodel}.
+ *
+ * @author Steven van Beelen
+ */
+class ConcreteEntityMetamodelInterceptorTest {
+
+    private static final QualifiedName INSTANCE_COMMAND = new QualifiedName("InstanceCommand");
+    private static final QualifiedName CREATIONAL_COMMAND = new QualifiedName("CreationalCommand");
+    private static final QualifiedName CHILD_COMMAND = new QualifiedName("ChildCommand");
+
+    private final TestEntity entity = new TestEntity();
+    private final ProcessingContext context = new StubProcessingContext();
+
+    @SuppressWarnings("unchecked")
+    private final EntityCommandHandler<TestEntity> instanceHandler = mock(EntityCommandHandler.class);
+    private final CommandHandler creationalHandler = mock(CommandHandler.class);
+
+    @BeforeEach
+    void setUp() {
+        when(instanceHandler.handle(any(), any(), any()))
+                .thenReturn(MessageStream.just(
+                        new GenericCommandResultMessage(new MessageType(String.class), "handled")
+                ));
+        when(creationalHandler.handle(any(), any()))
+                .thenReturn(MessageStream.just(
+                        new GenericCommandResultMessage(new MessageType(String.class), "created")
+                ));
+    }
+
+    private EntityMetamodelBuilder<TestEntity> testSubjectBuilder() {
+        return ConcreteEntityMetamodel.forEntityClass(TestEntity.class)
+                                      .instanceCommandHandler(INSTANCE_COMMAND, instanceHandler)
+                                      .creationalCommandHandler(CREATIONAL_COMMAND, creationalHandler);
+    }
+
+    @Test
+    void interceptorProceedingInvokesHandler() {
+        // given...
+        CommandMessage testCommand = new GenericCommandMessage(new MessageType(INSTANCE_COMMAND), "payload");
+        EntityMetamodel<TestEntity> testSubject = testSubjectBuilder()
+                .commandHandlerInterceptor((command, entity, context, chain) -> chain.proceed(command, entity, context))
+                .build();
+        // when...
+        MessageStream.Single<CommandResultMessage> result = testSubject.handleInstance(testCommand, entity, context);
+        // then...
+        Object resultPayload = result.asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("handled");
+        verify(instanceHandler).handle(testCommand, entity, context);
+    }
+
+    @Test
+    void interceptorShortCircuitingPreventsHandlerInvocation() {
+        // given...
+        CommandMessage testCommand = new GenericCommandMessage(new MessageType(INSTANCE_COMMAND), "payload");
+        EntityMetamodel<TestEntity> testSubject = testSubjectBuilder()
+                .commandHandlerInterceptor((command, entity, context, chain) -> MessageStream.just(
+                        new GenericCommandResultMessage(new MessageType(String.class), "intercepted")
+                ))
+                .build();
+        // when...
+        MessageStream.Single<CommandResultMessage> result = testSubject.handleInstance(testCommand, entity, context);
+        // then...
+        Object resultPayload = result.asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("intercepted");
+        verify(instanceHandler, never()).handle(any(), any(), any());
+    }
+
+    @Test
+    void multipleInterceptorsAreInvokedInRegistrationOrder() {
+        // given...
+        CommandMessage testCommand = new GenericCommandMessage(new MessageType(INSTANCE_COMMAND), "payload");
+        List<String> invocations = new ArrayList<>();
+        EntityCommandHandlerInterceptor<TestEntity> first = (command, ent, ctx, chain) -> {
+            invocations.add("first");
+            return chain.proceed(command, ent, ctx);
+        };
+        EntityCommandHandlerInterceptor<TestEntity> second = (command, ent, ctx, chain) -> {
+            invocations.add("second");
+            return chain.proceed(command, ent, ctx);
+        };
+        EntityMetamodel<TestEntity> testSubject = testSubjectBuilder()
+                .commandHandlerInterceptor(first)
+                .commandHandlerInterceptor(second)
+                .build();
+        // when...
+        testSubject.handleInstance(testCommand, entity, context).asCompletableFuture().join();
+        // then...
+        assertThat(invocations).containsExactly("first", "second");
+    }
+
+    @Test
+    void interceptorAlsoWrapsCreationalDispatchWithNullEntity() {
+        // given...
+        CommandMessage testCommand = new GenericCommandMessage(new MessageType(CREATIONAL_COMMAND), "payload");
+        EntityCommandHandlerInterceptor<TestEntity> interceptor = (command, entity, context, chain) -> {
+            assertThat(entity).isNull();
+            return chain.proceed(command, entity, context);
+        };
+        EntityMetamodel<TestEntity> testSubject = testSubjectBuilder().commandHandlerInterceptor(interceptor).build();
+        // when...
+        MessageStream.Single<CommandResultMessage> result = testSubject.handleCreate(testCommand, context);
+        // then...
+        Object resultPayload = result.asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("created");
+        verify(creationalHandler).handle(testCommand, context);
+    }
+
+    @Test
+    void interceptorThrowingSynchronouslyResultsInFailedMessageStreamInsteadOfPropagating() {
+        // given...
+        CommandMessage testCommand = new GenericCommandMessage(new MessageType(INSTANCE_COMMAND), "payload");
+        EntityCommandHandlerInterceptor<TestEntity> interceptor = (command, ent, ctx, chain) -> {
+            throw new IllegalStateException("Interceptor exploded");
+        };
+        EntityMetamodel<TestEntity> testSubject = testSubjectBuilder().commandHandlerInterceptor(interceptor).build();
+        // when/then...
+        MessageStreamTestUtils.assertCompletedExceptionally(
+                testSubject.handleInstance(testCommand, entity, context),
+                IllegalStateException.class,
+                "Interceptor exploded"
+        );
+    }
+
+    @Test
+    void parentInterceptorIsInvokedBeforeChildInterceptorForCommandRoutedToChild() {
+        // given...
+        CommandMessage testCommand = new GenericCommandMessage(new MessageType(CHILD_COMMAND), "payload");
+        List<String> invocations = new ArrayList<>();
+        TestChildEntity childEntity = new TestChildEntity();
+        @SuppressWarnings("unchecked")
+        EntityCommandHandler<TestChildEntity> childHandler = mock(EntityCommandHandler.class);
+        when(childHandler.handle(any(), any(), any())).thenReturn(
+                MessageStream.just(new GenericCommandResultMessage(new MessageType(String.class), "child-handled"))
+        );
+        EntityMetamodel<TestChildEntity> childMetamodel = ConcreteEntityMetamodel
+                .forEntityClass(TestChildEntity.class)
+                .instanceCommandHandler(CHILD_COMMAND, childHandler)
+                .commandHandlerInterceptor((command, ent, ctx, chain) -> {
+                    invocations.add("child");
+                    return chain.proceed(command, ent, ctx);
+                })
+                .build();
+        @SuppressWarnings("unchecked")
+        ChildEntityFieldDefinition<TestEntity, TestChildEntity> fieldDefinition =
+                mock(ChildEntityFieldDefinition.class);
+        when(fieldDefinition.getChildValue(any())).thenReturn(childEntity);
+        EntityMetamodel<TestEntity> testSubject = ConcreteEntityMetamodel
+                .forEntityClass(TestEntity.class)
+                .commandHandlerInterceptor((command, entity, context, chain) -> {
+                    invocations.add("parent");
+                    return chain.proceed(command, entity, context);
+                })
+                .addChild(SingleEntityChildMetamodel.forEntityModel(TestEntity.class, childMetamodel)
+                                                    .childEntityFieldDefinition(fieldDefinition)
+                                                    .build())
+                .build();
+        // when...
+        MessageStream.Single<CommandResultMessage> result =
+                testSubject.handleInstance(testCommand, entity, context);
+        // then...
+        Object resultPayload = result.asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("child-handled");
+        assertThat(invocations).containsExactly("parent", "child");
+        verify(childHandler).handle(testCommand, childEntity, context);
+    }
+
+    private static class TestEntity {
+
+    }
+
+    private static class TestChildEntity {
+
+    }
+}

--- a/modelling/src/test/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodelTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/PolymorphicEntityMetamodelTest.java
@@ -16,30 +16,40 @@
 
 package org.axonframework.modelling.entity;
 
+import org.axonframework.common.infra.MockComponentDescriptor;
 import org.axonframework.messaging.commandhandling.CommandHandler;
 import org.axonframework.messaging.commandhandling.CommandMessage;
 import org.axonframework.messaging.commandhandling.CommandResultMessage;
 import org.axonframework.messaging.commandhandling.GenericCommandMessage;
 import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
-import org.axonframework.common.infra.MockComponentDescriptor;
-import org.axonframework.messaging.eventhandling.EventMessage;
-import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageStreamTestUtils;
 import org.axonframework.messaging.core.MessageType;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 import org.axonframework.messaging.core.unitofwork.StubProcessingContext;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
 import org.axonframework.modelling.EntityEvolver;
 import org.junit.jupiter.api.*;
 import org.mockito.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.*;
 
+/**
+ * Test class validating the {@link EntityCommandHandlerInterceptor} support as provided in the
+ * {@link PolymorphicEntityMetamodel}.
+ *
+ * @author Steven van Beelen
+ */
 class PolymorphicEntityMetamodelTest {
 
     public static final QualifiedName SUPER_TYPE_INSTANCE_COMMAND = new QualifiedName("SuperTypeInstanceCommand");
@@ -130,7 +140,10 @@ class PolymorphicEntityMetamodelTest {
                                                                                          entity,
                                                                                          context);
 
-        assertEquals("concrete-one", result.first().asCompletableFuture().join().message().payload());
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("concrete-one");
         verify(concreteTestEntityOneEntityMetamodel, times(1)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -147,7 +160,10 @@ class PolymorphicEntityMetamodelTest {
         ProcessingContext context = new StubProcessingContext();
         MessageStream<CommandResultMessage> result = polymorphicMetamodel.handleCreate(commandMessage, context);
 
-        assertEquals("concrete-one-create", result.first().asCompletableFuture().join().message().payload());
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("concrete-one-create");
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(1)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -168,7 +184,10 @@ class PolymorphicEntityMetamodelTest {
                                                                                          entity,
                                                                                          context);
 
-        assertEquals("concrete-two", result.first().asCompletableFuture().join().message().payload());
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("concrete-two");
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(1)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -185,7 +204,10 @@ class PolymorphicEntityMetamodelTest {
         ProcessingContext context = new StubProcessingContext();
         MessageStream<CommandResultMessage> result = polymorphicMetamodel.handleCreate(commandMessage, context);
 
-        assertEquals("concrete-two-create", result.first().asCompletableFuture().join().message().payload());
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("concrete-two-create");
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
@@ -205,7 +227,10 @@ class PolymorphicEntityMetamodelTest {
                                                                                          entity,
                                                                                          context);
 
-        assertEquals("super-type", result.first().asCompletableFuture().join().message().payload());
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("super-type");
         verify(entityInstanceCommandHandler).handle(eq(commandMessage), same(entity), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
@@ -223,7 +248,10 @@ class PolymorphicEntityMetamodelTest {
         ProcessingContext context = new StubProcessingContext();
         MessageStream<CommandResultMessage> result = polymorphicMetamodel.handleCreate(commandMessage, context);
 
-        assertEquals("super-type-create", result.first().asCompletableFuture().join().message().payload());
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("super-type-create");
         verify(entityCreationalCommandHandler).handle(eq(commandMessage), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleCreate(eq(commandMessage), eq(context));
@@ -244,10 +272,68 @@ class PolymorphicEntityMetamodelTest {
                                                                                          entity,
                                                                                          context);
 
-        assertEquals("super-type", result.first().asCompletableFuture().join().message().payload());
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("super-type");
         verify(entityInstanceCommandHandler).handle(eq(commandMessage), same(entity), eq(context));
         verify(concreteTestEntityOneEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
         verify(concreteTestEntityTwoEntityMetamodel, times(0)).handleInstance(eq(commandMessage), any(), eq(context));
+    }
+
+    @Test
+    void commandHandlerInterceptorRegisteredOnPolymorphicBuilderInterceptsSuperTypeCommand() {
+        List<String> invocations = new ArrayList<>();
+        polymorphicMetamodel = PolymorphicEntityMetamodel
+                .forSuperType(AbstractTestEntity.class)
+                .addConcreteType(concreteTestEntityOneEntityMetamodel)
+                .addConcreteType(concreteTestEntityTwoEntityMetamodel)
+                .instanceCommandHandler(SUPER_TYPE_INSTANCE_COMMAND, entityInstanceCommandHandler)
+                .commandHandlerInterceptor((command, entity, ctx, chain) -> {
+                    invocations.add("intercepted");
+                    return chain.proceed(command, entity, ctx);
+                })
+                .build();
+
+        CommandMessage commandMessage = new GenericCommandMessage(new MessageType(SUPER_TYPE_INSTANCE_COMMAND),
+                                                                  "concrete-one");
+        ProcessingContext context = StubProcessingContext.forMessage(commandMessage);
+        ConcreteTestEntityOne entity = new ConcreteTestEntityOne();
+
+        MessageStream<CommandResultMessage> result = polymorphicMetamodel.handleInstance(commandMessage,
+                                                                                         entity,
+                                                                                         context);
+
+        Object resultPayload = result.first()
+                                     .asCompletableFuture().orTimeout(50, TimeUnit.MILLISECONDS).join()
+                                     .message().payload();
+        assertThat(resultPayload).isEqualTo("super-type");
+        assertThat(invocations).containsExactly("intercepted");
+    }
+
+    @Test
+    void commandHandlerInterceptorRegisteredOnPolymorphicBuilderDoesNotInterceptConcreteTypeOnlyCommand() {
+        List<String> invocations = new ArrayList<>();
+        polymorphicMetamodel = PolymorphicEntityMetamodel
+                .forSuperType(AbstractTestEntity.class)
+                .addConcreteType(concreteTestEntityOneEntityMetamodel)
+                .addConcreteType(concreteTestEntityTwoEntityMetamodel)
+                .instanceCommandHandler(SUPER_TYPE_INSTANCE_COMMAND, entityInstanceCommandHandler)
+                .commandHandlerInterceptor((command, entity, ctx, chain) -> {
+                    invocations.add("intercepted");
+                    return chain.proceed(command, entity, ctx);
+                })
+                .build();
+
+        CommandMessage commandMessage = new GenericCommandMessage(new MessageType(CONCRETE_ONE_INSTANCE_COMMAND),
+                                                                  "concrete-one-instance");
+        ProcessingContext context = StubProcessingContext.forMessage(commandMessage);
+        ConcreteTestEntityOne entity = new ConcreteTestEntityOne();
+
+        polymorphicMetamodel.handleInstance(commandMessage, entity, context);
+
+        // Dispatched straight to the (mocked) concrete-type metamodel; the super type's own interceptor never runs.
+        assertThat(invocations).isEmpty();
     }
 
     @Test
@@ -314,9 +400,8 @@ class PolymorphicEntityMetamodelTest {
         ConcreteTestEntityOne entity = new ConcreteTestEntityOne();
         ProcessingContext context = StubProcessingContext.forMessage(eventMessage);
         AbstractTestEntity result = polymorphicMetamodel.evolve(entity, eventMessage, context);
-        assertInstanceOf(ConcreteTestEntityTwo.class, result);
+        assertThat(result).isInstanceOf(ConcreteTestEntityTwo.class);
     }
-
 
     @Test
     void concreteTypeEvolverCanBeUsedToMorphTheConcreteType() {
@@ -334,12 +419,12 @@ class PolymorphicEntityMetamodelTest {
         ConcreteTestEntityOne entity = new ConcreteTestEntityOne();
         ProcessingContext context = StubProcessingContext.forMessage(eventMessage);
         AbstractTestEntity result = polymorphicMetamodel.evolve(entity, eventMessage, context);
-        assertInstanceOf(ConcreteTestEntityTwo.class, result);
+        assertThat(result).isInstanceOf(ConcreteTestEntityTwo.class);
     }
 
     @Test
     void returnsSuperTypeAsEntityType() {
-        assertEquals(AbstractTestEntity.class, polymorphicMetamodel.entityType());
+        assertThat(polymorphicMetamodel.entityType()).isEqualTo(AbstractTestEntity.class);
     }
 
     @Test
@@ -352,7 +437,7 @@ class PolymorphicEntityMetamodelTest {
                 CONCRETE_TWO_INSTANCE_COMMAND,
                 CONCRETE_ONE_INSTANCE_COMMAND
         );
-        assertEquals(expectedCommands, polymorphicMetamodel.supportedCommands());
+        assertThat(polymorphicMetamodel.supportedCommands()).isEqualTo(expectedCommands);
     }
 
     @Test
@@ -360,19 +445,19 @@ class PolymorphicEntityMetamodelTest {
         MockComponentDescriptor descriptor = new MockComponentDescriptor();
         polymorphicMetamodel.describeTo(descriptor);
 
-        assertEquals(AbstractTestEntity.class, descriptor.getProperty("entityType"));
+        assertThat((Object) descriptor.getProperty("entityType")).isEqualTo(AbstractTestEntity.class);
         EntityMetamodel<AbstractTestEntity> superTypeMetamodel = descriptor.getProperty("superTypeMetamodel");
         superTypeMetamodel.describeTo(descriptor);
 
-        assertEquals(entityEvolver, descriptor.getProperty("entityEvolver"));
-        assertEquals(Map.of(
+        assertThat((Object) descriptor.getProperty("entityEvolver")).isEqualTo(entityEvolver);
+        assertThat((Object) descriptor.getProperty("commandHandlers")).isEqualTo(Map.of(
                 SUPER_TYPE_INSTANCE_COMMAND, entityInstanceCommandHandler
-        ), descriptor.getProperty("commandHandlers"));
+        ));
 
-        assertEquals(Map.of(
+        assertThat((Object) descriptor.getProperty("polymorphicMetamodels")).isEqualTo(Map.of(
                 ConcreteTestEntityOne.class, concreteTestEntityOneEntityMetamodel,
                 ConcreteTestEntityTwo.class, concreteTestEntityTwoEntityMetamodel
-        ), descriptor.getProperty("polymorphicMetamodels"));
+        ));
     }
 
     @Nested
@@ -386,8 +471,8 @@ class PolymorphicEntityMetamodelTest {
                     .addConcreteType(concreteTestEntityOneEntityMetamodel)
                     .addConcreteType(concreteTestEntityTwoEntityMetamodel);
 
-            assertThrows(IllegalArgumentException.class,
-                         () -> builder.addConcreteType(concreteTestEntityOneEntityMetamodel));
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> builder.addConcreteType(concreteTestEntityOneEntityMetamodel));
         }
 
         @Test
@@ -400,8 +485,8 @@ class PolymorphicEntityMetamodelTest {
                     .forSuperType(AbstractTestEntity.class)
                     .addConcreteType(concreteTestEntityOneEntityMetamodel);
 
-            assertThrows(IllegalArgumentException.class,
-                         () -> builder.addConcreteType(concreteTestEntityTwoEntityMetamodel));
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> builder.addConcreteType(concreteTestEntityTwoEntityMetamodel));
         }
 
         @Test
@@ -409,7 +494,7 @@ class PolymorphicEntityMetamodelTest {
             PolymorphicEntityMetamodelBuilder<AbstractTestEntity> builder = PolymorphicEntityMetamodel.forSuperType(
                     AbstractTestEntity.class);
 
-            assertThrows(NullPointerException.class, () -> {
+            assertThatExceptionOfType(NullPointerException.class).isThrownBy(() -> {
                 //noinspection DataFlowIssue
                 builder.addConcreteType(null);
             });

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodelCommandInterceptorTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodelCommandInterceptorTest.java
@@ -182,6 +182,82 @@ class AnnotatedEntityMetamodelCommandInterceptorTest {
     }
 
     /**
+     * A concrete type's own interceptor must still run when the command it intercepts is declared (and handled) on
+     * the polymorphic super type, not on the concrete type itself. Before this was fixed, dispatch never visited the
+     * concrete type's own metamodel for such a command, so its interceptor was silently skipped.
+     */
+    @Nested
+    class ConcreteTypeInterceptorWithSupertypeHandler extends AbstractAnnotatedEntityMetamodelTest<GuardedShape> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<GuardedShape> getMetamodel() {
+            return AnnotatedEntityMetamodel.forPolymorphicType(
+                    GuardedShape.class,
+                    Set.of(GuardedCircle.class),
+                    parameterResolverFactory,
+                    handlerDefinition,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void concreteTypeInterceptorFiresForCommandHandledBySupertype() {
+            entityState = new GuardedCircle();
+
+            dispatchInstanceCommand(new RenameShape("new-name"));
+
+            assertThat(entityState.invocations).containsExactly("concrete-interceptor", "super-handled");
+        }
+    }
+
+    /**
+     * When both the polymorphic super type and a concrete type declare their own interceptor, both must fire for any
+     * command reaching that concrete type's instance, regardless of whether the command is declared on the concrete
+     * type or on the super type. Ordering here follows the concrete type first, then the super type, matching the
+     * order already observed for a command declared directly on the concrete type: there is no parent-before-child
+     * guarantee across this supertype/concrete-type axis (unlike the {@code @EntityMember} parent/child axis, which
+     * is unaffected and still runs parent-before-child).
+     */
+    @Nested
+    class InterceptorsAtBothHierarchyLevels extends AbstractAnnotatedEntityMetamodelTest<AuditedShape> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<AuditedShape> getMetamodel() {
+            return AnnotatedEntityMetamodel.forPolymorphicType(
+                    AuditedShape.class,
+                    Set.of(AuditedCircle.class),
+                    parameterResolverFactory,
+                    handlerDefinition,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void bothLevelsFireForConcreteTypeHandledCommand() {
+            entityState = new AuditedCircle();
+
+            dispatchInstanceCommand(new ResizeShape(5));
+
+            assertThat(entityState.invocations)
+                    .containsExactly("concrete-interceptor", "super-interceptor", "concrete-handled");
+        }
+
+        @Test
+        void bothLevelsFireForSupertypeHandledCommand() {
+            entityState = new AuditedCircle();
+
+            dispatchInstanceCommand(new RenameShape("new-name"));
+
+            assertThat(entityState.invocations)
+                    .containsExactly("concrete-interceptor", "super-interceptor", "super-handled");
+        }
+    }
+
+    /**
      * Reproduces the scenario from the original bug report: an entity rejects a command based on its own current state
      * through a {@link CommandHandlerInterceptor}. Before the fix, this interceptor was silently never invoked.
      */
@@ -338,6 +414,56 @@ class AnnotatedEntityMetamodelCommandInterceptorTest {
     }
 
     @SuppressWarnings("unused")
+    abstract static class GuardedShape {
+
+        final List<String> invocations = new ArrayList<>();
+
+        @CommandHandler
+        public void handle(RenameShape command) {
+            invocations.add("super-handled");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class GuardedCircle extends GuardedShape {
+
+        @CommandHandlerInterceptor
+        public void guard(CommandMessage command) {
+            invocations.add("concrete-interceptor");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    abstract static class AuditedShape {
+
+        final List<String> invocations = new ArrayList<>();
+
+        @CommandHandlerInterceptor
+        public void auditOnSupertype(CommandMessage command) {
+            invocations.add("super-interceptor");
+        }
+
+        @CommandHandler
+        public void handle(RenameShape command) {
+            invocations.add("super-handled");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class AuditedCircle extends AuditedShape {
+
+        @CommandHandlerInterceptor
+        public void auditOnConcreteType(CommandMessage command) {
+            invocations.add("concrete-interceptor");
+        }
+
+        @CommandHandler
+        public void handle(ResizeShape command) {
+            invocations.add("concrete-handled");
+        }
+    }
+
+    @SuppressWarnings("unused")
     static class GiftCard {
 
         boolean redeemed = false;
@@ -372,6 +498,14 @@ class AnnotatedEntityMetamodelCommandInterceptorTest {
     }
 
     record RedeemGiftCard(String id) {
+
+    }
+
+    record RenameShape(String name) {
+
+    }
+
+    record ResizeShape(int radius) {
 
     }
 }

--- a/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodelCommandInterceptorTest.java
+++ b/modelling/src/test/java/org/axonframework/modelling/entity/annotation/AnnotatedEntityMetamodelCommandInterceptorTest.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.modelling.entity.annotation;
+
+import org.axonframework.messaging.commandhandling.CommandMessage;
+import org.axonframework.messaging.commandhandling.GenericCommandResultMessage;
+import org.axonframework.messaging.commandhandling.annotation.CommandHandler;
+import org.axonframework.messaging.commandhandling.interception.annotation.CommandHandlerInterceptor;
+import org.axonframework.messaging.core.MessageHandlerInterceptorChain;
+import org.axonframework.messaging.core.MessageStream;
+import org.axonframework.messaging.core.MessageType;
+import org.junit.jupiter.api.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * Tests that {@link CommandHandlerInterceptor} (and the more generic
+ * {@link org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptor}) methods declared directly
+ * on an entity are invoked when commands are routed to that entity, both for the entity itself and for commands routed
+ * to a child entity added through {@link EntityMember}, and across a polymorphic hierarchy.
+ * <p>
+ * Each nested test uses a small, self-contained entity fixture rather than the shared domain fixtures used elsewhere in
+ * this package, since these tests are only concerned with interceptor invocation, not the rest of the entity model's
+ * behavior.
+ *
+ * @author Steven van Beelen
+ */
+class AnnotatedEntityMetamodelCommandInterceptorTest {
+
+    @Nested
+    class BeforeStyleInterceptor extends AbstractAnnotatedEntityMetamodelTest<InterceptedEntity> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<InterceptedEntity> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(InterceptedEntity.class,
+                                                            parameterResolverFactory,
+                                                            handlerDefinition,
+                                                            messageTypeResolver,
+                                                            messageConverter,
+                                                            eventConverter);
+        }
+
+        @Test
+        void interceptorRunsBeforeHandlerAndHandlerStillExecutes() {
+            entityState = new InterceptedEntity();
+
+            dispatchInstanceCommand(new Ping("hello"));
+
+            assertThat(entityState.invocations).containsExactly("intercepted", "handled");
+        }
+    }
+
+    @Nested
+    class SurroundStyleInterceptor extends AbstractAnnotatedEntityMetamodelTest<ShortCircuitingEntity> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<ShortCircuitingEntity> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(ShortCircuitingEntity.class,
+                                                            parameterResolverFactory,
+                                                            handlerDefinition,
+                                                            messageTypeResolver,
+                                                            messageConverter,
+                                                            eventConverter);
+        }
+
+        @Test
+        void interceptorShortCircuitsAndHandlerIsNeverInvoked() {
+            entityState = new ShortCircuitingEntity();
+
+            Object result = dispatchInstanceCommand(new Ping("hello"));
+
+            assertThat(result).isEqualTo("short-circuited");
+            assertThat(entityState.invocations).isEmpty();
+        }
+    }
+
+    @Nested
+    class MixedAnnotationInterceptors extends AbstractAnnotatedEntityMetamodelTest<MixedEntity> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<MixedEntity> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(MixedEntity.class,
+                                                            parameterResolverFactory,
+                                                            handlerDefinition,
+                                                            messageTypeResolver,
+                                                            messageConverter,
+                                                            eventConverter);
+        }
+
+        @Test
+        void bothCommandHandlerInterceptorAndDirectMessageHandlerInterceptorAreInvokedBeforeTheHandler() {
+            entityState = new MixedEntity();
+
+            dispatchInstanceCommand(new Ping("hello"));
+
+            assertThat(entityState.invocations).contains("via-command-handler-interceptor",
+                                                         "via-message-handler-interceptor");
+            assertThat(entityState.invocations.getLast()).isEqualTo("handled");
+        }
+    }
+
+    @Nested
+    class ParentAndChildInterceptorOrdering extends AbstractAnnotatedEntityMetamodelTest<ParentEntity> {
+
+        private final List<String> invocations = new ArrayList<>();
+
+        @Override
+        protected AnnotatedEntityMetamodel<ParentEntity> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(ParentEntity.class,
+                                                            parameterResolverFactory,
+                                                            handlerDefinition,
+                                                            messageTypeResolver,
+                                                            messageConverter,
+                                                            eventConverter);
+        }
+
+        @Test
+        void parentInterceptorRunsBeforeChildInterceptorForCommandRoutedToChild() {
+            entityState = new ParentEntity(invocations);
+            entityState.child = new ChildEntity(invocations);
+
+            dispatchInstanceCommand(new PingChild("hello"));
+
+            assertThat(invocations).containsExactly("parent", "child", "child-handled");
+        }
+    }
+
+    @Nested
+    class PolymorphicSupertypeInterceptor extends AbstractAnnotatedEntityMetamodelTest<Shape> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<Shape> getMetamodel() {
+            return AnnotatedEntityMetamodel.forPolymorphicType(
+                    Shape.class,
+                    Set.of(Circle.class, Square.class),
+                    parameterResolverFactory,
+                    handlerDefinition,
+                    messageTypeResolver,
+                    messageConverter,
+                    eventConverter
+            );
+        }
+
+        @Test
+        void supertypeInterceptorFiresForSupertypeDeclaredCommand() {
+            entityState = new Circle();
+
+            dispatchInstanceCommand(new Rename("new-name"));
+
+            assertThat(entityState.invocations).containsExactly("intercepted");
+            assertThat(entityState.name).isEqualTo("new-name");
+        }
+
+        @Test
+        void supertypeInterceptorAlsoFiresForConcreteTypeOnlyCommand() {
+            entityState = new Circle();
+
+            dispatchInstanceCommand(new SetRadius(5));
+
+            assertThat(entityState.invocations).containsExactly("intercepted");
+            assertThat(((Circle) entityState).radius).isEqualTo(5);
+        }
+    }
+
+    /**
+     * Reproduces the scenario from the original bug report: an entity rejects a command based on its own current state
+     * through a {@link CommandHandlerInterceptor}. Before the fix, this interceptor was silently never invoked.
+     */
+    @Nested
+    class RegressionRejectingBasedOnEntityState extends AbstractAnnotatedEntityMetamodelTest<GiftCard> {
+
+        @Override
+        protected AnnotatedEntityMetamodel<GiftCard> getMetamodel() {
+            return AnnotatedEntityMetamodel.forConcreteType(GiftCard.class,
+                                                            parameterResolverFactory,
+                                                            handlerDefinition,
+                                                            messageTypeResolver,
+                                                            messageConverter,
+                                                            eventConverter);
+        }
+
+        @Test
+        void interceptorRejectsRedeemCommandWhenAlreadyRedeemed() {
+            entityState = new GiftCard();
+
+            dispatchInstanceCommand(new RedeemGiftCard("card-1"));
+            assertThat(entityState.redeemed).isTrue();
+
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(() -> dispatchInstanceCommand(new RedeemGiftCard("card-1")))
+                    .withMessage("Gift card already redeemed");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class InterceptedEntity {
+
+        List<String> invocations = new ArrayList<>();
+
+        @CommandHandlerInterceptor
+        public void audit(CommandMessage command) {
+            invocations.add("intercepted");
+        }
+
+        @CommandHandler
+        public void handle(Ping command) {
+            invocations.add("handled");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class ShortCircuitingEntity {
+
+        List<String> invocations = new ArrayList<>();
+
+        @CommandHandlerInterceptor
+        public MessageStream<?> guard(CommandMessage command, MessageHandlerInterceptorChain<CommandMessage> chain) {
+            return MessageStream.just(
+                    new GenericCommandResultMessage(new MessageType(String.class), "short-circuited"));
+        }
+
+        @CommandHandler
+        public void handle(Ping command) {
+            invocations.add("handled");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class MixedEntity {
+
+        List<String> invocations = new ArrayList<>();
+
+        @CommandHandlerInterceptor
+        public void auditOne(CommandMessage command) {
+            invocations.add("via-command-handler-interceptor");
+        }
+
+        @org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptor(messageType = CommandMessage.class)
+        public void auditTwo(CommandMessage command) {
+            invocations.add("via-message-handler-interceptor");
+        }
+
+        @CommandHandler
+        public void handle(Ping command) {
+            invocations.add("handled");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class ParentEntity {
+
+        final List<String> invocations;
+
+        @EntityMember
+        ChildEntity child;
+
+        ParentEntity(List<String> invocations) {
+            this.invocations = invocations;
+        }
+
+        @CommandHandlerInterceptor
+        public void audit(CommandMessage command) {
+            invocations.add("parent");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class ChildEntity {
+
+        final List<String> invocations;
+
+        ChildEntity(List<String> invocations) {
+            this.invocations = invocations;
+        }
+
+        @CommandHandlerInterceptor
+        public void audit(CommandMessage command) {
+            invocations.add("child");
+        }
+
+        @CommandHandler
+        public void handle(PingChild command) {
+            invocations.add("child-handled");
+        }
+    }
+
+    @SuppressWarnings("unused")
+    abstract static class Shape {
+
+        List<String> invocations = new ArrayList<>();
+        String name;
+
+        @CommandHandlerInterceptor
+        public void audit(CommandMessage command) {
+            invocations.add("intercepted");
+        }
+
+        @CommandHandler
+        public void handle(Rename command) {
+            this.name = command.name();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class Circle extends Shape {
+
+        int radius;
+
+        @CommandHandler
+        public void handle(SetRadius command) {
+            this.radius = command.radius();
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class Square extends Shape {
+
+        int side;
+    }
+
+    @SuppressWarnings("unused")
+    static class GiftCard {
+
+        boolean redeemed = false;
+
+        @CommandHandlerInterceptor
+        public void rejectIfAlreadyRedeemed(CommandMessage command) {
+            if (redeemed) {
+                throw new IllegalStateException("Gift card already redeemed");
+            }
+        }
+
+        @CommandHandler
+        public void handle(RedeemGiftCard command) {
+            this.redeemed = true;
+        }
+    }
+
+    record Ping(String value) {
+
+    }
+
+    record PingChild(String value) {
+
+    }
+
+    record Rename(String name) {
+
+    }
+
+    record SetRadius(int radius) {
+
+    }
+
+    record RedeemGiftCard(String id) {
+
+    }
+}


### PR DESCRIPTION
We, sadly, missed reintegrating the `@CommandHandlerInterceptor` support that existed for Aggregates when rewriting everything to Entities.
This integration should've been part of https://github.com/AxonIQ/AxonFramework/issues/3485, but wasn't clearly covered in the success criteria.

This PR rectifies this problem, both for annotated and declarative configuration. 
The annotation solution is straightforward as the `AnnotatedHandlerInspector` already finds all the interceptors regardless of whether it's dealing with a regular component or an entity.
The declarative solution, however, requires a new interface that allows users to insert the entity as well.

To that end, the `EntityCommandHandlerInterceptor` interface, plus the `EntityCommandHandlerInterceptorChain`, have been introduces.
Both carry, next to the `CommandMessage`, `ProcessingContext`, and (in this case) the entity-specific interceptor chain, the nullable entity that's being intercepted.
It's made nullable, as the entity might not yet exist.
To register a `EntityCommandHandlerInterceptor`, the `EntityMetamodelBuilder` interface has been expanded, and the concrete and polymorphic implementations of the builder now have support to contain the `EntityCommandHandlerInterceptors`.

Upon construction of the meta-model, the chain is calculated once. 
**This** is what requires the `EntityCommandHandlerInterceptorChain`, as it allows us to pre-calculate the chain for creational and handler instances.
This pre-calculation resembles the logic in (for example) the `InterceptingCommandBus`, which also pre-calculates the command handler interceptor chain.

As with all other components, the annotation-based solution uses the new logic as made available in the `EntityMetamodelBuilder` and it's implementations.

All of the above has received tests, as well as a new section in the documentation specific to the component interceptor chapter, linked to from the Entity index page.

Although this should be regarded as a feature, I am marking it as a bug that should be back-ported to `axon-5.3.x`.
That decision's been made as this feature should've long since been part of Axon Framework, as pointed out at the beginning.