### PR TITLE
[#4382] Honor FIRST and LATEST tokens when streaming events

### DIFF
--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/EventStorageEngine.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.FutureUtils;
 import org.axonframework.common.annotation.Internal;
 import org.axonframework.common.infra.DescribableComponent;
 import org.axonframework.messaging.core.MessageStream;
@@ -144,6 +145,10 @@ public interface EventStorageEngine extends DescribableComponent {
      * <p>
      * The {@code condition} may dictate the {@link StreamingCondition#position()} to start streaming from, as well as
      * define {@link StreamingCondition#criteria() filter criteria} for the returned {@code MessageStream}.
+     * <p>
+     * {@link TrackingToken#FIRST} and {@link TrackingToken#LATEST} must be honored: the former starts at the beginning
+     * of the store, the latter only receives events appended after the stream is opened. Implementations should invoke
+     * {@link #resolveSpecialStreamingPosition(StreamingCondition)} before interpreting the position.
      *
      * @param condition The {@link StreamingCondition} dictating the {@link StreamingCondition#position()} to start
      *                  streaming from, as well as the {@link StreamingCondition#criteria() filter criteria} used for
@@ -152,6 +157,26 @@ public interface EventStorageEngine extends DescribableComponent {
      * {@code condition}.
      */
     MessageStream<EventMessage> stream(StreamingCondition condition);
+
+    /**
+     * Replaces {@link TrackingToken#FIRST} and {@link TrackingToken#LATEST} on the given {@code condition} with the
+     * concrete tokens from {@link #firstToken()} and {@link #latestToken()}.
+     * <p>
+     * Other positions, including {@code null}, are left unchanged.
+     *
+     * @param condition the streaming condition whose position may be a special token
+     * @return the given {@code condition}, or a copy whose position is the matching concrete token
+     */
+    default StreamingCondition resolveSpecialStreamingPosition(StreamingCondition condition) {
+        TrackingToken position = condition.position();
+        if (TrackingToken.FIRST.equals(position)) {
+            return condition.withPosition(FutureUtils.joinAndUnwrap(firstToken()));
+        }
+        if (TrackingToken.LATEST.equals(position)) {
+            return condition.withPosition(FutureUtils.joinAndUnwrap(latestToken()));
+        }
+        return condition;
+    }
 
     /**
      * Creates a {@link TrackingToken} that is at the first position of an event stream.

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/inmemory/InMemoryEventStorageEngine.java
@@ -238,13 +238,17 @@ public class InMemoryEventStorageEngine implements EventStorageEngine {
 
     @Override
     public MessageStream<EventMessage> stream(StreamingCondition condition) {
+        StreamingCondition resolvedCondition = resolveSpecialStreamingPosition(condition);
         if (logger.isDebugEnabled()) {
-            logger.debug("Start streaming events with condition [{}].", condition);
+            logger.debug("Start streaming events with condition [{}].", resolvedCondition);
         }
 
         // Set end to the Long.MAX-VALUE, to reflect it's an infinite stream.
         MapBackedMessageStream messageStream =
-                new MapBackedStreamingEventMessageStream(condition.position().position().orElse(-1), condition);
+                new MapBackedStreamingEventMessageStream(
+                        resolvedCondition.position().position().orElse(-1),
+                        resolvedCondition
+                );
         openStreams.add(messageStream);
         return messageStream;
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/jpa/AggregateBasedJpaEventStorageEngine.java
@@ -343,10 +343,13 @@ public class AggregateBasedJpaEventStorageEngine implements EventStorageEngine {
 
     @Override
     public MessageStream<EventMessage> stream(StreamingCondition condition) {
-        AtomicReference<GapAwareTrackingToken> cursorRef = new AtomicReference<>(tokenOperations.assertGapAwareTrackingToken(condition.position()));
+        StreamingCondition resolvedCondition = resolveSpecialStreamingPosition(condition);
+        AtomicReference<GapAwareTrackingToken> cursorRef = new AtomicReference<>(
+                tokenOperations.assertGapAwareTrackingToken(resolvedCondition.position())
+        );
 
         return new ContinuousMessageStream<>(
-                () -> queryTokensAndEventsBy(cursorRef, condition),
+                () -> queryTokensAndEventsBy(cursorRef, resolvedCondition),
                 tae -> new SimpleEntry<>(convertToEventMessage(tae.event), buildTrackedContext(tae)),
                 (ms, r) -> {
                     streamCallbacks.put(ms, r);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -167,6 +167,42 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
     }
 
     @Test
+    void streamingFromFirstTrackingTokenReturnsAllEvents() {
+        TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_TAGS);
+        TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_TAGS);
+        appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA), expectedEventOne, expectedEventTwo);
+
+        MessageStream<EventMessage> result = testSubject.stream(StreamingCondition.startingFrom(TrackingToken.FIRST));
+
+        StepVerifier.create(FluxUtils.of(result))
+                    .assertNext(entry -> assertTrackedEntry(entry, expectedEventOne.event(), 1))
+                    .assertNext(entry -> assertTrackedEntry(entry, expectedEventTwo.event(), 2))
+                    .thenCancel()
+                    .verify();
+    }
+
+    @Test
+    void streamingFromLatestTrackingTokenSkipsExistingEvents() {
+        appendEvents(
+                AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
+                taggedEventMessage("event-0", TEST_AGGREGATE_TAGS),
+                taggedEventMessage("event-1", TEST_AGGREGATE_TAGS)
+        );
+
+        MessageStream<EventMessage> stream = testSubject.stream(StreamingCondition.startingFrom(TrackingToken.LATEST));
+
+        assertFalse(stream.hasNextAvailable());
+
+        TaggedEventMessage<?> expectedEvent = taggedEventMessage("event-2", TEST_AGGREGATE_TAGS);
+        appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA), expectedEvent);
+
+        await().untilAsserted(() -> assertTrue(stream.hasNextAvailable()));
+        Optional<Entry<EventMessage>> next = stream.next();
+        assertTrue(next.isPresent());
+        assertTrackedEntry(next.get(), expectedEvent.event(), 3);
+    }
+
+    @Test
     void streamingFromSpecificPositionSkipsMessages() {
         TaggedEventMessage<?> expectedEventOne = taggedEventMessage("event-0", TEST_AGGREGATE_TAGS);
         TaggedEventMessage<?> expectedEventTwo = taggedEventMessage("event-1", TEST_AGGREGATE_TAGS);

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/AggregateBasedStorageEngineTestSuite.java
@@ -183,7 +183,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
 
     @Test
     void streamingFromLatestTrackingTokenSkipsExistingEvents() {
-        appendEvents(
+        ConsistencyMarker marker = appendEvents(
                 AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA),
                 taggedEventMessage("event-0", TEST_AGGREGATE_TAGS),
                 taggedEventMessage("event-1", TEST_AGGREGATE_TAGS)
@@ -194,7 +194,7 @@ public abstract class AggregateBasedStorageEngineTestSuite<ESE extends EventStor
         assertFalse(stream.hasNextAvailable());
 
         TaggedEventMessage<?> expectedEvent = taggedEventMessage("event-2", TEST_AGGREGATE_TAGS);
-        appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA), expectedEvent);
+        appendEvents(AppendCondition.withCriteria(TEST_AGGREGATE_CRITERIA).withMarker(marker), expectedEvent);
 
         await().untilAsserted(() -> assertTrue(stream.hasNextAvailable()));
         Optional<Entry<EventMessage>> next = stream.next();

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineTestSuite.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/StorageEngineTestSuite.java
@@ -569,6 +569,63 @@ public abstract class StorageEngineTestSuite<ESE extends EventStorageEngine> {
     }
 
     @Test
+    protected void streamingFromFirstTrackingTokenReturnsAllEvents() {
+        TaggedEventMessage<EventMessage> expectedEventOne = taggedEventMessage("event-0", TEST_CRITERIA_TAGS);
+        TaggedEventMessage<EventMessage> expectedEventTwo = taggedEventMessage("event-1", TEST_CRITERIA_TAGS);
+        appendEvents(AppendCondition.none(), expectedEventOne, expectedEventTwo);
+
+        MessageStream<EventMessage> result = testSubject.stream(
+                StreamingCondition.conditionFor(TrackingToken.FIRST, TEST_CRITERIA)
+        );
+
+        StepVerifier.create(FluxUtils.of(result))
+                    .assertNext(entry -> assertEvent(entry.message(), expectedEventOne.event()))
+                    .assertNext(entry -> assertEvent(entry.message(), expectedEventTwo.event()))
+                    .thenCancel()
+                    .verify();
+    }
+
+    @Test
+    protected void streamingFromFirstTrackingTokenHonorsCriteria() {
+        TaggedEventMessage<EventMessage> matching = taggedEventMessage("event-0", TEST_CRITERIA_TAGS);
+        appendEvents(
+                AppendCondition.none(),
+                matching,
+                taggedEventMessage("event-1", OTHER_CRITERIA_TAGS)
+        );
+
+        MessageStream<EventMessage> result = testSubject.stream(
+                StreamingCondition.conditionFor(TrackingToken.FIRST, TEST_CRITERIA)
+        );
+
+        StepVerifier.create(FluxUtils.of(result))
+                    .assertNext(entry -> assertEvent(entry.message(), matching.event()))
+                    .thenCancel()
+                    .verify();
+    }
+
+    @Test
+    protected void streamingFromLatestTrackingTokenSkipsExistingEvents() {
+        appendEvents(
+                AppendCondition.none(),
+                taggedEventMessage("event-0", TEST_CRITERIA_TAGS),
+                taggedEventMessage("event-1", TEST_CRITERIA_TAGS)
+        );
+
+        MessageStream<EventMessage> stream = testSubject.stream(StreamingCondition.startingFrom(TrackingToken.LATEST));
+
+        assertFalse(stream.hasNextAvailable());
+
+        TaggedEventMessage<EventMessage> expectedEvent = taggedEventMessage("event-2", TEST_CRITERIA_TAGS);
+        appendEvents(AppendCondition.none(), expectedEvent);
+
+        waitUntilHasNextAvailable(stream);
+        Optional<Entry<EventMessage>> next = stream.next();
+        assertTrue(next.isPresent());
+        assertEvent(next.get().message(), expectedEvent.event());
+    }
+
+    @Test
     protected void streamingAfterLastPositionReturnsEmptyStream() throws Exception {
         TrackingToken startToken = testSubject.latestToken().join();
 

--- a/messaging/src/main/java/org/axonframework/messaging/eventstreaming/StreamingCondition.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventstreaming/StreamingCondition.java
@@ -19,6 +19,7 @@ package org.axonframework.messaging.eventstreaming;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.TrackingToken;
 import org.jspecify.annotations.Nullable;
 
+import static java.util.Objects.requireNonNull;
 
 /**
  * Interface describing the condition to {@link StreamableEventSource#open(StreamingCondition,
@@ -83,6 +84,17 @@ public sealed interface StreamingCondition extends EventsCondition permits Defau
      * @throws NullPointerException if {@code criteria} is {@code null}
      */
     StreamingCondition withCriteria(EventCriteria criteria);
+
+    /**
+     * Returns a copy of this {@code StreamingCondition} that starts streaming from the given {@code position},
+     * preserving the current {@link #criteria()}.
+     *
+     * @param position the {@link TrackingToken} to start streaming from
+     * @return a copy of this {@code StreamingCondition} starting from the given {@code position}
+     */
+    default StreamingCondition withPosition(TrackingToken position) {
+        return conditionFor(requireNonNull(position, "The position cannot be null"), criteria());
+    }
 
     /**
      * Combines the {@link #criteria()} of {@code this} {@code  StreamingCondition} with the given {@code criteria}.

--- a/messaging/src/test/java/org/axonframework/messaging/eventstreaming/DefaultStreamingConditionTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventstreaming/DefaultStreamingConditionTest.java
@@ -80,6 +80,26 @@ class DefaultStreamingConditionTest {
     }
 
     @Test
+    void withPositionReplacesTheExistingPositionPreservingCriteria() {
+        // given a replacement position distinct from the existing one
+        GlobalSequenceTrackingToken replacement = new GlobalSequenceTrackingToken(42);
+
+        // when the position is replaced
+        StreamingCondition result = testSubject.withPosition(replacement);
+
+        // then the criteria is preserved and only the replacement position remains
+        assertEquals(replacement, result.position());
+        assertEquals(Set.of(TEST_CRITERIA), result.criteria().flatten());
+    }
+
+    @Test
+    void withPositionThrowsExceptionForNullPosition() {
+        // when replacing with a null position, then a NullPointerException is raised
+        //noinspection DataFlowIssue
+        assertThrows(NullPointerException.class, () -> testSubject.withPosition(null));
+    }
+
+    @Test
     void orCombinesGivenWithExistingCriteria() {
         // given a criteria targeting a different tag and a type
         EventCriteria testCriteria = EventCriteria.havingTags(new Tag("other-key", "other-value"))

--- a/messaging/src/test/java/org/axonframework/messaging/eventstreaming/StartingFromTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventstreaming/StartingFromTest.java
@@ -79,6 +79,19 @@ class StartingFromTest {
     }
 
     @Test
+    void withPositionReplacesTheExistingPositionPreservingCriteria() {
+        // given a StartingFrom whose default criteria matches any tag
+        GlobalSequenceTrackingToken replacement = new GlobalSequenceTrackingToken(42);
+
+        // when its position is replaced
+        StreamingCondition result = testSubject.withPosition(replacement);
+
+        // then the replacement position is used and the default criteria is preserved
+        assertEquals(replacement, result.position());
+        assertEquals(EventCriteria.havingAnyTag(), result.criteria());
+    }
+
+    @Test
     void withCriteriaThrowsIllegalArgumentExceptionWhenPositionIsNull() {
         // given a StartingFrom without a position
         StreamingCondition nullPositionTestSubject = StreamingCondition.startingFrom(null);


### PR DESCRIPTION
- Resolve `TrackingToken.FIRST` and `TrackingToken.LATEST` to `firstToken()` / `latestToken()` before `EventStorageEngine.stream()` interprets the position
- Keep existing stream criteria via `StreamingCondition.withPosition(...)`, so a special token can be used together with filters
- Apply the same resolution in the in-memory and JPA engines, which previously treated those tokens as `0` / `Long.MAX_VALUE` or rejected them as the wrong type
Fixes #4382