### PR TITLE
Recognize a self-hosting engine even when its SnapshotStore is decorated

### DIFF
--- a/common/src/main/java/org/axonframework/common/configuration/DecoratingComponent.java
+++ b/common/src/main/java/org/axonframework/common/configuration/DecoratingComponent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.common.configuration;
+
+/**
+ * Implemented by a {@link ComponentDecorator} output class to expose the single delegate it wraps, so code holding a
+ * decorated value can see through it back to whatever it was built from.
+ * <p>
+ * {@link #decoratedDelegate()} must return the immediate delegate -- never {@code this}, and never something that
+ * requires further unwrapping this class isn't aware of -- so that {@link #unwrapFully(Object)} always terminates.
+ *
+ * @author John Hendrikx
+ */
+public interface DecoratingComponent {
+
+    /**
+     * Returns the single delegate this decorator wraps.
+     *
+     * @return the wrapped delegate.
+     */
+    Object decoratedDelegate();
+
+    /**
+     * Follows the {@link #decoratedDelegate()} chain from {@code this} delegate down to its root, returning the
+     * first value encountered that is not itself a {@link DecoratingComponent}.
+     *
+     * @return the root delegate at the bottom of this instance's decoration chain.
+     */
+    default Object unwrapFully() {
+        return unwrapFully(this);
+    }
+
+    /**
+     * Follows the {@link #decoratedDelegate()} chain from the given {@code value} down to its root, returning the
+     * first value encountered that is not itself a {@link DecoratingComponent}.
+     * <p>
+     * Returns {@code value} itself, unchanged, when it is not a {@code DecoratingComponent} to begin with.
+     *
+     * @param value the value to unwrap.
+     * @return the root delegate at the bottom of {@code value}'s decoration chain, or {@code value} itself if it is
+     * not decorated.
+     */
+    static Object unwrapFully(Object value) {
+        Object current = value;
+        while (current instanceof DecoratingComponent decorating) {
+            current = decorating.decoratedDelegate();
+        }
+        return current;
+    }
+}

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngine.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.eventstore;
 
 import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.DecoratingComponent;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.snapshot.api.Snapshot;
 import org.axonframework.eventsourcing.snapshot.store.SnapshotStore;
@@ -81,10 +82,21 @@ public class SnapshotCapableEventStorageEngine implements EventStorageEngine {
      * Returns an {@link EventStorageEngine} that supports the {@link SourcingStrategy.Snapshot} sourcing strategy,
      * given the {@code engine} to source events from and the {@code snapshotStore} holding its snapshots.
      * <p>
-     * The given {@code engine} is returned as is when it already supports snapshotting natively (it implements
-     * {@link SnapshotStore} itself) or is already decorated by this class. In both cases, decorating again would
-     * only add an unnecessary indirection. Any other {@code engine} is wrapped so it resolves the snapshot from the
-     * {@code snapshotStore} before sourcing the events that follow it.
+     * The given {@code engine} is returned as is when the given {@code snapshotStore}, once any decoration around it
+     * is unwrapped through {@link DecoratingComponent}, is the {@code engine} itself. Such an engine resolves the
+     * snapshot within its own {@link #source(SourcingCondition, ProcessingContext) source} call, serving the
+     * snapshot and the events following it in a single round trip. Decorating it would resolve the snapshot
+     * separately and pass an {@link SourcingStrategy.Absolute absolute strategy} inward, disabling that optimization.
+     * <p>
+     * An {@code engine} that is already decorated by this class is returned as is too, so composing twice is
+     * harmless. It keeps resolving snapshots from the store it was decorated with, and the given
+     * {@code snapshotStore} is ignored for it. Decorating again would put the given store in front of that one
+     * instead of adding anything.
+     * <p>
+     * Any other {@code engine} is decorated, resolving the snapshot from the {@code snapshotStore} before sourcing
+     * the events that follow it. This includes an {@code engine} that happens to implement {@link SnapshotStore}
+     * itself but is not the one identified by {@code snapshotStore}: an explicitly configured, different
+     * {@code SnapshotStore} always takes precedence over an engine's own, incidental snapshot support.
      *
      * @param engine        the engine to source events from
      * @param snapshotStore the store holding the snapshots of the given {@code engine}
@@ -95,7 +107,8 @@ public class SnapshotCapableEventStorageEngine implements EventStorageEngine {
     public static EventStorageEngine decorate(EventStorageEngine engine, SnapshotStore snapshotStore) {
         Objects.requireNonNull(engine, "The engine parameter cannot be null.");
         Objects.requireNonNull(snapshotStore, "The snapshotStore parameter cannot be null.");
-        return engine instanceof SnapshotStore || engine instanceof SnapshotCapableEventStorageEngine
+        return DecoratingComponent.unwrapFully(snapshotStore) == engine
+                || engine instanceof SnapshotCapableEventStorageEngine
                 ? engine
                 : new SnapshotCapableEventStorageEngine(engine, snapshotStore);
     }

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/tracing/TracingEventStorageEngine.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/eventstore/tracing/TracingEventStorageEngine.java
@@ -17,6 +17,7 @@
 package org.axonframework.eventsourcing.eventstore.tracing;
 
 import org.axonframework.common.annotation.Internal;
+import org.axonframework.common.configuration.DecoratingComponent;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.eventstore.AppendCondition;
 import org.axonframework.eventsourcing.eventstore.ConsistencyMarker;
@@ -56,7 +57,7 @@ import java.util.function.Supplier;
  * @since 5.3.0
  */
 @Internal
-public final class TracingEventStorageEngine implements EventStorageEngine {
+public final class TracingEventStorageEngine implements EventStorageEngine, DecoratingComponent {
 
     /** Name of the span covering a complete append transaction. */
     private static final String APPEND_TRANSACTION_SPAN = "EventStorageEngine.appendTransaction";
@@ -149,6 +150,11 @@ public final class TracingEventStorageEngine implements EventStorageEngine {
     @Override
     public CompletableFuture<TrackingToken> tokenAt(Instant at) {
         return delegate.tokenAt(at);
+    }
+
+    @Override
+    public Object decoratedDelegate() {
+        return delegate;
     }
 
     @Override

--- a/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStore.java
+++ b/eventsourcing/src/main/java/org/axonframework/eventsourcing/snapshot/store/tracing/TracingSnapshotStore.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.snapshot.store.tracing;
 
+import org.axonframework.common.configuration.DecoratingComponent;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.messaging.tracing.Span;
 import org.axonframework.messaging.tracing.SpanFactory;
@@ -44,7 +45,7 @@ import java.util.concurrent.CompletableFuture;
  * @since 5.3.0
  */
 @Internal
-public final class TracingSnapshotStore implements SnapshotStore {
+public final class TracingSnapshotStore implements SnapshotStore, DecoratingComponent {
 
     /** Prefix for the snapshot-store-write span ({@code "SnapshotStore.store <name>"}). */
     private static final String STORE_SPAN = "SnapshotStore.store";
@@ -92,6 +93,11 @@ public final class TracingSnapshotStore implements SnapshotStore {
             span.addAttribute(EntityIdSpanAttributesProvider.DEFAULT_ATTRIBUTE_KEY, identifier.toString());
         }
         return span;
+    }
+
+    @Override
+    public Object decoratedDelegate() {
+        return delegate;
     }
 
     @Override

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/configuration/EventSourcingConfigurationDefaultsTest.java
@@ -163,7 +163,7 @@ class EventSourcingConfigurationDefaultsTest {
     }
 
     @Test
-    void doesNotDecorateEventStorageEngineWhenItImplementsSnapshotStore_evenIfADifferentSnapshotStoreInstanceIsRegistered(
+    void decoratesEventStorageEngineWhenSnapshotStoreIsDifferentInstance_evenIfEngineImplementsSnapshotStore(
             @Mock(extraInterfaces = SnapshotStore.class) InMemoryEventStorageEngine snapshotAwareEngine
     ) {
         ApplicationConfigurer configurer = EventSourcingConfigurer.create();
@@ -171,9 +171,10 @@ class EventSourcingConfigurationDefaultsTest {
                                              .registerComponent(SnapshotStore.class, c -> new InMemorySnapshotStore()));
         Configuration resultConfig = configurer.build();
 
-        // an engine that natively supports snapshotting is never wrapped, regardless of the registered SnapshotStore
+        // snapshot reads must be routed to the registered SnapshotStore, not the engine itself: an engine merely
+        // happening to implement SnapshotStore does not make it the SnapshotStore a caller explicitly configured
         assertThat(resultConfig.getComponent(EventStorageEngine.class))
-                .isNotInstanceOf(SnapshotCapableEventStorageEngine.class);
+                .isInstanceOf(SnapshotCapableEventStorageEngine.class);
     }
 
     @Test

--- a/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
+++ b/eventsourcing/src/test/java/org/axonframework/eventsourcing/eventstore/SnapshotCapableEventStorageEngineTest.java
@@ -16,6 +16,7 @@
 
 package org.axonframework.eventsourcing.eventstore;
 
+import org.axonframework.common.configuration.DecoratingComponent;
 import org.axonframework.common.infra.ComponentDescriptor;
 import org.axonframework.eventsourcing.eventstore.EventStorageEngine.AppendTransaction;
 import org.axonframework.eventsourcing.eventstore.inmemory.InMemoryEventStorageEngine;
@@ -188,15 +189,28 @@ class SnapshotCapableEventStorageEngineTest {
             assertThat(result).isSameAs(snapshotResolvingEngine);
         }
 
-        // config.getComponent(SnapshotStore.class) may return a decorated view of the engine's own SnapshotStore
-        // (e.g. wrapped for tracing) rather than the engine itself, even though the engine backs that component.
+        // An engine that happens to implement SnapshotStore is not automatically the SnapshotStore a caller means:
+        // a different, unrelated SnapshotStore instance always takes precedence over the engine's own support.
         @Test
-        void returnsAnEngineThatIsItsOwnSnapshotStoreAsIsEvenWhenGivenADifferentSnapshotStoreInstance() {
+        void decoratesAnEngineThatImplementsSnapshotStoreWhenGivenADifferentSnapshotStoreInstance() {
             SnapshotResolvingEngine snapshotResolvingEngine = new SnapshotResolvingEngine();
 
             EventStorageEngine result = SnapshotCapableEventStorageEngine.decorate(
                     snapshotResolvingEngine, new InMemorySnapshotStore()
             );
+
+            assertThat(result).isInstanceOf(SnapshotCapableEventStorageEngine.class);
+        }
+
+        // config.getComponent(SnapshotStore.class) may return a decorated view of the engine's own SnapshotStore
+        // (e.g. wrapped for tracing) rather than the engine itself, even though the engine backs that component.
+        @Test
+        void returnsAnEngineThatIsItsOwnSnapshotStoreAsIsEvenWhenTheSnapshotStoreIsDecorated() {
+            SnapshotResolvingEngine snapshotResolvingEngine = new SnapshotResolvingEngine();
+            SnapshotStore decoratedView = new DecoratingSnapshotStore(snapshotResolvingEngine);
+
+            EventStorageEngine result =
+                    SnapshotCapableEventStorageEngine.decorate(snapshotResolvingEngine, decoratedView);
 
             assertThat(result).isSameAs(snapshotResolvingEngine);
         }
@@ -238,6 +252,36 @@ class SnapshotCapableEventStorageEngineTest {
         @Override
         public CompletableFuture<Snapshot> load(QualifiedName qn, Object id, ProcessingContext context) {
             return CompletableFuture.completedFuture(null);
+        }
+    }
+
+    /** A decorator exposing its delegate via {@link DecoratingComponent}, mirroring {@code TracingSnapshotStore}. */
+    private static class DecoratingSnapshotStore implements SnapshotStore, DecoratingComponent {
+
+        private final SnapshotStore delegate;
+
+        DecoratingSnapshotStore(SnapshotStore delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public CompletableFuture<Void> store(QualifiedName qn, Object id, Snapshot s, ProcessingContext context) {
+            return delegate.store(qn, id, s, context);
+        }
+
+        @Override
+        public CompletableFuture<Snapshot> load(QualifiedName qn, Object id, ProcessingContext context) {
+            return delegate.load(qn, id, context);
+        }
+
+        @Override
+        public Object decoratedDelegate() {
+            return delegate;
+        }
+
+        @Override
+        public void describeTo(ComponentDescriptor descriptor) {
+            descriptor.describeWrapperOf(delegate);
         }
     }
 


### PR DESCRIPTION
## Summary

`SnapshotCapableEventStorageEngine#decorate` decides whether to leave an `EventStorageEngine` undecorated (because it already resolves its own snapshots in a single round trip) by checking `engine instanceof SnapshotStore`. That check can't distinguish "this engine happens to also implement `SnapshotStore`" from "this engine IS the `SnapshotStore` a caller configured" — an engine that implements `SnapshotStore` incidentally will win over a different, explicitly-registered `SnapshotStore`, silently ignoring it. It also doesn't survive the `SnapshotStore` component being decorated (e.g. by tracing): a decorated view is a different object from the engine, so the previous, identity-based check used to break in exactly that case, which is what motivated the `instanceof` check in the first place.

`DecoratingComponent` is a marker interface a decorator implements to expose the single delegate it wraps, plus a static `unwrapFully()` that follows the chain to its root. `decorate()` now checks `DecoratingComponent.unwrapFully(snapshotStore) == engine`: this recovers the precision of the original identity check (an explicitly different `SnapshotStore` always takes precedence, regardless of what the engine happens to implement) while still recognizing a self-hosting engine whose `SnapshotStore` slot has been wrapped by something that exposes its delegate this way.

## Changes
- New: `DecoratingComponent` (`common`)
- `SnapshotCapableEventStorageEngine#decorate`: checks `DecoratingComponent.unwrapFully(snapshotStore) == engine` instead of `engine instanceof SnapshotStore`
- `TracingSnapshotStore`, `TracingEventStorageEngine`: implement `DecoratingComponent`
- `EventSourcingConfigurationDefaultsTest`, `SnapshotCapableEventStorageEngineTest`: updated to reflect the corrected precedence, with new coverage for the decorated-snapshot-store case

## Test plan
- [x] `common`, `eventsourcing` full test suites green (0 failures/errors)