### PR TITLE
Token claims stolen from segments waiting for a worker thread, despite coordinator claim extension

### DIFF
--- a/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
+++ b/docs/reference-guide/modules/events/pages/event-processors/streaming.adoc
@@ -409,6 +409,11 @@ A processor uses this value to steal token claims from other processor threads.
 This value defaults to 5000 milliseconds.
 * `claimExtensionThreshold`: Threshold to extend the claim in the absence of events.
 The value defaults to 5000 milliseconds.
+* `coordinatorClaimExtension`: Has the coordinator extend the claims of its work packages, instead of leaving that to the work packages themselves.
+Off by default.
+Enable it when handling a batch regularly takes longer than the claim timeout of the token store, since a work package can only extend its own claim from a worker thread.
+
+With Spring Boot, these are also available as properties per processor: `axon.eventhandling.processors.<name>.token-claim-interval`, `axon.eventhandling.processors.<name>.claim-extension-threshold` (in milliseconds) and `axon.eventhandling.processors.<name>.coordinator-claim-extension`.
 
 Consider the following snippet if you want to configure these values:
 
@@ -473,6 +478,10 @@ Examples of when a thread may get its token stolen are:
 - Too large event batch size.
 - Blocking operations inside event handlers.
 - Blocking exceptions inside event handlers.
+
+Note that a work package can only update its token timestamp from a worker thread.
+Lengthy handling therefore not only stales the segment it happens on, but also occupies a thread the work packages of other segments need to update their timestamp.
+Enabling `enableCoordinatorClaimExtension()` lets the coordinator extend the claims of its work packages, covering both the segment handling the lengthy batch and the ones waiting for a thread.
 
 ==== What are the consequences of token stealing?
 
@@ -878,7 +887,7 @@ The second thread pool deals with all the segments the `Coordinator` of the pool
 The `Coordinator` starts a `WorkPackage` for each segment and provides them the events to handle.
 The work package will, in turn, invoke the Event Handling Components to process the events.
 These packages run within the second thread pool, the so-called "worker executor" pool.
-The worker-pool also defaults to `ScheduledExecutorService` with a single thread.
+The worker-pool defaults to a `ScheduledExecutorService` with four threads, shared by the work packages of all claimed segments.
 
 When you want to increase event handling throughput, we recommend changing the number of threads for the worker thread pool.
 How to do this is shown in the following sample:

--- a/docs/reference-guide/modules/tuning/pages/event-processing.adoc
+++ b/docs/reference-guide/modules/tuning/pages/event-processing.adoc
@@ -15,7 +15,7 @@ The main tuning knobs are:
 * `tokenClaimInterval(long)` to control how often the coordinator retries token claims
 * `claimExtensionThreshold(long)` to decide when a running work package refreshes its claim
 * `maxClaimedSegments(int)` or `maxSegmentProvider(...)` to limit how much work one instance can own
-* `enableCoordinatorClaimExtension()` when work packages spend a long time handling batches
+* `enableCoordinatorClaimExtension()` when work packages spend a long time handling batches, or if it takes a long time before a batch is assigned a thread for processing.
 
 In practice, most tuning starts with `batchSize`, `initialSegmentCount`, and the executor sizing.
 The defaults are conservative and work well for small systems, but high-throughput installations usually need larger batches and more careful claim management.

--- a/docs/reference-guide/modules/tuning/pages/event-processing.adoc
+++ b/docs/reference-guide/modules/tuning/pages/event-processing.adoc
@@ -15,7 +15,7 @@ The main tuning knobs are:
 * `tokenClaimInterval(long)` to control how often the coordinator retries token claims
 * `claimExtensionThreshold(long)` to decide when a running work package refreshes its claim
 * `maxClaimedSegments(int)` or `maxSegmentProvider(...)` to limit how much work one instance can own
-* `enableCoordinatorClaimExtension()` when work packages spend a long time handling batches, or if it takes a long time before a batch is assigned a thread for processing.
+* `enableCoordinatorClaimExtension()` when work packages spend a long time handling batches, or if it takes a long time before a batch is assigned a thread for processing
 
 In practice, most tuning starts with `batchSize`, `initialSegmentCount`, and the executor sizing.
 The defaults are conservative and work well for small systems, but high-throughput installations usually need larger batches and more careful claim management.

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
@@ -302,15 +302,6 @@ public class EventProcessorProperties {
             this.tokenClaimIntervalTimeUnit = tokenClaimIntervalTimeUnit;
         }
 
-        /**
-         * Returns the threshold, in milliseconds, after which a work package of a
-         * {@link PooledStreamingEventProcessor} extends the claim on its token. Defaults to 5000 milliseconds.
-         *
-         * @return the claim extension threshold in milliseconds
-         */
-        public long getClaimExtensionThreshold() {
-            return claimExtensionThreshold;
-        }
 
         @Override
         public long claimExtensionThresholdInMillis() {

--- a/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/main/java/org/axonframework/extension/springboot/EventProcessorProperties.java
@@ -141,6 +141,23 @@ public class EventProcessorProperties {
         private TimeUnit tokenClaimIntervalTimeUnit = TimeUnit.MILLISECONDS;
 
         /**
+         * The threshold after which a work package of a {@link PooledStreamingEventProcessor} extends the claim on its
+         * token, in the absence of event handling that updates the token anyway.
+         * <p>
+         * Defaults to 5000 milliseconds.
+         */
+        private long claimExtensionThreshold = 5000;
+
+        /**
+         * Indicates whether the coordinator of a {@link PooledStreamingEventProcessor} extends the claims of its work
+         * packages, rather than leaving that to the work packages themselves. Enable this when event handling
+         * regularly takes longer than the claim timeout of the {@link TokenStore}.
+         * <p>
+         * Defaults to {@code false}.
+         */
+        private boolean coordinatorClaimExtension = false;
+
+        /**
          * The maximum number of threads the processor should process events with. Defaults to 4 for a
          * {@link PooledStreamingEventProcessor}.
          */
@@ -283,6 +300,46 @@ public class EventProcessorProperties {
          */
         public void setTokenClaimIntervalTimeUnit(TimeUnit tokenClaimIntervalTimeUnit) {
             this.tokenClaimIntervalTimeUnit = tokenClaimIntervalTimeUnit;
+        }
+
+        /**
+         * Returns the threshold, in milliseconds, after which a work package of a
+         * {@link PooledStreamingEventProcessor} extends the claim on its token. Defaults to 5000 milliseconds.
+         *
+         * @return the claim extension threshold in milliseconds
+         */
+        public long getClaimExtensionThreshold() {
+            return claimExtensionThreshold;
+        }
+
+        @Override
+        public long claimExtensionThresholdInMillis() {
+            return claimExtensionThreshold;
+        }
+
+        /**
+         * Sets the threshold, in milliseconds, after which a work package of a {@link PooledStreamingEventProcessor}
+         * extends the claim on its token. Defaults to 5000 milliseconds.
+         *
+         * @param claimExtensionThreshold the claim extension threshold in milliseconds
+         */
+        public void setClaimExtensionThreshold(long claimExtensionThreshold) {
+            this.claimExtensionThreshold = claimExtensionThreshold;
+        }
+
+        @Override
+        public boolean coordinatorClaimExtension() {
+            return coordinatorClaimExtension;
+        }
+
+        /**
+         * Sets whether the coordinator of a {@link PooledStreamingEventProcessor} extends the claims of its work
+         * packages. Defaults to {@code false}.
+         *
+         * @param coordinatorClaimExtension whether the coordinator extends the claims of its work packages
+         */
+        public void setCoordinatorClaimExtension(boolean coordinatorClaimExtension) {
+            this.coordinatorClaimExtension = coordinatorClaimExtension;
         }
 
         /**

--- a/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorPropertiesIT.java
+++ b/extensions/spring/spring-boot-autoconfigure/src/test/java/org/axonframework/extension/springboot/EventProcessorPropertiesIT.java
@@ -88,6 +88,8 @@ class EventProcessorPropertiesIT {
                     "axon.eventhandling.processors.foo.thread-count=3",
                     "axon.eventhandling.processors.foo.token-claim-interval=4",
                     "axon.eventhandling.processors.foo.token-claim-interval-time-unit=SECONDS",
+                    "axon.eventhandling.processors.foo.claim-extension-threshold=1234",
+                    "axon.eventhandling.processors.foo.coordinator-claim-extension=true",
                     "axon.eventhandling.processors.bar.initial-segment-count=77",
             }
     )
@@ -114,6 +116,8 @@ class EventProcessorPropertiesIT {
             assertThat(castedFooSettings.threadCount()).isEqualTo(3);
             assertThat(castedFooSettings.getTokenClaimInterval()).isEqualTo(4);
             assertThat(castedFooSettings.getTokenClaimIntervalTimeUnit()).isEqualTo(TimeUnit.SECONDS);
+            assertThat(castedFooSettings.claimExtensionThresholdInMillis()).isEqualTo(1234);
+            assertThat(castedFooSettings.coordinatorClaimExtension()).isTrue();
 
             EventProcessorProperties.ProcessorSettings defaultSettings = new EventProcessorProperties.ProcessorSettings();
             EventProcessorSettings barSettings = eventProcessorProperties.settings().get("bar");
@@ -129,6 +133,10 @@ class EventProcessorPropertiesIT {
             assertThat(castedBarSettings.threadCount()).isEqualTo(defaultSettings.threadCount());
             assertThat(castedBarSettings.getTokenClaimInterval()).isEqualTo(defaultSettings.getTokenClaimInterval());
             assertThat(castedBarSettings.getTokenClaimIntervalTimeUnit()).isEqualTo(defaultSettings.getTokenClaimIntervalTimeUnit());
+            assertThat(castedBarSettings.claimExtensionThresholdInMillis())
+                    .isEqualTo(defaultSettings.claimExtensionThresholdInMillis());
+            assertThat(castedBarSettings.coordinatorClaimExtension())
+                    .isEqualTo(defaultSettings.coordinatorClaimExtension());
         }
     }
 

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/EventProcessorSettings.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/EventProcessorSettings.java
@@ -131,6 +131,32 @@ public sealed interface EventProcessorSettings {
         int batchSize();
 
         /**
+         * Threshold, in milliseconds, after which a work package extends the claim on its {@code TrackingToken} in the
+         * absence of event handling.
+         * <p>
+         * Defaults to 5000 milliseconds, matching the default of the pooled streaming processor configuration.
+         *
+         * @return the claim extension threshold in milliseconds
+         */
+        default long claimExtensionThresholdInMillis() {
+            return 5000;
+        }
+
+        /**
+         * Whether the coordinator extends the claims of its work packages, rather than leaving that to the work
+         * packages themselves.
+         * <p>
+         * Enable this when event handling regularly takes longer than the claim timeout of the {@code TokenStore}: a
+         * work package cannot extend its own claim while it is handling a batch, nor while it waits for a thread of
+         * the worker executor that lengthy handling on other segments occupies. Defaults to {@code false}.
+         *
+         * @return {@code true} if the coordinator extends the claims of its work packages, {@code false} otherwise
+         */
+        default boolean coordinatorClaimExtension() {
+            return false;
+        }
+
+        /**
          * Name of the bean acting as token store for this pooled streaming processor.
          *
          * @return only used if non-null.

--- a/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
+++ b/extensions/spring/spring/src/main/java/org/axonframework/extension/spring/config/SpringCustomizations.java
@@ -167,9 +167,15 @@ interface SpringCustomizations {
             var result = eventProcessorConfiguration
                     .workerExecutor(scheduledExecutorService)
                     .tokenClaimInterval(settings.tokenClaimIntervalInMillis())
+                    .claimExtensionThreshold(settings.claimExtensionThresholdInMillis())
                     .batchSize(settings.batchSize())
                     .initialSegmentCount(settings.initialSegmentCount())
                     .unitOfWorkFactory(unitOfWorkFactory);
+
+            if (settings.coordinatorClaimExtension()) {
+                // Only applied when enabled, so a customization applied elsewhere that enables it is never undone.
+                result = result.enableCoordinatorClaimExtension();
+            }
 
             String sourceName = StringUtils.nonEmptyOrNull(settings.source()) ? settings.source() : null;
             var eventSource = getComponent(configuration, StreamableEventSource.class, sourceName, null);

--- a/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
+++ b/extensions/spring/spring/src/test/java/org/axonframework/extension/spring/config/SpringCustomizationsTest.java
@@ -330,6 +330,56 @@ class SpringCustomizationsTest {
         }
     }
 
+    @Nested
+    class PooledClaimExtension {
+
+        @Test
+        void appliesTheClaimExtensionSettings() {
+            // given
+            var configuration = configuration(cr -> {
+            });
+
+            // when
+            var result = SpringCustomizations
+                    .pooledStreamingCustomizations(PROCESSOR_NAME, new TestClaimExtensionSettings(1234, true))
+                    .apply(configuration, pooledProcessorConfiguration());
+
+            // then
+            assertThat(result.claimExtensionThreshold()).isEqualTo(1234);
+            assertThat(result.coordinatorExtendsClaims()).isTrue();
+        }
+
+        @Test
+        void defaultsMatchTheProcessorConfigurationDefaults() {
+            // given - settings that do not override the claim extension defaults
+            var configuration = configuration(cr -> {
+            });
+
+            // when
+            var result = customizePooled(configuration, null, null);
+
+            // then
+            assertThat(result.claimExtensionThreshold()).isEqualTo(5000);
+            assertThat(result.coordinatorExtendsClaims()).isFalse();
+        }
+
+        @Test
+        void keepsCoordinatorClaimExtensionEnabledByAnotherCustomization() {
+            // given - the setting is off, while another customization already enabled the coordinator claim extension
+            var configuration = configuration(cr -> {
+            });
+            var alreadyEnabled = pooledProcessorConfiguration().enableCoordinatorClaimExtension();
+
+            // when
+            var result = SpringCustomizations
+                    .pooledStreamingCustomizations(PROCESSOR_NAME, new TestClaimExtensionSettings(5000, false))
+                    .apply(configuration, alreadyEnabled);
+
+            // then - settings never undo an enable applied elsewhere
+            assertThat(result.coordinatorExtendsClaims()).isTrue();
+        }
+    }
+
     private static AxonConfiguration configuration(Consumer<ComponentRegistry> components) {
         MessagingConfigurer configurer = MessagingConfigurer.create();
         // classpath enhancers, like the event sourcing defaults, would register additional event sources
@@ -375,6 +425,40 @@ class SpringCustomizationsTest {
     private record TestSubscribingSettings(@Nullable String source)
             implements EventProcessorSettings.SubscribingEventProcessorSettings {
 
+    }
+
+    private record TestClaimExtensionSettings(long claimExtensionThresholdInMillis, boolean coordinatorClaimExtension)
+            implements EventProcessorSettings.PooledEventProcessorSettings {
+
+        @Override
+        public @Nullable String source() {
+            return null;
+        }
+
+        @Override
+        public @Nullable String tokenStore() {
+            return null;
+        }
+
+        @Override
+        public int initialSegmentCount() {
+            return 1;
+        }
+
+        @Override
+        public long tokenClaimIntervalInMillis() {
+            return 5000;
+        }
+
+        @Override
+        public int threadCount() {
+            return 1;
+        }
+
+        @Override
+        public int batchSize() {
+            return 1;
+        }
     }
 
     private record TestPooledSettings(@Nullable String source, @Nullable String tokenStore)

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/Coordinator.java
@@ -738,7 +738,8 @@ class Coordinator {
      * sense means:
      * <ol>
      *     <li>Abort {@link WorkPackage WorkPackages} for which {@link #releaseUntil(int, Instant)} has been invoked.</li>
-     *     <li>{@link WorkPackage#extendClaimIfThresholdIsMet() Extend the claims} of all {@code WorkPackages} to relieve them of this effort.
+     *     <li>{@link WorkPackage#extendClaimIfThresholdIsMet() Extend the claims} of all {@code WorkPackages} with an
+     *     outstanding worker, to relieve them of this effort.
      *     This is an optimization activated through {@link Builder#coordinatorClaimExtension(boolean)}.</li>
      *     <li>Validating if there are {@link CoordinatorTask CoordinatorTasks} to run, and run a single one if there are any.</li>
      *     <li>Periodically checking for unclaimed segments, claim these and start a {@code WorkPackage} per claim.</li>
@@ -804,15 +805,16 @@ class Coordinator {
 
             if (coordinatorExtendsClaims) {
                 logger.debug(
-                        "Processor [{}] (Coordination Task [{}]) will extend the claim of work packages that are busy processing events and have met the claim threshold.",
+                        "Processor [{}] (Coordination Task [{}]) will extend the claim of work packages with an outstanding worker that have met the claim threshold.",
                         name,
                         generation);
-                // Extend the claims of each work package busy processing events.
-                // Doing so relieves this effort from the work package as an optimization.
+                // A work package only refreshes its own claim from its worker. As long as a worker is outstanding it
+                // cannot do so, whether it is handling a lengthy batch or still waiting for a thread of a worker
+                // executor that lengthy batches on other segments occupy. Extending on its behalf covers both.
                 workPackages.values()
                             .stream()
                             .filter(workPackage -> !workPackage.isAbortTriggered())
-                            .filter(WorkPackage::isProcessingEvents)
+                            .filter(WorkPackage::isWorkerScheduled)
                             .forEach(workPackage -> workPackage.extendClaimIfThresholdIsMet()
                                                                .whenComplete((ignored, e) -> {
                                                                    if (e == null) {

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorConfiguration.java
@@ -433,7 +433,10 @@ public class PooledStreamingEventProcessorConfiguration extends EventProcessorCo
      * <p>
      * In both scenarios, there's a window of opportunity that the {@code WorkPackage} is not fast enough in extending
      * the claim itself. Not being able to do so potentially causes token stealing by other instances of this
-     * {@link PooledStreamingEventProcessor}, thus overburdening the overall event processing task.
+     * {@link PooledStreamingEventProcessor}, thus overburdening the overall event processing task. The same holds for
+     * segments that are not handling any events at that moment, as lengthy handling on other segments occupies the
+     * threads of the shared {@link #workerExecutor(java.util.function.Supplier) worker executor} they need to extend
+     * their own claim.
      * <p>
      * Note that enabling this feature will result in more frequent invocation of the {@link TokenStore} to update the
      * tokens.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackage.java
@@ -107,7 +107,6 @@ class WorkPackage implements SegmentProgressContext {
     private TrackingToken lastDeliveredToken; // For use only by event delivery threads, like Coordinator
     private @Nullable TrackingToken lastStoredToken;
     private final AtomicLong nextClaimExtension;
-    private final AtomicBoolean processingEvents;
 
     private final Queue<ProcessingEntry> processingQueue = new ConcurrentLinkedQueue<>();
     private final AtomicBoolean scheduled = new AtomicBoolean();
@@ -145,7 +144,6 @@ class WorkPackage implements SegmentProgressContext {
         // the first store of every claim cycle.
         this.lastStoredToken = builder.initialToken;
         this.nextClaimExtension = new AtomicLong(now() + claimExtensionThreshold);
-        this.processingEvents = new AtomicBoolean(false);
         this.schedulingProcessingContextProvider = builder.schedulingProcessingContextProvider;
         // Created last: the factory only retains this context (as SegmentProgressContext); it must be fully initialized.
         this.progressStrategy = builder.progressStrategyFactory.create(this);
@@ -385,7 +383,6 @@ class WorkPackage implements SegmentProgressContext {
 
         logger.debug("Work Package [{}]-[{}] is processing a batch of {} events.",
                      segment.getSegmentId(), name, eventBatch.size());
-        processingEvents.set(true);
         var unitOfWork = unitOfWorkFactory.create();
         unitOfWork.runOnPreInvocation(ctx -> {
             ctx.putResource(Segment.RESOURCE_KEY, segment);
@@ -407,7 +404,7 @@ class WorkPackage implements SegmentProgressContext {
         } catch (Throwable e) {
             result = CompletableFuture.failedFuture(e);
         }
-        return result.whenComplete((v, t) -> processingEvents.set(false));
+        return result;
     }
 
     private void onProcessingComplete(@Nullable Throwable e) {
@@ -656,12 +653,17 @@ class WorkPackage implements SegmentProgressContext {
     }
 
     /**
-     * Returns whether this {@code WorkPackage} is actively processing events.
+     * Indicates whether a worker is scheduled for this {@code WorkPackage}, either processing a batch or waiting for a
+     * thread of the worker executor to become available.
+     * <p>
+     * This {@code WorkPackage} refreshes its claim on its {@link TrackingToken} from its worker only. As long as one is
+     * outstanding it thus cannot do so itself, regardless of whether that worker is handling events or is still queued
+     * behind work on other segments.
      *
-     * @return Whether this {@code WorkPackage} is actively processing events.
+     * @return {@code true} if a worker is processing a batch or waiting for a thread, {@code false} otherwise
      */
-    public boolean isProcessingEvents() {
-        return processingEvents.get();
+    public boolean isWorkerScheduled() {
+        return scheduled.get();
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/CoordinatorTest.java
@@ -705,7 +705,7 @@ class CoordinatorTest {
                                                               .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
             doReturn(SEGMENT_ZERO).when(workPackage).segment();
             doReturn(false).when(workPackage).isAbortTriggered();
-            doReturn(true).when(workPackage).isProcessingEvents();
+            doReturn(true).when(workPackage).isWorkerScheduled();
             doReturn(CompletableFuture.failedFuture(new CompletionException(innerCause)))
                     .when(workPackage).extendClaimIfThresholdIsMet();
             doReturn(emptyCompletedFuture()).when(workPackage).abort(any());
@@ -744,7 +744,7 @@ class CoordinatorTest {
                                                               .fetchAvailableSegments(eq(PROCESSOR_NAME), any());
             doReturn(SEGMENT_ZERO).when(workPackage).segment();
             doReturn(false).when(workPackage).isAbortTriggered();
-            doReturn(true).when(workPackage).isProcessingEvents();
+            doReturn(true).when(workPackage).isWorkerScheduled();
             doReturn(CompletableFuture.failedFuture(new RuntimeException("extend claim failed")))
                     .when(workPackage).extendClaimIfThresholdIsMet();
             doReturn(emptyCompletedFuture()).when(workPackage).abort(any());

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
@@ -20,6 +20,8 @@ import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.configuration.AxonConfiguration;
+import org.axonframework.common.configuration.ConfigurationExtension;
+import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.core.EmptyApplicationContext;
 import org.axonframework.messaging.core.MessageHandlerInterceptor;
 import org.axonframework.messaging.core.MessageStream;
@@ -772,6 +774,83 @@ class PooledStreamingEventProcessorModuleTest {
                 .eventHandlingComponents(singleTestEventHandlingComponent())
                 .customized((cfg, c) -> c.eventSource(cfg.getOptionalComponent(StreamableEventSource.class)
                                                          .orElse(new AsyncInMemoryStreamableEventSource())));
+    }
+
+    @Nested
+    class CoordinatorClaimExtensionTest {
+
+        @Test
+        void coordinatorClaimExtensionReachesTheProcessorConfiguration() {
+            // given - the flag is set halfway a customization chain that ends on another setting
+            var configurer = MessagingConfigurer.create();
+            var processorName = "testProcessor";
+            var unitOfWorkFactory = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
+            var module = EventProcessorModule
+                    .pooledStreaming(processorName)
+                    .eventHandlingComponents(singleTestEventHandlingComponent())
+                    .customized((cfg, c) -> c.initialSegmentCount(4)
+                                             .batchSize(10)
+                                             .enableCoordinatorClaimExtension()
+                                             .eventSource(new AsyncInMemoryStreamableEventSource())
+                                             .tokenStore(new InMemoryTokenStore())
+                                             .unitOfWorkFactory(unitOfWorkFactory));
+            configurer.eventProcessing(ep -> ep.pooledStreaming(ps -> ps.processor(module)));
+
+            // when
+            var configuration = configurer.build();
+
+            // then - the setting survives every step between the customization and the built processor
+            var processorConfig = configurationOf(processor(configuration, processorName).orElse(null));
+            assertThat(processorConfig).isNotNull();
+            assertThat(processorConfig.coordinatorExtendsClaims()).isTrue();
+            assertThat(processorConfig.batchSize()).isEqualTo(10);
+        }
+
+        @Test
+        void coordinatorClaimExtensionSurvivesAnExtensionRegisteredAfterIt() {
+            // given - the customization ends on extend(), whose return value becomes the processor configuration
+            var configurer = MessagingConfigurer.create();
+            var processorName = "testProcessor";
+            var unitOfWorkFactory = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
+            var module = EventProcessorModule
+                    .pooledStreaming(processorName)
+                    .eventHandlingComponents(singleTestEventHandlingComponent())
+                    .customized((cfg, c) -> c.enableCoordinatorClaimExtension()
+                                             .eventSource(new AsyncInMemoryStreamableEventSource())
+                                             .tokenStore(new InMemoryTokenStore())
+                                             .unitOfWorkFactory(unitOfWorkFactory)
+                                             .extend(TestConfigurationExtension.class,
+                                                     TestConfigurationExtension::new));
+            configurer.eventProcessing(ep -> ep.pooledStreaming(ps -> ps.processor(module)));
+
+            // when
+            var configuration = configurer.build();
+
+            // then
+            var processorConfig = configurationOf(processor(configuration, processorName).orElse(null));
+            assertThat(processorConfig).isNotNull();
+            assertThat(processorConfig.coordinatorExtendsClaims()).isTrue();
+            assertThat(processorConfig.extension(TestConfigurationExtension.class)).isNotNull();
+        }
+    }
+
+    private static class TestConfigurationExtension
+            implements ConfigurationExtension<PooledStreamingEventProcessorConfiguration> {
+
+        @Override
+        public String name() {
+            return "test-extension";
+        }
+
+        @Override
+        public void validate() {
+            // nothing to validate
+        }
+
+        @Override
+        public void describeTo(@NonNull ComponentDescriptor descriptor) {
+            descriptor.describeProperty("name", name());
+        }
     }
 
     private @NonNull

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
@@ -16,8 +16,6 @@
 
 package org.axonframework.messaging.eventhandling.processing.streaming.pooled;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 import org.axonframework.common.AxonConfigurationException;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.common.configuration.ConfigurationExtension;
@@ -42,12 +40,14 @@ import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.configuration.EventHandlingComponentsConfigurer;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorConfiguration;
 import org.axonframework.messaging.eventhandling.configuration.EventProcessorModule;
-import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.errorhandling.ErrorHandler;
 import org.axonframework.messaging.eventhandling.processing.errorhandling.PropagatingErrorHandler;
+import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.inmemory.InMemoryTokenStore;
 import org.axonframework.messaging.eventstreaming.StreamableEventSource;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.*;
 
 import java.time.Duration;
@@ -84,9 +84,8 @@ class PooledStreamingEventProcessorModuleTest {
             // when
             PooledStreamingEventProcessorModule module = EventProcessorModule
                     .pooledStreaming(processorName)
-                    .eventHandlingComponents(components -> components.declarative("component",
-                                                                                  cfg -> SimpleEventHandlingComponent.create(
-                                                                                          "test")
+                    .eventHandlingComponents(components -> components.declarative(
+                            "component", cfg -> SimpleEventHandlingComponent.create("test")
                     ))
                     .customized((cfg, c) -> c);
 
@@ -166,9 +165,15 @@ class PooledStreamingEventProcessorModuleTest {
                     ep -> ep.pooledStreaming(
                             ps -> ps.defaults(d -> d.eventSource(eventSource))
                                     .defaultProcessor("test-processor",
-                                                      components -> components.declarative("component1", cfg -> component1)
-                                                                              .declarative("component2", cfg -> component2)
-                                                                              .autodetected("component3", cfg -> component3)
+                                                      components -> components.declarative(
+                                                                                      "component1", cfg -> component1
+                                                                              )
+                                                                              .declarative(
+                                                                                      "component2", cfg -> component2
+                                                                              )
+                                                                              .autodetected(
+                                                                                      "component3", cfg -> component3
+                                                                              )
                                     )
                     )
             );
@@ -225,7 +230,9 @@ class PooledStreamingEventProcessorModuleTest {
             PooledStreamingEventProcessorModule psepModuleOne =
                     EventProcessorModule.pooledStreaming("processor-one")
                                         .eventHandlingComponents(
-                                                components -> components.declarative("componentOne", cfg -> componentOne)
+                                                components -> components.declarative(
+                                                        "componentOne", cfg -> componentOne
+                                                )
                                         )
                                         .customized((config, psepConfig) -> psepConfig.withInterceptor(
                                                 specificInterceptorOne
@@ -234,7 +241,9 @@ class PooledStreamingEventProcessorModuleTest {
             PooledStreamingEventProcessorModule psepModuleTwo =
                     EventProcessorModule.pooledStreaming("processor-two")
                                         .eventHandlingComponents(
-                                                components -> components.declarative("componentTwo", cfg -> componentTwo)
+                                                components -> components.declarative(
+                                                        "componentTwo", cfg -> componentTwo
+                                                )
                                         )
                                         .customized((config, psepConfig) -> psepConfig.withInterceptor(
                                                 specificInterceptorTwo

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorTest.java
@@ -994,6 +994,44 @@ class PooledStreamingEventProcessorTest {
         }
 
         @Test
+        void coordinatorExtendsClaimsOfSegmentsWaitingForAWorkerThread() {
+            // given - a single worker thread, so lengthy handling on one segment starves the work package of the
+            //         other segment of the thread it needs to extend its own claim
+            workerExecutor.shutdown();
+            workerExecutor = new DelegateScheduledExecutorService(Executors.newScheduledThreadPool(1));
+            withTestSubject(
+                    List.of(),
+                    c -> c.initialSegmentCount(2).claimExtensionThreshold(100).enableCoordinatorClaimExtension()
+            );
+
+            AtomicBoolean isWaiting = new AtomicBoolean(false);
+            CountDownLatch handleLatch = new CountDownLatch(1);
+            doAnswer(invocation -> {
+                // Waiting for the latch to simulate a slow/busy WorkPackage occupying the only worker thread.
+                isWaiting.set(true);
+                handleLatch.await(5, TimeUnit.SECONDS);
+                return MessageStream.empty();
+            }).when(defaultEventHandlingComponent)
+              .handle(any(EventMessage.class), any(ProcessingContext.class));
+
+            createEvents(8).forEach(stubMessageSource::publishMessage);
+
+            // when
+            startEventProcessor();
+            await().pollDelay(Duration.ofMillis(50))
+                   .atMost(Duration.ofSeconds(5))
+                   .until(isWaiting::get);
+
+            // then - both the segment handling events and the one waiting for a thread keep their claim extended
+            try {
+                verify(tokenStore, timeout(3000).atLeast(3)).extendClaim(eq(PROCESSOR_NAME), eq(0), any());
+                verify(tokenStore, timeout(3000).atLeast(3)).extendClaim(eq(PROCESSOR_NAME), eq(1), any());
+            } finally {
+                handleLatch.countDown();
+            }
+        }
+
+        @Test
         void coordinatorExtendingClaimFailsAndAbortsWorkPackage() {
             withTestSubject(
                     List.of(),

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/WorkPackageTest.java
@@ -858,7 +858,7 @@ class WorkPackageTest {
     class ScheduleWorkerLifecycleTest {
 
         @Test
-        void processingEventsIsFalseAfterSuccessfulProcessing() {
+        void workerIsNoLongerScheduledAfterSuccessfulProcessing() {
             // given
             TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
             var testEvent = new SimpleEntry<>(EventTestUtils.asEventMessage("some-event"), trackingTokenContext(testToken));
@@ -869,12 +869,12 @@ class WorkPackageTest {
             // then
             await().atMost(TIMEOUT).untilAsserted(() -> {
                 verify(tokenStore).storeToken(any(), eq(PROCESSOR_NAME), eq(segment.getSegmentId()), any());
-                assertThat(testSubject.isProcessingEvents()).isFalse();
+                assertThat(testSubject.isWorkerScheduled()).isFalse();
             });
         }
 
         @Test
-        void processingEventsIsFalseAfterFailedProcessing() {
+        void batchProcessorFailureTriggersAbort() {
             // given
             TrackingToken testToken = new GlobalSequenceTrackingToken(1L);
             var testEvent = new SimpleEntry<>(EventTestUtils.asEventMessage("some-event"), trackingTokenContext(testToken));
@@ -887,7 +887,7 @@ class WorkPackageTest {
 
             // then - wait for abort to be fully processed (trackerStatus set to null by abort handler)
             await().atMost(TIMEOUT).untilAsserted(() -> assertThat(trackerStatus).isNull());
-            assertThat(testSubject.isProcessingEvents()).isFalse();
+            assertThat(testSubject.abort(null)).isDone();
         }
 
         @Test


### PR DESCRIPTION
## Problem

When event handling occupies every thread of a processor's worker executor, the work packages of the *other* segments are stuck in that executor's queue. A `WorkPackage` refreshes its token claim only from its worker, so those packages cannot reach the token store at all: their claims go stale, another instance steals them, and their events are handled a second time.

`enableCoordinatorClaimExtension()` exists for exactly this situation, but it did not cover it. The coordinator extended claims only for packages that were inside a batch (`WorkPackage#isProcessingEvents`), and skipped every package that was merely scheduled. Those are the ones that need it most, since the package handling the lengthy batch is the reason the others have no thread.

Measured on 8 segments at the defaults (5000ms threshold, 10s claim timeout), with the worker executor occupied by one lengthy handler for 20 seconds:

| | segments whose claim was refreshed |
|---|---|
| before | 1 of 8 (only the one inside the handler) |
| after | 8 of 8, every ~5.8s |

The seven starved segments received no `extendClaim` and no `storeToken` at all in those 20 seconds, so every one of them was past the 10 second claim timeout.

A second problem surfaced while confirming this: the feature could not be switched on from configuration properties. Neither the flag nor `claimExtensionThreshold` was exposed, so only the Configuration API could reach it.

## Change

- The coordinator selects packages with an outstanding worker (`WorkPackage#isWorkerScheduled`) instead of only those inside a batch. That is a strict superset, so the behaviour for a package handling a lengthy batch is unchanged, and the existing threshold check keeps the extension a no-op for a claim that was just refreshed.
- `processingEvents` is replaced by the `scheduled` flag it duplicated.
- `claim-extension-threshold` and `coordinator-claim-extension` are bound per processor from `axon.eventhandling.processors.<name>`. The accessors on `PooledEventProcessorSettings` have defaults, so integrations implementing that interface outside this repository keep compiling. The flag is only ever applied when enabled, so a customization elsewhere that enables it is never undone.
- Documentation: the token-claim section now covers the setting and the new property names, and the stated worker-executor default is corrected from one thread to four.

## Verification

The new `coordinatorExtendsClaimsOfSegmentsWaitingForAWorkerThread` fails on the current main (the starved segment receives nothing) and passes with this change. Two tests pin the path from the module customization to the built processor configuration, which nothing covered before.

`messaging` event processing: 582 tests. `spring` and `spring-boot-autoconfigure`: 166 and 134. All green.