### PR TITLE
Customizing a processor twice silently discards the earlier customization

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/configuration/EventProcessorModule.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/configuration/EventProcessorModule.java
@@ -122,6 +122,12 @@ public interface EventProcessorModule extends Module {
          * <p>
          * This method applies processor-specific customizations on top of shared defaults from parent modules,
          * providing the recommended approach for most configuration scenarios.
+         * <p>
+         * Customizations compound: calling this method again applies the given {@code instanceCustomization} on top of
+         * the configuration the previous one returned, in registration order. Two customizations that set the same
+         * property therefore resolve to the value of the last one registered, while everything else each of them set
+         * is retained. This lets an integration configure a processor from its own settings without discarding what
+         * the application configured, or the other way around.
          *
          * @param instanceCustomization A function that receives the configuration and default processor config,
          *                              returning the customized processor configuration.

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModule.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModule.java
@@ -36,6 +36,7 @@ import org.axonframework.messaging.eventhandling.interception.InterceptingEventH
 import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.axonframework.messaging.eventhandling.processing.streaming.segmenting.SequenceCachingEventHandlingComponent;
 import org.axonframework.messaging.eventhandling.processing.streaming.token.store.TokenStore;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;
@@ -75,7 +76,7 @@ public class PooledStreamingEventProcessorModule extends BaseModule<PooledStream
 
     private final String processorName;
     private Map<String, ComponentBuilder<EventHandlingComponent>> eventHandlingComponentBuilders;
-    private ComponentBuilder<PooledStreamingEventProcessorConfiguration> customizedProcessorConfigurationBuilder;
+    private @Nullable ComponentBuilder<PooledStreamingEventProcessorConfiguration> customizedProcessorConfigurationBuilder;
 
     /**
      * Constructs a module with the given processor name.
@@ -208,12 +209,19 @@ public class PooledStreamingEventProcessorModule extends BaseModule<PooledStream
     public PooledStreamingEventProcessorModule customized(
             BiFunction<Configuration, PooledStreamingEventProcessorConfiguration, PooledStreamingEventProcessorConfiguration> instanceCustomization
     ) {
-        this.customizedProcessorConfigurationBuilder = config -> {
-            var typeCustomization = typeSpecificCustomizationOrNoOp(config)
-                    .apply(config, defaultEventProcessorsConfiguration(config, processorName));
-            return instanceCustomization.apply(config, typeCustomization);
-        };
+        Objects.requireNonNull(instanceCustomization, "instanceCustomization may not be null");
+        ComponentBuilder<PooledStreamingEventProcessorConfiguration> previous =
+                this.customizedProcessorConfigurationBuilder;
+        this.customizedProcessorConfigurationBuilder =
+                previous == null
+                        ? config -> instanceCustomization.apply(config, typeCustomizedConfiguration(config))
+                        : config -> instanceCustomization.apply(config, previous.build(config));
         return this;
+    }
+
+    private PooledStreamingEventProcessorConfiguration typeCustomizedConfiguration(Configuration config) {
+        return typeSpecificCustomizationOrNoOp(config)
+                .apply(config, defaultEventProcessorsConfiguration(config, processorName));
     }
 
     private static PooledStreamingEventProcessorModule.Customization typeSpecificCustomizationOrNoOp(

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModule.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModule.java
@@ -158,12 +158,19 @@ public class SubscribingEventProcessorModule extends BaseModule<SubscribingEvent
     public SubscribingEventProcessorModule customized(
             BiFunction<Configuration, SubscribingEventProcessorConfiguration, SubscribingEventProcessorConfiguration> instanceCustomization
     ) {
-        this.customizedProcessorConfigurationBuilder = config -> {
-            var typeCustomization = typeSpecificCustomizationOrNoOp(config)
-                    .apply(config, defaultEventProcessorsConfiguration(config, processorName));
-            return instanceCustomization.apply(config, typeCustomization);
-        };
+        Objects.requireNonNull(instanceCustomization, "instanceCustomization may not be null");
+        ComponentBuilder<SubscribingEventProcessorConfiguration> previous =
+                this.customizedProcessorConfigurationBuilder;
+        this.customizedProcessorConfigurationBuilder =
+                previous == null
+                        ? config -> instanceCustomization.apply(config, typeCustomizedConfiguration(config))
+                        : config -> instanceCustomization.apply(config, previous.build(config));
         return this;
+    }
+
+    private SubscribingEventProcessorConfiguration typeCustomizedConfiguration(Configuration config) {
+        return typeSpecificCustomizationOrNoOp(config)
+                .apply(config, defaultEventProcessorsConfiguration(config, processorName));
     }
 
     @Override

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/streaming/pooled/PooledStreamingEventProcessorModuleTest.java
@@ -774,6 +774,36 @@ class PooledStreamingEventProcessorModuleTest {
                                                          .orElse(new AsyncInMemoryStreamableEventSource())));
     }
 
+    @Nested
+    class RepeatedCustomizationTest {
+
+        @Test
+        void customizationsCompoundInRegistrationOrder() {
+            // given - two customizations, as an integration and the application it serves would each register one
+            var configurer = MessagingConfigurer.create();
+            var processorName = "testProcessor";
+            var unitOfWorkFactory = new SimpleUnitOfWorkFactory(EmptyApplicationContext.INSTANCE);
+            var module = EventProcessorModule
+                    .pooledStreaming(processorName)
+                    .eventHandlingComponents(singleTestEventHandlingComponent())
+                    .customized((cfg, c) -> c.enableCoordinatorClaimExtension().batchSize(5))
+                    .customized((cfg, c) -> c.batchSize(10)
+                                             .eventSource(new AsyncInMemoryStreamableEventSource())
+                                             .tokenStore(new InMemoryTokenStore())
+                                             .unitOfWorkFactory(unitOfWorkFactory));
+            configurer.eventProcessing(ep -> ep.pooledStreaming(ps -> ps.processor(module)));
+
+            // when
+            var configuration = configurer.build();
+
+            // then - what only the first one set is retained, and the last one wins the property both set
+            var processorConfig = configurationOf(processor(configuration, processorName).orElse(null));
+            assertThat(processorConfig).isNotNull();
+            assertThat(processorConfig.coordinatorExtendsClaims()).isTrue();
+            assertThat(processorConfig.batchSize()).isEqualTo(10);
+        }
+    }
+
     private @NonNull
     static Function<EventHandlingComponentsConfigurer.RequiredComponentPhase, EventHandlingComponentsConfigurer.CompletePhase> singleTestEventHandlingComponent() {
         var eventHandlingComponent = SimpleEventHandlingComponent.create("test");

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/processing/subscribing/SubscribingEventProcessorModuleTest.java
@@ -442,6 +442,37 @@ class SubscribingEventProcessorModuleTest {
     }
 
     @Nested
+    class RepeatedCustomizationTest {
+
+        @Test
+        void customizationsCompoundInRegistrationOrder() {
+            // given - two customizations, as an integration and the application it serves would each register one
+            var configurer = MessagingConfigurer.create();
+            var processorName = "testProcessor";
+            ErrorHandler firstErrorHandler = exception -> {
+            };
+            ErrorHandler secondErrorHandler = exception -> {
+            };
+            SimpleEventBus eventSource = new SimpleEventBus();
+            var module = EventProcessorModule
+                    .subscribing(processorName)
+                    .eventHandlingComponents(singleTestEventHandlingComponent())
+                    .customized((cfg, c) -> c.errorHandler(firstErrorHandler).eventSource(eventSource))
+                    .customized((cfg, c) -> c.errorHandler(secondErrorHandler));
+            configurer.eventProcessing(ep -> ep.subscribing(sp -> sp.processor(module)));
+
+            // when
+            var configuration = configurer.build();
+
+            // then - what only the first one set is retained, and the last one wins the property both set
+            var processorConfig = configurationOf(processor(configuration, processorName).orElse(null));
+            assertThat(processorConfig).isNotNull();
+            assertThat(processorConfig.eventSource()).isEqualTo(eventSource);
+            assertThat(processorConfig.errorHandler()).isEqualTo(secondErrorHandler);
+        }
+    }
+
+    @Nested
     @DisplayName("Configuration Hierarchy: Should apply configuration customizations in order: shared -> type-specific -> instance-specific")
     class ConfigurationHierarchyTest {
 


### PR DESCRIPTION
## Problem

`EventProcessorModule.CustomizationPhase#customized` replaced the previous customization instead of adding to it. Every call rebuilt the configuration from the type-specific default, so only the last registered function had any effect:

```java
EventProcessorModule.pooledStreaming("orders")
    .eventHandlingComponents(...)
    .customized((cfg, c) -> c.enableCoordinatorClaimExtension())  // silently discarded
    .customized((cfg, c) -> c.eventSource(source).tokenStore(store));
// coordinatorExtendsClaims == false
```

The loss is hard to spot. The configuration object the discarded function returned really was configured, so anything still holding that instance reports the settings as applied, while the processor is built from an entirely different one. A missing setting therefore looks like the setting not working, rather than like configuration that never arrived.

It also makes the method unusable for an integration that configures a processor from its own settings: the application it serves cannot add a customization without one of the two being dropped, in whichever order they happen to run. The Spring integration only escapes this because `DefaultProcessorModuleFactory` composes base, definition and extension customizations into a single call before handing it over.

## Change

Customizations apply on top of the configuration the previous one returned, in registration order. A single call behaves exactly as before; two customizations that set the same property resolve to the last one registered, while everything else each of them set is retained. Applied to both `PooledStreamingEventProcessorModule` and `SubscribingEventProcessorModule`, with the contract documented on the interface, and the builder field marked nullable to reflect that no customization need be present.

No caller in this repository relied on the replacing behaviour: every main-code call site either customizes once or uses `notCustomized()`.

## Verification

A compounding test in each module's test class. Both fail on the current main, each in its own way: the pooled one loses `coordinatorExtendsClaims`, and the subscribing one loses the event source from the first customization and falls back to the type-level default.

Full `messaging` suite: 4520 tests. `spring` and `spring-boot-autoconfigure`: 163 and 134. All green.