### PR TITLE
Fix bugs found in AF4 during large investigation in AF5

### DIFF
--- a/common/src/main/java/org/axonframework/common/ProcessUtils.java
+++ b/common/src/main/java/org/axonframework/common/ProcessUtils.java
@@ -16,6 +16,10 @@
 
 package org.axonframework.common;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -28,12 +32,11 @@ import java.util.function.Supplier;
  * Processing utilities.
  *
  * @author Marc Gathier
- * @since 4.2
+ * @since 4.2.0
  */
 public final class ProcessUtils {
 
-    private ProcessUtils() {
-    }
+    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     /**
      * Executes an action, with potential retry in case of an exception.
@@ -72,8 +75,8 @@ public final class ProcessUtils {
     }
 
     /**
-     * Executes an action asynchronously, with potential retry in case the result is false. Exception handling should
-     * be taken care of within the action if needed.
+     * Executes an action asynchronously, with potential retry in case the result is false. Exception handling should be
+     * taken care of within the action if needed.
      *
      * @param action        action to execute, will be executed until the result is {@code true} or max tries are
      *                      reached
@@ -81,16 +84,16 @@ public final class ProcessUtils {
      * @param maxTries      maximum number of times the action is invoked
      * @param executor      executor used to schedule the delay between retries
      * @return a {@link CompletableFuture} that completes when the action returns {@code true}, or exceptionally with a
-     *         {@link ProcessRetriesExhaustedException} if max tries is reached
+     * {@link ProcessRetriesExhaustedException} if max tries is reached
      */
     public static CompletableFuture<Void> executeUntilTrue(Supplier<CompletableFuture<Boolean>> action,
-                                                                 long retryInterval, long maxTries, Executor executor) {
+                                                           long retryInterval, long maxTries, Executor executor) {
         return executeUntilTrue(action, retryInterval, maxTries, maxTries, executor);
     }
 
     private static CompletableFuture<Void> executeUntilTrue(Supplier<CompletableFuture<Boolean>> action,
-                                                                  long retryInterval, long originalMaxTries,
-                                                                  long attemptsLeft, Executor executor) {
+                                                            long retryInterval, long originalMaxTries,
+                                                            long attemptsLeft, Executor executor) {
         if (attemptsLeft <= 0) {
             return CompletableFuture.failedFuture(new ProcessRetriesExhaustedException(String.format(
                     "Tried invoking the action for %d times, without the result being true", originalMaxTries
@@ -101,10 +104,11 @@ public final class ProcessUtils {
                 return CompletableFuture.completedFuture(null);
             }
             return CompletableFuture
-                    .runAsync(() -> {}, CompletableFuture.delayedExecutor(retryInterval, TimeUnit.MILLISECONDS,
-                                                                          executor))
+                    .runAsync(() -> {
+                    }, CompletableFuture.delayedExecutor(retryInterval, TimeUnit.MILLISECONDS,
+                                                         executor))
                     .thenCompose(ignored -> executeUntilTrue(action, retryInterval, originalMaxTries,
-                                                                  attemptsLeft - 1, executor));
+                                                             attemptsLeft - 1, executor));
         });
     }
 
@@ -120,7 +124,7 @@ public final class ProcessUtils {
         AtomicLong totalTriesCounter = new AtomicLong();
         boolean result = runnable.getAsBoolean();
         while (!result) {
-            if (totalTriesCounter.incrementAndGet() >= maxTries){
+            if (totalTriesCounter.incrementAndGet() >= maxTries) {
                 throw new ProcessRetriesExhaustedException(String.format(
                         "Tried invoking the action for %d times, without the result being true",
                         maxTries));
@@ -132,5 +136,29 @@ public final class ProcessUtils {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /**
+     * Wraps the given {@code task} so that any {@link Throwable} escaping it is logged rather than silently lost.
+     * <p>
+     * When a {@code Throwabel} is thrown, the given {@code errorMessage} is logged on
+     * {@link Logger#error(String, Throwable) error level}.
+     *
+     * @param task         the task to guard against an escaping {@link Throwable}
+     * @param errorMessage the error message to log on {@link Logger#error(String, Throwable) error level} when the
+     *                     {@code task} throws a {@link Throwable}
+     * @return a {@link Runnable} that never throws
+     */
+    public static Runnable safeguard(Runnable task, String errorMessage) {
+        return () -> {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                logger.error(errorMessage, e);
+            }
+        };
+    }
+
+    private ProcessUtils() {
     }
 }

--- a/common/src/test/java/org/axonframework/common/ProcessUtilsTest.java
+++ b/common/src/test/java/org/axonframework/common/ProcessUtilsTest.java
@@ -16,14 +16,23 @@
 
 package org.axonframework.common;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
 import org.junit.jupiter.api.*;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -174,6 +183,109 @@ class ProcessUtilsTest {
                               .havingCause()
                               .isEqualTo(cause);
             assertThat(callCount.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    class Safeguard {
+
+        private ListAppender appender;
+        private Logger logger;
+        private Level previousLevel;
+        private boolean previousAdditive;
+
+        @BeforeEach
+        void attachAppender() {
+            appender = new ListAppender("ProcessUtilsTestAppender");
+            appender.start();
+
+            logger = (Logger) LogManager.getLogger(ProcessUtils.class);
+            previousLevel = logger.getLevel();
+            previousAdditive = logger.isAdditive();
+            Configurator.setLevel(ProcessUtils.class.getName(), Level.DEBUG);
+            logger.setAdditive(false);
+            logger.addAppender(appender);
+        }
+
+        @AfterEach
+        void detachAppender() {
+            logger.removeAppender(appender);
+            logger.setAdditive(previousAdditive);
+            Configurator.setLevel(ProcessUtils.class.getName(), previousLevel);
+            appender.stop();
+        }
+
+        private List<LogEvent> events() {
+            return appender.getEvents();
+        }
+
+        @Test
+        void executesTheGivenTask() {
+            // given
+            AtomicBoolean invoked = new AtomicBoolean(false);
+            Runnable safeguarded = ProcessUtils.safeguard(() -> invoked.set(true), "error");
+
+            // when
+            safeguarded.run();
+
+            // then
+            assertThat(invoked).isTrue();
+            assertThat(events()).isEmpty();
+        }
+
+        @Test
+        void doesNotThrowAndLogsAtErrorLevelWhenTaskThrowsAnException() {
+            // given
+            RuntimeException exception = new RuntimeException("boom");
+            Runnable safeguarded = ProcessUtils.safeguard(() -> {
+                throw exception;
+            }, "task failed");
+
+            // when / then
+            assertThatCode(safeguarded::run).doesNotThrowAnyException();
+
+            assertThat(events()).hasSize(1);
+            LogEvent event = events().getFirst();
+            assertThat(event.getLevel()).isEqualTo(Level.ERROR);
+            assertThat(event.getMessage().getFormattedMessage()).isEqualTo("task failed");
+            assertThat(event.getThrown()).isSameAs(exception);
+        }
+
+        @Test
+        void doesNotThrowWhenTaskThrowsAnError() {
+            // given
+            Error error = new StackOverflowError("simulated");
+            Runnable safeguarded = ProcessUtils.safeguard(() -> {
+                throw error;
+            }, "task failed with an error");
+
+            // when / then
+            assertThatCode(safeguarded::run).doesNotThrowAnyException();
+
+            assertThat(events()).hasSize(1);
+            assertThat(events().getFirst().getThrown()).isSameAs(error);
+        }
+
+        @Test
+        void canBeInvokedMultipleTimesIndependently() {
+            // given
+            AtomicLong invocationCount = new AtomicLong();
+            Runnable safeguarded = ProcessUtils.safeguard(() -> {
+                if (invocationCount.incrementAndGet() <= 2) {
+                    throw new IllegalStateException("failure #" + invocationCount.get());
+                }
+            }, "repeated failure");
+
+            // when
+            safeguarded.run();
+            safeguarded.run();
+            safeguarded.run();
+
+            // then - two failures logged, third invocation completes without logging
+            assertThat(invocationCount.get()).isEqualTo(3);
+            assertThat(events()).hasSize(2);
+            assertThat(events().get(0).getMessage().getFormattedMessage()).isEqualTo("repeated failure");
+            assertThat(events().get(1).getMessage().getFormattedMessage()).isEqualTo("repeated failure");
         }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/core/timeout/AxonTimeLimitedTask.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/timeout/AxonTimeLimitedTask.java
@@ -47,6 +47,7 @@ class AxonTimeLimitedTask {
     private final String taskName;
     private final ScheduledExecutorService scheduledExecutorService;
     private final Logger logger;
+    private final Object lock = new Object();
     @Nullable
     private final String callerClassName; // stored as name to avoid getName() on every stack frame check
     private boolean completed = false;
@@ -198,12 +199,22 @@ class AxonTimeLimitedTask {
 
     /**
      * Marks the task as completed. Cancels the current future warning or interrupt if any exists.
+     * <p>
+     * If the scheduled interrupt lambda won a race against this call -- i.e., it already set the interrupt flag on
+     * the task thread before {@code complete()} could cancel it -- the interrupt is cleared here so it does not leak
+     * into the caller's subsequent code.
      */
     public void complete() {
-        completed = true;
-        if (currentScheduledFuture != null) {
-            currentScheduledFuture.cancel(false);
-            currentScheduledFuture = null;
+        synchronized (lock) {
+            completed = true;
+            if (currentScheduledFuture != null) {
+                currentScheduledFuture.cancel(false);
+                currentScheduledFuture = null;
+            }
+            if (interrupted) {
+                interrupted = false;
+                Thread.interrupted(); // clear the spurious flag set by the racing lambda
+            }
         }
         if (logger.isTraceEnabled()) {
             logger.trace("{} completed", taskName);
@@ -345,14 +356,16 @@ class AxonTimeLimitedTask {
      */
     private void scheduleInterrupt(long remainingTimeout) {
         currentScheduledFuture = scheduledExecutorService.schedule(() -> {
-            if (!completed && !interrupted) {
-                logger.error(
-                        "{} has exceeded its timeout of [{}ms]. Interrupting thread.\nStacktrace of current thread:\n{}",
-                        taskName,
-                        timeout,
-                        getCurrentStackTrace());
-                interrupted = true;
-                thread.interrupt();
+            synchronized (lock) {
+                if (!completed && !interrupted) {
+                    logger.error(
+                            "{} has exceeded its timeout of [{}ms]. Interrupting thread.\nStacktrace of current thread:\n{}",
+                            taskName,
+                            timeout,
+                            getCurrentStackTrace());
+                    interrupted = true;
+                    thread.interrupt();
+                }
             }
         }, remainingTimeout, TimeUnit.MILLISECONDS);
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/timeout/UnitOfWorkTimeoutInterceptorBuilder.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/timeout/UnitOfWorkTimeoutInterceptorBuilder.java
@@ -151,7 +151,14 @@ public class UnitOfWorkTimeoutInterceptorBuilder {
                 task.ensureNoInterruptionWasSwallowed();
                 return proceed;
             } catch (Exception e) {
-                return MessageStream.failed(task.detectInterruptionInsteadOfException(e));
+                Exception result = task.detectInterruptionInsteadOfException(e);
+                if (result == e) {
+                    // The exception was not caused by this task's timeout, so complete it now.
+                    // This cancels any still-pending interrupt and clears one that may have already fired,
+                    // preventing it from leaking into code that runs after this interceptor returns.
+                    task.complete();
+                }
+                return MessageStream.failed(result);
             }
         };
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/transaction/TransactionManager.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/transaction/TransactionManager.java
@@ -18,6 +18,7 @@ package org.axonframework.messaging.core.unitofwork.transaction;
 
 import org.axonframework.messaging.core.unitofwork.ProcessingLifecycle;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
@@ -65,14 +66,29 @@ public interface TransactionManager {
      * The attached {@code Transaction} will from there {@link Transaction#commit() commit} in the
      * {@link ProcessingLifecycle#runOnCommit(Consumer) commit phase} and {@link Transaction#rollback() rollback}
      * {@link ProcessingLifecycle#onError(ProcessingLifecycle.ErrorHandler) on error}.
+     * <p>
+     * The transaction is concluded (committed or rolled back) exactly once. This guards against a sibling handler
+     * registered in the same commit phase, or a handler in a later phase, failing after this transaction has
+     * already committed -- which would otherwise also invoke the error handler and roll back an already-committed
+     * transaction.
      *
      * @param processingLifecycle the {@code ProcessingLifecycle} to attach a {@link Transaction} to
      */
     default void attachToProcessingLifecycle(ProcessingLifecycle processingLifecycle) {
         processingLifecycle.runOnPreInvocation(pc -> {
             Transaction transaction = startTransaction();
-            pc.runOnCommit(p -> transaction.commit());
-            pc.onError((p, phase, e) -> transaction.rollback());
+            AtomicBoolean concluded = new AtomicBoolean(false);
+
+            pc.runOnCommit(p -> {
+                if (concluded.compareAndSet(false, true)) {
+                    transaction.commit();
+                }
+            });
+            pc.onError((p, phase, e) -> {
+                if (concluded.compareAndSet(false, true)) {
+                    transaction.rollback();
+                }
+            });
         });
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/transaction/jpa/EntityManagerTransactionManager.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/unitofwork/transaction/jpa/EntityManagerTransactionManager.java
@@ -25,6 +25,7 @@ import org.axonframework.messaging.core.unitofwork.transaction.Transaction;
 import org.axonframework.messaging.core.unitofwork.transaction.TransactionManager;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A {@link TransactionManager} implementation that manages JPA {@link EntityTransaction EntityTransactions} directly
@@ -67,7 +68,6 @@ public class EntityManagerTransactionManager implements TransactionManager {
         this.entityManagerProvider = Objects.requireNonNull(entityManagerProvider, "entityManagerProvider");
     }
 
-    
     @Override
     public Transaction startTransaction() {
         EntityTransaction tx = entityManagerProvider.getEntityManager().getTransaction();
@@ -108,9 +108,19 @@ public class EntityManagerTransactionManager implements TransactionManager {
     public void attachToProcessingLifecycle(ProcessingLifecycle processingLifecycle) {
         processingLifecycle.runOnPreInvocation(pc -> {
             Transaction transaction = startTransaction();
+            AtomicBoolean concluded = new AtomicBoolean(false);
+
             pc.putResource(JpaTransactionalExecutorProvider.SUPPLIER_KEY, CachingSupplier.of(() -> new EntityManagerExecutor(entityManagerProvider)));
-            pc.runOnCommit(p -> transaction.commit());
-            pc.onError((p, phase, e) -> transaction.rollback());
+            pc.runOnCommit(p -> {
+                if (concluded.compareAndSet(false, true)) {
+                    transaction.commit();
+                }
+            });
+            pc.onError((p, phase, e) -> {
+                if (concluded.compareAndSet(false, true)) {
+                    transaction.rollback();
+                }
+            });
         });
     }
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -1609,17 +1609,10 @@ class Coordinator {
      * @return a {@link Runnable} that never throws
      */
     private Runnable safeguard(Runnable task) {
-        return () -> {
-            try {
-                task.run();
-            } catch (Throwable e) {
-                logger.error(
-                        "Processor [{}]. Unexpected error escaped a coordination task. "
-                                + "This processor may no longer make progress.",
-                        name,
-                        e
-                );
-            }
-        };
+        return ProcessUtils.safeguard(
+                task,
+                "Processor [" + name + "]. Unexpected error escaped a coordination task. "
+                        + "This processor may no longer make progress."
+        );
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -162,7 +162,7 @@ class Coordinator {
             return ProcessUtils.executeUntilTrue(this::initializeTokenStore, tokenStoreInitRetryInterval, tokenStoreInitMaxRetries, executorService)
                     .thenRun(() -> {
                         CoordinationTask task = new CoordinationTask();
-                        executorService.submit(task);
+                        executorService.submit(safeguard(task));
                         this.coordinationTask.set(task);
                     })
                     .exceptionally(e -> {
@@ -1003,7 +1003,7 @@ class Coordinator {
                             generation);
                     scheduleCoordinationTask(100);
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 logger.warn(
                         "Processor [{}] (Coordination Task [{}]). Exception occurred while coordinating the work packages.",
                         name,
@@ -1428,10 +1428,10 @@ class Coordinator {
                         name,
                         generation,
                         delay);
-                executorService.schedule(() -> {
+                executorService.schedule(safeguard(() -> {
                     scheduledGate.set(false);
                     this.run();
-                }, delay, TimeUnit.MILLISECONDS);
+                }), delay, TimeUnit.MILLISECONDS);
             } else {
                 logger.trace(
                         "Processor [{}] (Coordination Task [{}]). Skipped scheduling coordination task (delay={}ms). "
@@ -1451,10 +1451,10 @@ class Coordinator {
                         name,
                         generation,
                         delay);
-                executorService.schedule(() -> {
+                executorService.schedule(safeguard(() -> {
                     interruptibleScheduledGate.set(false);
                     this.run();
-                }, delay, TimeUnit.MILLISECONDS);
+                }), delay, TimeUnit.MILLISECONDS);
             } else {
                 logger.trace(
                         "Processor [{}] (Coordination Task [{}]). Skipped scheduling delayed coordination task (delay={}ms). "
@@ -1496,7 +1496,7 @@ class Coordinator {
                                 errorWaitBackOff);
                         // Construct a new CoordinationTask, thus abandoning the old task and it's progress entirely.
                         CoordinationTask task = new CoordinationTask();
-                        executorService.schedule(task, errorWaitBackOff, TimeUnit.MILLISECONDS);
+                        executorService.schedule(safeguard(task), errorWaitBackOff, TimeUnit.MILLISECONDS);
                         coordinationTask.set(task);
                         processingGate.set(false);
                     }
@@ -1596,5 +1596,30 @@ class Coordinator {
                     }
             );
         }
+    }
+
+    /**
+     * Wraps the given {@code task} so that any {@link Throwable} escaping it is logged rather than silently lost.
+     * Tasks submitted or scheduled on {@link #executorService} have their {@code Future} discarded, since nothing
+     * polls it for a result; without this safety net, a {@code Throwable} that escapes all the way out of a task
+     * (bypassing every catch inside {@link CoordinationTask#run()}) would otherwise vanish without a trace, leaving
+     * this {@code Coordinator}'s internal gating flags permanently stuck and this processor silently dead.
+     *
+     * @param task the task to guard against an escaping {@link Throwable}
+     * @return a {@link Runnable} that never throws
+     */
+    private Runnable safeguard(Runnable task) {
+        return () -> {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                logger.error(
+                        "Processor [{}]. Unexpected error escaped a coordination task. "
+                                + "This processor may no longer make progress.",
+                        name,
+                        e
+                );
+            }
+        };
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -61,6 +61,7 @@ import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
 import static org.axonframework.common.FutureUtils.emptyCompletedFuture;
+import static org.axonframework.common.ProcessUtils.safeguard;
 
 /**
  * Defines the process of handling {@link EventMessage}s for a specific {@link Segment}. This entails validating if the
@@ -341,31 +342,12 @@ class WorkPackage implements SegmentProgressContext {
             return;
         }
         logger.debug("Scheduling Work Package [{}]-[{}] to process events.", segment.getSegmentId(), name);
-        executorService.submit(safeguard(this::runWorker));
-    }
-
-    /**
-     * Wraps the given {@code task} so that any {@link Throwable} escaping it is logged rather than silently lost.
-     * The task submitted to {@link #executorService} has its {@code Future} discarded, since nothing polls it for a
-     * result; without this safety net, a {@link Throwable} that escapes {@link #runWorker()} before it ever produces
-     * a {@link CompletableFuture} to report on (e.g. a synchronous failure in {@link #processEvents()}) would
-     * otherwise vanish without a trace, leaving this {@code WorkPackage}'s {@link #scheduled} flag permanently set
-     * and this segment silently stuck.
-     *
-     * @param task the task to guard against an escaping {@link Throwable}
-     * @return a {@link Runnable} that never throws
-     */
-    private Runnable safeguard(Runnable task) {
-        return () -> {
-            try {
-                task.run();
-            } catch (Throwable e) {
-                logger.error(
-                        "Work Package [{}]-[{}]. Unexpected error escaped the worker task. "
-                                + "This Work Package may no longer be scheduled for further processing.",
-                        segment.getSegmentId(), name, e);
-            }
-        };
+        executorService.submit(safeguard(
+                this::runWorker,
+                "Work Package [" + segment.getSegmentId() + "]-[" + name + "]. "
+                        + "Unexpected error escaped the worker task. "
+                        + "This Work Package may no longer be scheduled for further processing."
+        ));
     }
 
     private void runWorker() {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -321,7 +321,7 @@ class WorkPackage implements SegmentProgressContext {
     private boolean canHandle(EventMessage eventMessage, ProcessingContext processingContext) {
         try {
             return eventFilter.canHandle(eventMessage, processingContext, segment);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             logger.warn("Error while detecting whether event can be handled in Work Package [{}]-[{}]. "
                                 + "Aborting Work Package...",
                         segment.getSegmentId(), name, e);
@@ -341,7 +341,31 @@ class WorkPackage implements SegmentProgressContext {
             return;
         }
         logger.debug("Scheduling Work Package [{}]-[{}] to process events.", segment.getSegmentId(), name);
-        executorService.submit(this::runWorker);
+        executorService.submit(safeguard(this::runWorker));
+    }
+
+    /**
+     * Wraps the given {@code task} so that any {@link Throwable} escaping it is logged rather than silently lost.
+     * The task submitted to {@link #executorService} has its {@code Future} discarded, since nothing polls it for a
+     * result; without this safety net, a {@link Throwable} that escapes {@link #runWorker()} before it ever produces
+     * a {@link CompletableFuture} to report on (e.g. a synchronous failure in {@link #processEvents()}) would
+     * otherwise vanish without a trace, leaving this {@code WorkPackage}'s {@link #scheduled} flag permanently set
+     * and this segment silently stuck.
+     *
+     * @param task the task to guard against an escaping {@link Throwable}
+     * @return a {@link Runnable} that never throws
+     */
+    private Runnable safeguard(Runnable task) {
+        return () -> {
+            try {
+                task.run();
+            } catch (Throwable e) {
+                logger.error(
+                        "Work Package [{}]-[{}]. Unexpected error escaped the worker task. "
+                                + "This Work Package may no longer be scheduled for further processing.",
+                        segment.getSegmentId(), name, e);
+            }
+        };
     }
 
     private void runWorker() {
@@ -398,7 +422,7 @@ class WorkPackage implements SegmentProgressContext {
         CompletableFuture<Void> result;
         try {
             result = unitOfWork.execute();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             result = CompletableFuture.failedFuture(e);
         }
         return result.whenComplete((v, t) -> processingEvents.set(false));


### PR DESCRIPTION
- `Coordinator`/`WorkPackage`: catch `Throwable` (not just `Exception`) around the pooled processor's commit/abort paths and wrap executor-submitted tasks in a `safeguard()` so an escaping `Error` gets logged instead of silently vanishing via a discarded Future.                                  
- `AxonTimeLimitedTask`: synchronize the scheduled-interrupt lambda with `complete()` on a shared lock (clearing a spurious interrupt if the lambda wins the race), and have `UnitOfWorkTimeoutInterceptorBuilder` complete the task immediately on a confirmed non-timeout exception, closing a race that could leak an interrupt into later code.
- `TransactionManager`: guard `attachToProcessingLifecycle()` (and its JPA override) with an exactly-once concluded flag so a transaction that already committed can't be rolled back again if a later handler/phase fails.