### PR TITLE
Defer `ConfigurationPropertiesBinding` qualified beans on `SpringComponentRegistry` initialization

### DIFF
--- a/extensions/spring/spring-boot-autoconfigure/pom.xml
+++ b/extensions/spring/spring-boot-autoconfigure/pom.xml
@@ -262,6 +262,13 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing</artifactId>
+            <version>1.5.12</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Test-->
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/TracingAutoConfiguration.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/autoconfig/TracingAutoConfiguration.java
@@ -50,7 +50,7 @@ import org.springframework.context.annotation.Bean;
  * @since 4.6.0
  */
 @AutoConfiguration
-@ConditionalOnClass(SpanFactory.class)
+@ConditionalOnClass(name = "io.micrometer.tracing.Tracer")
 @ConditionalOnProperty(prefix = "axon.tracing", name = "enabled", havingValue = "true", matchIfMissing = true)
 @EnableConfigurationProperties(TracingProperties.class)
 public class TracingAutoConfiguration {

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/TracingAutoConfigurationTest.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/autoconfig/TracingAutoConfigurationTest.java
@@ -36,6 +36,7 @@ import org.axonframework.modelling.tracing.configuration.ModellingTracingSetting
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.ApplicationContext;
 
@@ -100,6 +101,13 @@ class TracingAutoConfigurationTest {
     void tracingDisabledContributesNoEnhancerAtAll() {
         // given / when / then - the autoconfiguration backs off entirely
         contextRunner.withPropertyValues("axon.tracing.enabled=false")
+                     .run(context -> assertThat(context).doesNotHaveBean("tracingConfigurationEnhancer"));
+    }
+
+    @Test
+    void backsOffEntirelyWithoutATracingBackendOnTheClasspath() {
+        // given / when / then - no tracing backend (e.g. Micrometer's Tracer) present, so the autoconfiguration
+        contextRunner.withClassLoader(new FilteredClassLoader("io.micrometer.tracing.Tracer"))
                      .run(context -> assertThat(context).doesNotHaveBean("tracingConfigurationEnhancer"));
     }
 

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringComponentRegistry.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringComponentRegistry.java
@@ -47,6 +47,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -102,6 +103,14 @@ public class SpringComponentRegistry implements
         ComponentRegistry {
 
     private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    /**
+     * The {@link org.springframework.beans.factory.annotation.Qualifier @Qualifier} value Spring Boot's
+     * {@code ConfigurationPropertiesBinding} annotation carries. Used by {@link #shouldDeferInitialization(String)}
+     * to detect beans matching that qualifier without a compile-time dependency on Spring Boot.
+     */
+    private static final String CONFIGURATION_PROPERTIES_BINDING_QUALIFIER =
+            "org.springframework.boot.context.properties.ConfigurationPropertiesBinding";
 
     private final SpringLifecycleRegistry lifecycleRegistry;
 
@@ -324,7 +333,7 @@ public class SpringComponentRegistry implements
     @Override
     public Object postProcessAfterInitialization(Object bean,
                                                  String beanName) throws BeansException {
-        if (!initialized.get() && isInfrastructureBean(beanName)) {
+        if (!initialized.get() && shouldDeferInitialization(beanName)) {
             return bean;
         }
         // Ensure this ComponentRegistry is fully initialized, as this may set additional components and decorators.
@@ -364,37 +373,40 @@ public class SpringComponentRegistry implements
     }
 
     /**
-     * Checks whether the given {@code beanName} refers to a Spring infrastructure bean.
+     * Checks whether {@code this ComponentRegistry} should keep deferring {@link #initialize()} while post-processing
+     * the given {@code beanName}, rather than letting it trigger Axon's configuration cascade mid-construction.
      * <p>
-     * This is used to avoid triggering Axon's full {@link #initialize()} during Spring Boot's early internal startup
-     * phase. In Spring Boot 4, infrastructure beans involved in configuration properties binding (for example,
-     * {@code BoundConfigurationProperties}) are created very early. If Axon initializes at that moment, enhancer
-     * scanning and component lookups may eagerly request application-level {@code @ConfigurationProperties} beans such
-     * as {@code AxonServerConfiguration}. That can cause a circular dependency between early Boot binding internals and
-     * Axon's properties beans.
+     * Two categories of beans are deferred: {@link BeanDefinition#ROLE_INFRASTRUCTURE} beans, and beans qualified with
+     * Spring Boot's {@code @ConfigurationPropertiesBinding} (typically a {@code Converter} or {@code Formatter}
+     * contributed by a third-party auto-configuration, e.g. Flyway). The latter matters because Spring Boot's
+     * {@code ConversionServiceDeducer} eagerly resolves <b>every</b> bean carrying that qualifier whenever it builds a
+     * {@code ConversionService} for {@code @ConfigurationProperties} binding.
      * <p>
-     * By deferring initialization while only infrastructure beans are being post-processed, we let Spring finish its
-     * internal bootstrap first. Initialization then happens on the first non-infrastructure bean, preserving normal
-     * Axon behavior.
+     * When a {@link ConfigurationEnhancer} we invoke triggers such a binding while a qualified converter is still
+     * mid-construction, Spring re-enters that still-in-creation bean and throws
+     * {@code BeanCurrentlyInCreationException}. Deferring on this qualifier keeps such converters from ever being the
+     * bean that triggers {@link #initialize()} mid-construction.
      * <p>
-     * We intentionally do <b>not</b> skip {@link BeanDefinition#ROLE_SUPPORT} or
-     * {@link BeanDefinition#ROLE_APPLICATION} beans:
-     * <ul>
-     *   <li>{@code ROLE_APPLICATION} contains user and framework-integrated application beans that should be eligible
-     *   for Axon decoration and lifecycle registration.</li>
-     *   <li>{@code ROLE_SUPPORT} can still participate in application wiring, so filtering it broadly could skip
-     *   required post-processing.</li>
-     * </ul>
+     * The qualifier is matched via {@link BeanFactoryAnnotationUtils#isQualifierMatch} against the literal qualifier
+     * value rather than the annotation type, since this module has no compile-time dependency on Spring Boot.
+     * <p>
+     * {@link BeanDefinition#ROLE_SUPPORT} beans and otherwise-unqualified {@link BeanDefinition#ROLE_APPLICATION} beans
+     * are intentionally not deferred here. They remain eligible for Axon decoration and lifecycle registration.
      *
-     * @param beanName The bean name to inspect.
-     * @return {@code true} if the bean definition role is {@link BeanDefinition#ROLE_INFRASTRUCTURE}, {@code false}
-     * otherwise.
+     * @param beanName the bean name to inspect
+     * @return {@code true} if {@link #initialize()} should stay deferred while processing this bean, {@code false}
+     * otherwise
      */
-    private boolean isInfrastructureBean(String beanName) {
+    private boolean shouldDeferInitialization(String beanName) {
         if (!beanFactory.containsBeanDefinition(beanName)) {
             return false;
         }
-        return beanFactory.getBeanDefinition(beanName).getRole() == BeanDefinition.ROLE_INFRASTRUCTURE;
+        if (beanFactory.getBeanDefinition(beanName).getRole() == BeanDefinition.ROLE_INFRASTRUCTURE) {
+            return true;
+        }
+        return BeanFactoryAnnotationUtils.isQualifierMatch(
+                CONFIGURATION_PROPERTIES_BINDING_QUALIFIER::equals, beanName, beanFactory
+        );
     }
 
     /**

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringComponentRegistry.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringComponentRegistry.java
@@ -382,7 +382,7 @@ public class SpringComponentRegistry implements
      * {@code ConversionServiceDeducer} eagerly resolves <b>every</b> bean carrying that qualifier whenever it builds a
      * {@code ConversionService} for {@code @ConfigurationProperties} binding.
      * <p>
-     * When a {@link ConfigurationEnhancer} we invoke triggers such a binding while a qualified converter is still
+     * When a {@link ConfigurationEnhancer} triggers such a binding while a qualified converter is still
      * mid-construction, Spring re-enters that still-in-creation bean and throws
      * {@code BeanCurrentlyInCreationException}. Deferring on this qualifier keeps such converters from ever being the
      * bean that triggers {@link #initialize()} mid-construction.

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringComponentRegistryConfigurationPropertiesBindingIntegrationTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringComponentRegistryConfigurationPropertiesBindingIntegrationTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.extension.spring.config;
+
+import org.axonframework.common.configuration.ComponentRegistry;
+import org.axonframework.common.configuration.ConfigurationEnhancer;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.convert.converter.Converter;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Reproduces, through a real {@link AnnotationConfigApplicationContext} refresh, the
+ * {@code BeanCurrentlyInCreationException} that motivated deferring {@code @ConfigurationPropertiesBinding}-qualified
+ * beans in {@link SpringComponentRegistry}.
+ * <p>
+ * Unlike {@link SpringComponentRegistryInitializationTest}, which calls
+ * {@link SpringComponentRegistry#postProcessAfterInitialization(Object, String)} directly, this test lets Spring
+ * drive bean creation itself, exercising its real "bean currently in creation" tracking.
+ * <p>
+ * The qualified converter is resolved as a nested dependency of an unrelated {@code rootBean} - mirroring how
+ * Flyway's converter is pulled in by Tomcat's web server factory chain in the original crash - rather than as its own
+ * top-level bean. That's deliberate: Spring Framework 6.2+ catches and logs (rather than propagates) a
+ * {@code BeanCurrentlyInCreationException} a top-level singleton throws for itself during pre-instantiation, which
+ * would otherwise mask this exact bug.
+ * <p>
+ * Without the fix, the qualified converter becomes the first non-infrastructure bean processed, triggering
+ * {@link SpringComponentRegistry#initialize()} mid-construction. The {@link ConfigurationEnhancer} below then
+ * re-resolves every bean carrying the same qualifier - exactly what Spring Boot's {@code ConversionServiceDeducer}
+ * does during {@code @ConfigurationProperties} binding - re-entering the still-in-creation bean.
+ *
+ * @author Steven van Beelen
+ */
+class SpringComponentRegistryConfigurationPropertiesBindingIntegrationTest {
+
+    private static final String CONFIGURATION_PROPERTIES_BINDING_QUALIFIER =
+            "org.springframework.boot.context.properties.ConfigurationPropertiesBinding";
+
+    @Test
+    void contextRefreshesWithoutBeanCurrentlyInCreationException() {
+        try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
+            // Matches Spring Boot's default (disabled since Boot 2.6) - otherwise a bean still under construction
+            // resolves via an early reference instead of throwing, masking the race this test reproduces.
+            context.getDefaultListableBeanFactory().setAllowCircularReferences(false);
+
+            // Infrastructure beans, so they don't themselves trigger initialize().
+            context.registerBean(
+                    "springLifecycleRegistry",
+                    SpringLifecycleRegistry.class,
+                    () -> {
+                        SpringLifecycleRegistry registry = new SpringLifecycleRegistry();
+                        registry.setBeanFactory(context.getDefaultListableBeanFactory());
+                        return registry;
+                    },
+                    beanDefinition -> beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
+            );
+            context.registerBean(
+                    "springComponentRegistry",
+                    SpringComponentRegistry.class,
+                    () -> new SpringComponentRegistry(
+                            context.getDefaultListableBeanFactory(),
+                            context.getBean(SpringLifecycleRegistry.class)
+                    ),
+                    beanDefinition -> beanDefinition.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
+            );
+
+            // Stands in for Tomcat's web server factory chain: pulls the qualified converter in as a nested
+            // dependency, so the converter is never its own top-level pre-instantiation entry.
+            context.registerBean("rootBean", Object.class, () -> {
+                context.getBean(QualifiedConverterBean.class);
+                return new Object();
+            });
+            // Stands in for a third-party @ConfigurationPropertiesBinding converter, e.g. Flyway's converter.
+            context.registerBean("qualifiedConverter", QualifiedConverterBean.class, QualifiedConverterBean::new);
+            // Stands in for an enhancer like PersistentStreamConfigurationEnhancer, which eagerly resolves a
+            // @ConfigurationProperties bean and thereby walks every @ConfigurationPropertiesBinding-qualified bean.
+            context.registerBean(
+                    "reentrantEnhancer",
+                    ReentrantEnhancer.class,
+                    () -> new ReentrantEnhancer(context.getDefaultListableBeanFactory())
+            );
+            // A trailing bean for initialize() to trigger on, once the qualified converter is safely out of the way.
+            context.registerBean("trailingBean", Object.class, Object::new);
+
+            assertThatCode(context::refresh).doesNotThrowAnyException();
+        }
+    }
+
+    @Qualifier(CONFIGURATION_PROPERTIES_BINDING_QUALIFIER)
+    private static class QualifiedConverterBean implements Converter<String, Integer> {
+
+        @Override
+        public Integer convert(String source) {
+            return Integer.valueOf(source);
+        }
+    }
+
+    private static class ReentrantEnhancer implements ConfigurationEnhancer {
+
+        private final ListableBeanFactory beanFactory;
+
+        private ReentrantEnhancer(ListableBeanFactory beanFactory) {
+            this.beanFactory = beanFactory;
+        }
+
+        @Override
+        public void enhance(ComponentRegistry registry) {
+            BeanFactoryAnnotationUtils.qualifiedBeansOfType(
+                    beanFactory, Converter.class, CONFIGURATION_PROPERTIES_BINDING_QUALIFIER
+            );
+        }
+    }
+}

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringComponentRegistryConfigurationPropertiesBindingIntegrationTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringComponentRegistryConfigurationPropertiesBindingIntegrationTest.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.convert.converter.Converter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
@@ -102,6 +103,7 @@ class SpringComponentRegistryConfigurationPropertiesBindingIntegrationTest {
             context.registerBean("trailingBean", Object.class, Object::new);
 
             assertThatCode(context::refresh).doesNotThrowAnyException();
+            assertThat(context.getBean(ReentrantEnhancer.class).invoked).isTrue();
         }
     }
 
@@ -118,12 +120,15 @@ class SpringComponentRegistryConfigurationPropertiesBindingIntegrationTest {
 
         private final ListableBeanFactory beanFactory;
 
+        private boolean invoked = false;
+
         private ReentrantEnhancer(ListableBeanFactory beanFactory) {
             this.beanFactory = beanFactory;
         }
 
         @Override
         public void enhance(ComponentRegistry registry) {
+            invoked = true;
             BeanFactoryAnnotationUtils.qualifiedBeansOfType(
                     beanFactory, Converter.class, CONFIGURATION_PROPERTIES_BINDING_QUALIFIER
             );

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringComponentRegistryInitializationTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringComponentRegistryInitializationTest.java
@@ -19,12 +19,18 @@ package org.axonframework.extension.spring.config;
 import org.axonframework.common.configuration.ComponentRegistry;
 import org.axonframework.common.configuration.ConfigurationEnhancer;
 import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Test class validating the initialization of the {@link SpringComponentRegistry}.
+ *
+ * @author Mateusz Nowak
+ */
 class SpringComponentRegistryInitializationTest {
 
     @Test
@@ -52,6 +58,34 @@ class SpringComponentRegistryInitializationTest {
         assertThat(beanFactory.containsSingleton("testEnhancer")).isTrue();
     }
 
+    @Test
+    void shouldDeferInitializationForConfigurationPropertiesBindingQualifiedBeans() {
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        SpringLifecycleRegistry lifecycleRegistry = new SpringLifecycleRegistry();
+        lifecycleRegistry.setBeanFactory(beanFactory);
+
+        // A ROLE_APPLICATION bean qualified like Spring Boot's ConfigurationPropertiesBinding converters
+        // (e.g. Flyway's stringOrNumberMigrationVersionConverter) must be deferred.
+        beanFactory.registerBeanDefinition(
+                "qualifiedBean",
+                BeanDefinitionBuilder.rootBeanDefinition(QualifiedConverterBean.class).getBeanDefinition()
+        );
+        beanFactory.registerBeanDefinition("applicationBean", new RootBeanDefinition(Object.class));
+        beanFactory.registerBeanDefinition(
+                "testEnhancer",
+                BeanDefinitionBuilder.rootBeanDefinition(TestEnhancer.class).getBeanDefinition()
+        );
+
+        SpringComponentRegistry testSubject = new SpringComponentRegistry(beanFactory, lifecycleRegistry);
+        testSubject.postProcessBeanFactory(beanFactory);
+
+        testSubject.postProcessAfterInitialization(new QualifiedConverterBean(), "qualifiedBean");
+        assertThat(beanFactory.containsSingleton("testEnhancer")).isFalse();
+
+        testSubject.postProcessAfterInitialization(new Object(), "applicationBean");
+        assertThat(beanFactory.containsSingleton("testEnhancer")).isTrue();
+    }
+
     @SuppressWarnings("unused")
     private static class TestEnhancer implements ConfigurationEnhancer {
 
@@ -59,5 +93,10 @@ class SpringComponentRegistryInitializationTest {
         public void enhance(ComponentRegistry registry) {
             // No-op
         }
+    }
+
+    @Qualifier("org.springframework.boot.context.properties.ConfigurationPropertiesBinding")
+    private static class QualifiedConverterBean {
+
     }
 }


### PR DESCRIPTION
This pull request makes a slight yet important adjustment to the `SpringComponentRegistry`.
Next to deferring the initialization for infrastructure beans, it now also defers it for beans with `org.springframework.boot.context.properties.ConfigurationPropertiesBinding` in it's qualifier.

If we do not defer on these beans, the `SpringComponentRegistry` may eagerly start invoking `ConfigurationEnhancers`, which in turn may trigger Spring Boot property objects (as we do in our Tracing and Persistent Stream `ConfigurationEnhancers`, for example), which trips up the entire Spring wiring logic to early.

The result of such an eager initialization is a `BeanCurrentlyInCreationExceptions` being thrown by a users application. A clear scenario where we've seen this occur is the combination of Axon Framework with Flyway (which is far from a one-off case).

Besides this fix, I've made a slight adjustment to the `TracingAutoConfiguration`, to only trigger when `io.micrometer.tracing.Tracer`. Although a side effect of figuring out the above, Axon's tracing components were always created as there always is a `SpanFactory`. Hence, I've switched that `@ConditionalOnClass` to lock for a tracer. Based on the FQCN to not have to depend on an actual `Tracer`.