### PR TITLE
[#3306] introduce annotated version specifier

### DIFF
--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/SimpleCommandBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/SimpleCommandBus.java
@@ -27,10 +27,12 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -49,7 +51,7 @@ public class SimpleCommandBus implements CommandBus {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleCommandBus.class);
 
-    private final ConcurrentMap<QualifiedName, CommandHandler> subscriptions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<QualifiedName, List<CommandHandler>> subscriptions = new ConcurrentHashMap<>();
     private final UnitOfWorkFactory unitOfWorkFactory;
 
     /**
@@ -70,13 +72,25 @@ public class SimpleCommandBus implements CommandBus {
     @Override
     public SimpleCommandBus subscribe(QualifiedName name, CommandHandler commandHandler) {
         CommandHandler handler = requireNonNull(commandHandler, "Given command handler cannot be null.");
+        requireNonNull(name, "The command name cannot be null.");
         logger.debug("Subscribing command handler with name [{}].", name);
-        var existingHandler =
-                subscriptions.putIfAbsent(requireNonNull(name, "The command name cannot be null."), handler);
 
-        if (existingHandler != null && existingHandler != handler) {
-            throw new DuplicateCommandHandlerSubscriptionException(name, existingHandler, handler);
-        }
+        subscriptions.compute(name, (key, existingHandlers) -> {
+            if (existingHandlers == null) {
+                existingHandlers = new CopyOnWriteArrayList<>();
+            }
+            for (CommandHandler existing : existingHandlers) {
+                if (existing == handler) {
+                    return existingHandlers;
+                }
+                if (existing.supportedVersions().overlaps(handler.supportedVersions())) {
+                    throw new DuplicateCommandHandlerSubscriptionException(name, existing, handler);
+                }
+            }
+            existingHandlers.add(handler);
+            return existingHandlers;
+        });
+
         return this;
     }
 
@@ -91,7 +105,14 @@ public class SimpleCommandBus implements CommandBus {
     }
 
     private Optional<CommandHandler> findCommandHandlerFor(CommandMessage command) {
-        return Optional.ofNullable(subscriptions.get(command.type().qualifiedName()));
+        String version = command.type().version();
+        List<CommandHandler> handlers = subscriptions.get(command.type().qualifiedName());
+        if (handlers == null) {
+            return Optional.empty();
+        }
+        return handlers.stream()
+                       .filter(h -> h.supportedVersions().matches(version))
+                       .findFirst();
     }
 
     /**

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/SimpleCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/SimpleCommandHandlingComponent.java
@@ -23,8 +23,10 @@ import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -47,7 +49,7 @@ public class SimpleCommandHandlingComponent implements CommandHandlingComponent,
         CommandHandlerRegistry<SimpleCommandHandlingComponent> {
 
     private final String name;
-    private final Map<QualifiedName, CommandHandler> commandHandlers = new HashMap<>();
+    private final Map<QualifiedName, List<CommandHandler>> commandHandlers = new HashMap<>();
     private final Set<CommandHandlingComponent> subComponents = new HashSet<>();
 
     /**
@@ -72,11 +74,21 @@ public class SimpleCommandHandlingComponent implements CommandHandlingComponent,
             return subscribe(component);
         }
 
-        CommandHandler existingHandler = commandHandlers.computeIfAbsent(name, k -> commandHandler);
-
-        if (existingHandler != commandHandler) {
-            throw new DuplicateCommandHandlerSubscriptionException(name, existingHandler, commandHandler);
-        }
+        commandHandlers.compute(name, (key, existingHandlers) -> {
+            if (existingHandlers == null) {
+                existingHandlers = new ArrayList<>();
+            }
+            for (CommandHandler existing : existingHandlers) {
+                if (existing == commandHandler) {
+                    return existingHandlers;
+                }
+                if (existing.supportedVersions().overlaps(commandHandler.supportedVersions())) {
+                    throw new DuplicateCommandHandlerSubscriptionException(name, existing, commandHandler);
+                }
+            }
+            existingHandlers.add(commandHandler);
+            return existingHandlers;
+        });
 
         return this;
     }
@@ -106,17 +118,35 @@ public class SimpleCommandHandlingComponent implements CommandHandlingComponent,
             }
         }
 
-        if (commandHandlers.containsKey(qualifiedName)) {
-            try {
-                return commandHandlers.get(qualifiedName).handle(command, context);
-            } catch (Throwable e) {
-                return MessageStream.failed(e);
+        String version = command.type().version();
+        List<CommandHandler> handlers = commandHandlers.get(qualifiedName);
+        if (handlers != null) {
+            Optional<MessageStream.Single<CommandResultMessage>> result = handleWithVersionMatch(handlers, version, command, context);
+            if (result.isPresent()) {
+                return result.get();
             }
         }
 
         String message = "No handler was subscribed for command with qualified name [%s] on component [%s]. Registered handlers: [%s]"
                 .formatted(qualifiedName.fullName(), this.getClass().getName(), supportedCommands());
         return MessageStream.failed(new NoHandlerForCommandException(message));
+    }
+
+    private Optional<MessageStream.Single<CommandResultMessage>> handleWithVersionMatch(
+            List<CommandHandler> handlers,
+            String version,
+            CommandMessage command,
+            ProcessingContext context) {
+        for (CommandHandler handler : handlers) {
+            if (handler.supportedVersions().matches(version)) {
+                try {
+                    return Optional.of(handler.handle(command, context));
+                } catch (Throwable e) {
+                    return Optional.of(MessageStream.failed(e));
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponent.java
@@ -31,8 +31,10 @@ import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.core.annotation.HandlerAttributes;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.core.VersionSpecifier;
 import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -114,17 +116,11 @@ public class AnnotatedCommandHandlingComponent<T> implements CommandHandlingComp
 
     private CommandHandler constructCommandHandlerFor(CommandHandlingMember<? super T> handler) {
         MessageHandlerInterceptorMemberChain<T> interceptorChain = model.chainedInterceptor(target.getClass());
-        return (command, context) -> interceptorChain.handle(
-                                                             command.withConvertedPayload(
-                                                                     handler.payloadType(), converter
-                                                             ),
-                                                             context,
-                                                             target,
-                                                             handler
-                                                     )
-                                                     .mapMessage(this::asCommandResultMessage)
-                                                     .first()
-                                                     .cast();
+        VersionSpecifier versionSpecifier = handler.<String>attribute(HandlerAttributes.COMMAND_VERSION_RANGE)
+                                                   .map(VersionSpecifier::parse)
+                                                   .orElse(VersionSpecifier.any());
+
+        return new AdapterCommandHandler(handler, interceptorChain, versionSpecifier);
     }
 
 
@@ -151,5 +147,37 @@ public class AnnotatedCommandHandlingComponent<T> implements CommandHandlingComp
         descriptor.describeWrapperOf(handlingComponent);
         descriptor.describeProperty("messageTypeResolver", messageTypeResolver);
         descriptor.describeProperty("converter", converter);
+    }
+
+    private class AdapterCommandHandler implements CommandHandler {
+        private final CommandHandlingMember<? super T> delegate;
+        private final MessageHandlerInterceptorMemberChain<T> interceptorChain;
+        private final VersionSpecifier versionSpecifier;
+
+        private AdapterCommandHandler(CommandHandlingMember<? super T> delegate,
+                                      MessageHandlerInterceptorMemberChain<T> interceptorChain,
+                                      VersionSpecifier versionSpecifier) {
+            this.delegate = delegate;
+            this.interceptorChain = interceptorChain;
+            this.versionSpecifier = versionSpecifier;
+        }
+
+        @Override
+        public MessageStream.Single<CommandResultMessage> handle(CommandMessage command, ProcessingContext context) {
+            return interceptorChain.handle(
+                                           command.withConvertedPayload(delegate.payloadType(), converter),
+                                           context,
+                                           target,
+                                           delegate
+                                   )
+                                   .mapMessage(AnnotatedCommandHandlingComponent.this::asCommandResultMessage)
+                                   .first()
+                                   .cast();
+        }
+
+        @Override
+        public VersionSpecifier supportedVersions() {
+            return versionSpecifier;
+        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/CommandHandler.java
+++ b/messaging/src/main/java/org/axonframework/messaging/commandhandling/annotation/CommandHandler.java
@@ -92,4 +92,14 @@ public @interface CommandHandler {
      * @return The payload type expected by this handler.
      */
     Class<?> payloadType() default Object.class;
+
+    /**
+     * The version range of the command this handler listens to.
+     * <p>
+     * Defaults to an empty string, meaning the handler accepts any version of the command.
+     * The string can define a specific version (e.g. {@code "1.0"}) or an inclusive range (e.g. {@code "1.0-2.0"}).
+     *
+     * @return The version range of the command expected by this handler.
+     */
+    String versionRange() default "";
 }

--- a/messaging/src/main/java/org/axonframework/messaging/core/AnyVersionSpecifier.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/AnyVersionSpecifier.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+/**
+ * A {@link VersionSpecifier} that matches any version. This is the default specifier used when a
+ * {@link MessageHandler} does not restrict the versions it supports.
+ *
+ * @author Ishaan Bhela
+ * @since 5.4.0
+ */
+final class AnyVersionSpecifier implements VersionSpecifier {
+
+    static final AnyVersionSpecifier INSTANCE = new AnyVersionSpecifier();
+
+    private AnyVersionSpecifier() {
+    }
+
+    @Override
+    public boolean matches(String version) {
+        return true;
+    }
+
+    @Override
+    public boolean overlaps(VersionSpecifier other) {
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "VersionSpecifier.any()";
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/MessageHandler.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/MessageHandler.java
@@ -26,4 +26,18 @@ package org.axonframework.messaging.core;
  */
 public interface MessageHandler {
 
+    /**
+     * Returns the {@link VersionSpecifier} indicating which message versions this handler supports.
+     * <p>
+     * During dispatch, the framework uses this specifier to determine whether this handler is eligible to handle an
+     * incoming message based on its {@link VersionedType#version() version}.
+     * <p>
+     * Defaults to {@link VersionSpecifier#any()}, meaning the handler accepts all versions. Override this method to
+     * restrict handling to a specific version or version range.
+     *
+     * @return The {@link VersionSpecifier} for this handler.
+     */
+    default VersionSpecifier supportedVersions() {
+        return VersionSpecifier.any();
+    }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/core/VersionRange.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/VersionRange.java
@@ -43,6 +43,9 @@ record VersionRange(String from, String to) implements VersionSpecifier {
 
     @Override
     public boolean matches(String version) {
+        if (version == null) {
+            return false;
+        }
         return compareVersions(from, version) <= 0
                 && compareVersions(version, to) <= 0;
     }

--- a/messaging/src/main/java/org/axonframework/messaging/core/VersionRange.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/VersionRange.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A {@link VersionSpecifier} that matches versions within an inclusive range {@code [from, to]}.
+ * <p>
+ * This class supports semantic versioning (e.g. {@code 1.2.0}). When the {@code from} and {@code to}
+ * versions are equal, this effectively acts as an exact version match.
+ *
+ * @param from The lower bound of the version range (inclusive).
+ * @param to   The upper bound of the version range (inclusive).
+ * @author Ishaan Bhela
+ * @since 5.4.0
+ */
+record VersionRange(String from, String to) implements VersionSpecifier {
+
+    VersionRange {
+        requireNonNull(from, "The 'from' version may not be null.");
+        requireNonNull(to, "The 'to' version may not be null.");
+        if (compareVersions(from, to) > 0) {
+            throw new IllegalArgumentException(
+                    "The 'from' version [%s] must not be greater than the 'to' version [%s].".formatted(from, to)
+            );
+        }
+    }
+
+    @Override
+    public boolean matches(String version) {
+        return compareVersions(from, version) <= 0
+                && compareVersions(version, to) <= 0;
+    }
+
+    @Override
+    public boolean overlaps(VersionSpecifier other) {
+        if (other instanceof AnyVersionSpecifier) {
+            return true;
+        }
+        if (other instanceof VersionRange otherRange) {
+            return compareVersions(from, otherRange.to) <= 0
+                    && compareVersions(otherRange.from, to) <= 0;
+        }
+        // Conservative default: assume overlap for unknown implementations.
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return from.equals(to)
+                ? "VersionSpecifier.exact(\"%s\")".formatted(from)
+                : "VersionSpecifier.range(\"%s\", \"%s\")".formatted(from, to);
+    }
+
+    /**
+     * Compares two version strings segment by segment.
+     * <p>
+     * Each version is split on {@code '.'} and segments are compared as integers when possible, falling back to
+     * lexicographic comparison for non-numeric segments. Missing trailing segments are treated as {@code 0}.
+     *
+     * @param v1 The first version string.
+     * @param v2 The second version string.
+     * @return A negative integer, zero, or a positive integer if {@code v1} is less than, equal to, or greater than
+     * {@code v2}.
+     */
+    static int compareVersions(String v1, String v2) {
+        String[] parts1 = v1.split("\\.");
+        String[] parts2 = v2.split("\\.");
+        int length = Math.max(parts1.length, parts2.length);
+        for (int i = 0; i < length; i++) {
+            String segment1 = i < parts1.length ? parts1[i] : "0";
+            String segment2 = i < parts2.length ? parts2[i] : "0";
+            int comparison = compareSegments(segment1, segment2);
+            if (comparison != 0) {
+                return comparison;
+            }
+        }
+        return 0;
+    }
+
+    private static int compareSegments(String s1, String s2) {
+        try {
+            return Integer.compare(Integer.parseInt(s1), Integer.parseInt(s2));
+        } catch (NumberFormatException e) {
+            return s1.compareTo(s2);
+        }
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/VersionSpecifier.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/VersionSpecifier.java
@@ -61,6 +61,30 @@ public interface VersionSpecifier {
     }
 
     /**
+     * Parses a string representation of a version specifier into a {@link VersionSpecifier} instance.
+     * <p>
+     * The following formats are supported:
+     * <ul>
+     * <li>Empty string or {@code null} returns {@link #any()}</li>
+     * <li>A single version (e.g., {@code "1.0"}) returns an exact match specifier</li>
+     * <li>A range separated by a hyphen (e.g., {@code "1.0-2.0"}) returns a range specifier</li>
+     * </ul>
+     *
+     * @param spec The string representation of the version specifier.
+     * @return A {@code VersionSpecifier} corresponding to the parsed string.
+     */
+    static VersionSpecifier parse(String spec) {
+        if (spec == null || spec.trim().isEmpty()) {
+            return any();
+        }
+        String[] parts = spec.split("-", 2);
+        if (parts.length == 2) {
+            return range(parts[0].trim(), parts[1].trim());
+        }
+        return exact(spec.trim());
+    }
+
+    /**
      * Returns a {@code VersionSpecifier} that matches versions within the inclusive range {@code [from, to]}.
      * <p>
      * Versions are compared segment by segment (split on {@code '.'}), with each segment parsed as an integer where

--- a/messaging/src/main/java/org/axonframework/messaging/core/VersionSpecifier.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/VersionSpecifier.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+/**
+ * Specifies which message versions a {@link MessageHandler} supports.
+ * <p>
+ * A {@code VersionSpecifier} is used during message dispatch to determine whether a handler is eligible to handle a
+ * message based on the message's {@link VersionedType#version() version}. It is also used during registration to detect
+ * overlapping handlers for the same {@link QualifiedName}.
+ *
+ * @author Ishaan
+ * @since 5.4.0
+ * @see MessageHandler#supportedVersions()
+ */
+public interface VersionSpecifier {
+
+    /**
+     * Returns whether this specifier matches the given {@code version}.
+     *
+     * @param version The version string to test against this specifier.
+     * @return {@code true} if the given version falls within the range of this specifier, {@code false} otherwise.
+     */
+    boolean matches(String version);
+
+    /**
+     * Returns whether this specifier overlaps with the given {@code other} specifier. Two specifiers overlap if there
+     * exists at least one version string that both would {@link #matches(String) match}.
+     * <p>
+     * This is used during handler registration to detect conflicting subscriptions for message types that allow only a
+     * single handler per {@link QualifiedName} (e.g., commands).
+     *
+     * @param other The other specifier to check for overlap.
+     * @return {@code true} if the two specifiers overlap, {@code false} otherwise.
+     */
+    boolean overlaps(VersionSpecifier other);
+
+    /**
+     * Returns a {@code VersionSpecifier} that matches all versions.
+     * <p>
+     * This is the default specifier used when a handler does not restrict the versions it supports.
+     *
+     * @return A {@code VersionSpecifier} matching any version.
+     */
+    static VersionSpecifier any() {
+        return AnyVersionSpecifier.INSTANCE;
+    }
+
+    /**
+     * Returns a {@code VersionSpecifier} that matches versions within the inclusive range {@code [from, to]}.
+     * <p>
+     * Versions are compared segment by segment (split on {@code '.'}), with each segment parsed as an integer where
+     * possible. When {@code from} and {@code to} are equal, this effectively acts as an exact-version specifier.
+     *
+     * @param from The lower bound of the version range (inclusive).
+     * @param to   The upper bound of the version range (inclusive).
+     * @return A {@code VersionSpecifier} matching versions in the given range.
+     * @throws IllegalArgumentException if {@code from} is greater than {@code to}.
+     */
+    static VersionSpecifier range(String from, String to) {
+        return new VersionRange(from, to);
+    }
+
+    /**
+     * Returns a {@code VersionSpecifier} that matches exactly the given {@code version}.
+     * <p>
+     * This is equivalent to calling {@code range(version, version)}.
+     *
+     * @param version The exact version to match.
+     * @return A {@code VersionSpecifier} matching only the given version.
+     */
+    static VersionSpecifier exact(String version) {
+        return new VersionRange(version, version);
+    }
+}

--- a/messaging/src/main/java/org/axonframework/messaging/core/annotation/HandlerAttributes.java
+++ b/messaging/src/main/java/org/axonframework/messaging/core/annotation/HandlerAttributes.java
@@ -58,10 +58,25 @@ public interface HandlerAttributes {
      */
     String QUERY_NAME = "QueryHandler.queryName";
     /**
+     * Attribute key referencing the version range of the {@link org.axonframework.messaging.queryhandling.QueryMessage}
+     * the handler can handle.
+     */
+    String QUERY_VERSION_RANGE = "QueryHandler.versionRange";
+    /**
+     * Attribute key referencing the version range of the {@link CommandMessage} the handler
+     * can handle.
+     */
+    String COMMAND_VERSION_RANGE = "CommandHandler.versionRange";
+    /**
      * Attribute key referencing the name of the {@link EventMessage} the handler can
      * handle.
      */
     String EVENT_NAME = "EventHandler.eventName";
+    /**
+     * Attribute key referencing the version range of the {@link EventMessage} the handler
+     * can handle.
+     */
+    String EVENT_VERSION_RANGE = "EventHandler.versionRange";
     /**
      * Attribute key referencing the result type the handler can handle.
      */

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/SimpleEventHandlingComponent.java
@@ -125,9 +125,12 @@ public class SimpleEventHandlingComponent implements
         }
         MessageStream<Message> result = MessageStream.empty();
 
+        String version = event.type().version();
         for (var handler : handlers) {
-            var handlerResult = handler.handle(event, context);
-            result = result.concatWith(handlerResult);
+            if (handler.supportedVersions().matches(version)) {
+                var handlerResult = handler.handle(event, context);
+                result = result.concatWith(handlerResult);
+            }
         }
         return result.ignoreEntries().cast();
     }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponent.java
@@ -24,6 +24,7 @@ import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
 import org.axonframework.messaging.core.annotation.HandlerAttributes;
+import org.axonframework.messaging.core.VersionSpecifier;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
 import org.axonframework.messaging.core.annotation.MessageHandlingMember;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
@@ -131,17 +132,11 @@ public class AnnotatedEventHandlingComponent<T> implements EventHandlingComponen
     private EventHandler constructEventHandlerFor(QualifiedName qualifiedName,
                                                   MessageHandlingMember<? super T> handler) {
         MessageHandlerInterceptorMemberChain<T> interceptorChain = model.chainedInterceptor(target.getClass());
-        EventHandler interceptedHandler =
-                (event, context) -> interceptorChain.handle(
-                                                            event.withConvertedPayload(
-                                                                    handler.payloadType(), converter
-                                                            ),
-                                                            context,
-                                                            target,
-                                                            handler
-                                                    )
-                                                    .ignoreEntries()
-                                                    .cast();
+        VersionSpecifier versionSpecifier = handler.<String>attribute(HandlerAttributes.EVENT_VERSION_RANGE)
+                                                   .map(VersionSpecifier::parse)
+                                                   .orElse(VersionSpecifier.any());
+
+        EventHandler interceptedHandler = new AdapterEventHandler(handler, interceptorChain, versionSpecifier);
 
         return whenCustomSequencingPolicyOn(handler)
                 .map(sequencingPolicy -> {
@@ -272,5 +267,36 @@ public class AnnotatedEventHandlingComponent<T> implements EventHandlingComponen
         descriptor.describeWrapperOf(handlingComponent);
         descriptor.describeProperty("messageTypeResolver", messageTypeResolver);
         descriptor.describeProperty("converter", converter);
+    }
+
+    private class AdapterEventHandler implements EventHandler {
+        private final MessageHandlingMember<? super T> delegate;
+        private final MessageHandlerInterceptorMemberChain<T> interceptorChain;
+        private final VersionSpecifier versionSpecifier;
+
+        private AdapterEventHandler(MessageHandlingMember<? super T> delegate,
+                                    MessageHandlerInterceptorMemberChain<T> interceptorChain,
+                                    VersionSpecifier versionSpecifier) {
+            this.delegate = delegate;
+            this.interceptorChain = interceptorChain;
+            this.versionSpecifier = versionSpecifier;
+        }
+
+        @Override
+        public MessageStream.Empty<Message> handle(EventMessage event, ProcessingContext context) {
+            return interceptorChain.handle(
+                                           event.withConvertedPayload(delegate.payloadType(), converter),
+                                           context,
+                                           target,
+                                           delegate
+                                   )
+                                   .ignoreEntries()
+                                   .cast();
+        }
+
+        @Override
+        public VersionSpecifier supportedVersions() {
+            return versionSpecifier;
+        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/EventHandler.java
+++ b/messaging/src/main/java/org/axonframework/messaging/eventhandling/annotation/EventHandler.java
@@ -94,4 +94,14 @@ public @interface EventHandler {
      * @return The type of the event this method handles.
      */
     Class<?> payloadType() default Object.class;
+
+    /**
+     * The version range of the event this handler listens to.
+     * <p>
+     * Defaults to an empty string, meaning the handler accepts any version of the event.
+     * The string can define a specific version (e.g. {@code "1.0"}) or an inclusive range (e.g. {@code "1.0-2.0"}).
+     *
+     * @return The version range of the event expected by this handler.
+     */
+    String versionRange() default "";
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryBus.java
@@ -33,11 +33,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.IntSupplier;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -73,7 +75,7 @@ public class SimpleQueryBus implements QueryBus {
     private static final ResourceKey<List<Runnable>> UPDATE_TASKS_KEY = ResourceKey.withLabel("update-tasks");
 
     private final UnitOfWorkFactory unitOfWorkFactory;
-    private final ConcurrentMap<QualifiedName, QueryHandler> subscriptions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<QualifiedName, List<QueryHandler>> subscriptions = new ConcurrentHashMap<>();
     private final ConcurrentMap<QueryMessage, QueueMessageStream<SubscriptionQueryUpdateMessage>> updateHandlers =
             new ConcurrentHashMap<>();
 
@@ -90,10 +92,23 @@ public class SimpleQueryBus implements QueryBus {
     @Override
     public QueryBus subscribe(QualifiedName queryName, QueryHandler queryHandler) {
         logger.debug("Subscribing query handler for name [{}].", queryName);
-        QueryHandler existingHandler = subscriptions.putIfAbsent(queryName, queryHandler);
-        if (existingHandler != null && existingHandler != queryHandler) {
-            throw new DuplicateQueryHandlerSubscriptionException(queryName, existingHandler, queryHandler);
-        }
+
+        subscriptions.compute(queryName, (key, existingHandlers) -> {
+            if (existingHandlers == null) {
+                existingHandlers = new CopyOnWriteArrayList<>();
+            }
+            for (QueryHandler existing : existingHandlers) {
+                if (existing == queryHandler) {
+                    return existingHandlers;
+                }
+                if (existing.supportedVersions().overlaps(queryHandler.supportedVersions())) {
+                    throw new DuplicateQueryHandlerSubscriptionException(queryName, existing, queryHandler);
+                }
+            }
+            existingHandlers.add(queryHandler);
+            return existingHandlers;
+        });
+
         return this;
     }
 
@@ -185,10 +200,15 @@ public class SimpleQueryBus implements QueryBus {
 
     private QueryHandler handlerFor(QueryMessage query) {
         QualifiedName handlerName = query.type().qualifiedName();
-        if (!subscriptions.containsKey(handlerName)) {
+        String version = query.type().version();
+        List<QueryHandler> handlers = subscriptions.get(handlerName);
+        if (handlers == null) {
             throw NoHandlerForQueryException.forBus(query);
         }
-        return subscriptions.get(handlerName);
+        return handlers.stream()
+                       .filter(h -> h.supportedVersions().matches(version))
+                       .findFirst()
+                       .orElseThrow(() -> NoHandlerForQueryException.forBus(query));
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/SimpleQueryHandlingComponent.java
@@ -23,8 +23,10 @@ import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -43,7 +45,7 @@ public class SimpleQueryHandlingComponent implements
         QueryHandlerRegistry<SimpleQueryHandlingComponent> {
 
     private final String name;
-    private final Map<QualifiedName, QueryHandler> queryHandlers = new HashMap<>();
+    private final Map<QualifiedName, List<QueryHandler>> queryHandlers = new HashMap<>();
     private final Set<QueryHandlingComponent> subComponents = new HashSet<>();
 
     /**
@@ -68,11 +70,21 @@ public class SimpleQueryHandlingComponent implements
             return subscribe(component);
         }
 
-        QueryHandler existingHandler = queryHandlers.computeIfAbsent(queryName, k -> handler);
-
-        if (existingHandler != handler) {
-            throw new DuplicateQueryHandlerSubscriptionException(queryName, existingHandler, handler);
-        }
+        queryHandlers.compute(queryName, (key, existingHandlers) -> {
+            if (existingHandlers == null) {
+                existingHandlers = new ArrayList<>();
+            }
+            for (QueryHandler existing : existingHandlers) {
+                if (existing == handler) {
+                    return existingHandlers;
+                }
+                if (existing.supportedVersions().overlaps(handler.supportedVersions())) {
+                    throw new DuplicateQueryHandlerSubscriptionException(queryName, existing, handler);
+                }
+            }
+            existingHandlers.add(handler);
+            return existingHandlers;
+        });
 
         return this;
     }
@@ -98,14 +110,33 @@ public class SimpleQueryHandlingComponent implements
                 return MessageStream.failed(e);
             }
         }
-        if (queryHandlers.containsKey(handlerName)) {
-            try {
-                return queryHandlers.get(handlerName).handle(query, context);
-            } catch (Throwable e) {
-                return MessageStream.failed(e);
+        String version = query.type().version();
+        List<QueryHandler> handlers = queryHandlers.get(handlerName);
+        if (handlers != null) {
+            Optional<MessageStream<QueryResponseMessage>> result = handleWithVersionMatch(handlers, version, query, context);
+            if (result.isPresent()) {
+                return result.get();
             }
         }
+
         return MessageStream.failed(NoHandlerForQueryException.forHandlingComponent(query));
+    }
+
+    private Optional<MessageStream<QueryResponseMessage>> handleWithVersionMatch(
+            List<QueryHandler> handlers,
+            String version,
+            QueryMessage query,
+            ProcessingContext context) {
+        for (QueryHandler handler : handlers) {
+            if (handler.supportedVersions().matches(version)) {
+                try {
+                    return Optional.of(handler.handle(query, context));
+                } catch (Throwable e) {
+                    return Optional.of(MessageStream.failed(e));
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     @Override

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponent.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponent.java
@@ -22,8 +22,10 @@ import org.axonframework.messaging.core.MessageStream;
 import org.axonframework.messaging.core.MessageTypeResolver;
 import org.axonframework.messaging.core.QualifiedName;
 import org.axonframework.messaging.core.annotation.AnnotatedHandlerInspector;
+import org.axonframework.messaging.core.annotation.HandlerAttributes;
 import org.axonframework.messaging.core.annotation.HandlerDefinition;
 import org.axonframework.messaging.core.annotation.ParameterResolverFactory;
+import org.axonframework.messaging.core.VersionSpecifier;
 import org.axonframework.messaging.core.conversion.MessageConverter;
 import org.axonframework.messaging.core.interception.annotation.MessageHandlerInterceptorMemberChain;
 import org.axonframework.messaging.core.unitofwork.ProcessingContext;
@@ -115,24 +117,11 @@ public class AnnotatedQueryHandlingComponent<T> implements QueryHandlingComponen
 
     private QueryHandler constructQueryHandlerFor(QueryHandlingMember<? super T> handler) {
         MessageHandlerInterceptorMemberChain<T> interceptorChain = model.chainedInterceptor(target.getClass());
-        return (query, context) -> {
-            MessageStream<QueryResponseMessage> resultStream =
-                    interceptorChain.handle(
-                                            query.withConvertedPayload(handler.payloadType(), converter),
-                                            context,
-                                            target,
-                                            handler
-                                    )
-                                    .mapMessage(this::asQueryResponseMessage);
-            Optional<Throwable> handlingException = resultStream.error();
-            if (handlingException.isPresent() && !(handlingException.get() instanceof QueryExecutionException)) {
-                return MessageStream.failed(new QueryExecutionException(
-                        "Handling query with identifier [" + query.identifier() + "] failed.",
-                        handlingException.get()
-                ));
-            }
-            return resultStream;
-        };
+        VersionSpecifier versionSpecifier = handler.<String>attribute(HandlerAttributes.QUERY_VERSION_RANGE)
+                                                   .map(VersionSpecifier::parse)
+                                                   .orElse(VersionSpecifier.any());
+
+        return new AdapterQueryHandler(handler, interceptorChain, versionSpecifier);
     }
 
     private QueryResponseMessage asQueryResponseMessage(Message queryResponse) {
@@ -158,5 +147,44 @@ public class AnnotatedQueryHandlingComponent<T> implements QueryHandlingComponen
         descriptor.describeWrapperOf(handlingComponent);
         descriptor.describeProperty("messageTypeResolver", messageTypeResolver);
         descriptor.describeProperty("converter", converter);
+    }
+
+    private class AdapterQueryHandler implements QueryHandler {
+        private final QueryHandlingMember<? super T> delegate;
+        private final MessageHandlerInterceptorMemberChain<T> interceptorChain;
+        private final VersionSpecifier versionSpecifier;
+
+        private AdapterQueryHandler(QueryHandlingMember<? super T> delegate,
+                                    MessageHandlerInterceptorMemberChain<T> interceptorChain,
+                                    VersionSpecifier versionSpecifier) {
+            this.delegate = delegate;
+            this.interceptorChain = interceptorChain;
+            this.versionSpecifier = versionSpecifier;
+        }
+
+        @Override
+        public MessageStream<QueryResponseMessage> handle(QueryMessage query, ProcessingContext context) {
+            MessageStream<QueryResponseMessage> resultStream =
+                    interceptorChain.handle(
+                                            query.withConvertedPayload(delegate.payloadType(), converter),
+                                            context,
+                                            target,
+                                            delegate
+                                    )
+                                    .mapMessage(AnnotatedQueryHandlingComponent.this::asQueryResponseMessage);
+            Optional<Throwable> handlingException = resultStream.error();
+            if (handlingException.isPresent() && !(handlingException.get() instanceof QueryExecutionException)) {
+                return MessageStream.failed(new QueryExecutionException(
+                        "Handling query with identifier [" + query.identifier() + "] failed.",
+                        handlingException.get()
+                ));
+            }
+            return resultStream;
+        }
+
+        @Override
+        public VersionSpecifier supportedVersions() {
+            return versionSpecifier;
+        }
     }
 }

--- a/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/QueryHandler.java
+++ b/messaging/src/main/java/org/axonframework/messaging/queryhandling/annotation/QueryHandler.java
@@ -70,4 +70,14 @@ public @interface QueryHandler {
      * {@link QueryMessage#type()}.
      */
     String queryName() default "";
+
+    /**
+     * The version range of the query this handler listens to.
+     * <p>
+     * Defaults to an empty string, meaning the handler accepts any version of the query.
+     * The string can define a specific version (e.g. {@code "1.0"}) or an inclusive range (e.g. {@code "1.0-2.0"}).
+     *
+     * @return The version range of the query expected by this handler.
+     */
+    String versionRange() default "";
 }

--- a/messaging/src/test/java/org/axonframework/messaging/commandhandling/SimpleCommandBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/commandhandling/SimpleCommandBusTest.java
@@ -228,7 +228,9 @@ class SimpleCommandBusTest {
     @Test
     void duplicateRegistrationIsRejected() {
         var handler1 = mock(CommandHandler.class);
+        when(handler1.supportedVersions()).thenReturn(org.axonframework.messaging.core.VersionSpecifier.any());
         var handler2 = mock(CommandHandler.class);
+        when(handler2.supportedVersions()).thenReturn(org.axonframework.messaging.core.VersionSpecifier.any());
         testSubject.subscribe(COMMAND_NAME, handler1);
         assertThrows(DuplicateCommandHandlerSubscriptionException.class,
                      () -> testSubject.subscribe(COMMAND_NAME, handler2));
@@ -237,6 +239,7 @@ class SimpleCommandBusTest {
     @Test
     void duplicateRegistrationForSameHandlerIsAllowed() {
         var handler = mock(CommandHandler.class);
+        when(handler.supportedVersions()).thenReturn(org.axonframework.messaging.core.VersionSpecifier.any());
         testSubject.subscribe(COMMAND_NAME, handler);
         assertDoesNotThrow(() -> testSubject.subscribe(COMMAND_NAME, handler));
     }
@@ -256,7 +259,54 @@ class SimpleCommandBusTest {
 
         verify(mockComponentDescriptor).describeProperty("unitOfWorkFactory", unitOfWorkFactory);
         verify(mockComponentDescriptor)
-                .describeProperty("subscriptions", Map.of(COMMAND_NAME, handler1, handlerTwoName, handler2));
+                .describeProperty("subscriptions", Map.of(COMMAND_NAME, java.util.List.of(handler1), handlerTwoName, java.util.List.of(handler2)));
+    }
+
+    @Test
+    void overlappingRegistrationIsRejected() {
+        var handler1 = mock(CommandHandler.class);
+        when(handler1.supportedVersions()).thenReturn(org.axonframework.messaging.core.VersionSpecifier.range("1.0", "3.0"));
+        
+        var handler2 = mock(CommandHandler.class);
+        when(handler2.supportedVersions()).thenReturn(org.axonframework.messaging.core.VersionSpecifier.range("2.0", "4.0"));
+        
+        testSubject.subscribe(COMMAND_NAME, handler1);
+        assertThrows(DuplicateCommandHandlerSubscriptionException.class,
+                     () -> testSubject.subscribe(COMMAND_NAME, handler2));
+    }
+
+    @Test
+    void nonOverlappingRegistrationIsAllowedAndDispatchesCorrectly() throws Exception {
+        var handler1 = new StubCommandHandler("V1") {
+            @Override
+            public org.axonframework.messaging.core.VersionSpecifier supportedVersions() {
+                return org.axonframework.messaging.core.VersionSpecifier.range("1.0", "1.9");
+            }
+        };
+        var handler2 = new StubCommandHandler("V2") {
+            @Override
+            public org.axonframework.messaging.core.VersionSpecifier supportedVersions() {
+                return org.axonframework.messaging.core.VersionSpecifier.range("2.0", "2.9");
+            }
+        };
+
+        testSubject.subscribe(COMMAND_NAME, handler1);
+        testSubject.subscribe(COMMAND_NAME, handler2);
+
+        // Dispatch V1 command
+        CommandMessage commandV1 = new GenericCommandMessage(new MessageType("command", "1.5"), "payload");
+        var actualV1 = testSubject.dispatch(commandV1, StubProcessingContext.forMessage(commandV1));
+        assertEquals("V1", actualV1.join().payload());
+
+        // Dispatch V2 command
+        CommandMessage commandV2 = new GenericCommandMessage(new MessageType("command", "2.1"), "payload");
+        var actualV2 = testSubject.dispatch(commandV2, StubProcessingContext.forMessage(commandV2));
+        assertEquals("V2", actualV2.join().payload());
+
+        // Dispatch V3 command (no handler)
+        CommandMessage commandV3 = new GenericCommandMessage(new MessageType("command", "3.0"), "payload");
+        var actualV3 = testSubject.dispatch(commandV3, StubProcessingContext.forMessage(commandV3));
+        assertTrue(actualV3.isCompletedExceptionally());
     }
 
     private static class StubCommandHandler implements CommandHandler {

--- a/messaging/src/test/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/commandhandling/annotation/AnnotatedCommandHandlingComponentTest.java
@@ -113,6 +113,40 @@ class AnnotatedCommandHandlingComponentTest {
     }
 
     @Test
+    void subscribesCommandHandlerWithVersionRange() {
+        Object annotatedCommandHandler = new Object() {
+            @SuppressWarnings("unused")
+            @CommandHandler(commandName = "myCommandName", versionRange = "1.0-2.0")
+            public void handle(String command) {
+                // Unimportant
+            }
+        };
+        MessageTypeResolver messageTypeResolver = spy(new AnnotationMessageTypeResolver());
+        AnnotatedCommandHandlingComponent<Object> annotatedComponent = new AnnotatedCommandHandlingComponent<>(
+                annotatedCommandHandler,
+                ClasspathParameterResolverFactory.forClass(annotatedCommandHandler.getClass()),
+                ClasspathHandlerDefinition.forClass(annotatedCommandHandler.getClass()),
+                messageTypeResolver,
+                new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+        );
+
+        CommandMessage testCommand = new GenericCommandMessage(new MessageType("myCommandName", "1.5"), "payload");
+        MessageStream.Single<CommandResultMessage> resultStream =
+                annotatedComponent.handle(testCommand, StubProcessingContext.forMessage(testCommand));
+
+        assertTrue(resultStream.isCompleted());
+        assertFalse(resultStream.error().isPresent());
+        
+        CommandMessage outOfRangeCommand = new GenericCommandMessage(new MessageType("myCommandName", "2.5"), "payload");
+        MessageStream.Single<CommandResultMessage> outOfRangeStream =
+                annotatedComponent.handle(outOfRangeCommand, StubProcessingContext.forMessage(outOfRangeCommand));
+        
+        assertTrue(outOfRangeStream.isCompleted());
+        assertTrue(outOfRangeStream.error().isPresent());
+        assertTrue(outOfRangeStream.error().get() instanceof NoHandlerForCommandException);
+    }
+
+    @Test
     void subscribesCommandHandlerThroughMessageTypeResolverWhenCommandNameIsEmpty() {
         QualifiedName expectedName = new QualifiedName("defaultName");
 

--- a/messaging/src/test/java/org/axonframework/messaging/core/VersionSpecifierTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/VersionSpecifierTest.java
@@ -33,6 +33,7 @@ class VersionSpecifierTest {
             assertTrue(specifier.matches("2.5.1"));
             assertTrue(specifier.matches("anything"));
             assertTrue(specifier.matches(""));
+            assertTrue(specifier.matches(null));
         }
 
         @Test
@@ -55,6 +56,7 @@ class VersionSpecifierTest {
             assertFalse(specifier.matches("1.1"));
             assertFalse(specifier.matches("2.0"));
             assertFalse(specifier.matches("0.9"));
+            assertFalse(specifier.matches(null));
         }
 
         @Test
@@ -126,6 +128,35 @@ class VersionSpecifierTest {
         void fallsBackToLexicographicalForNonNumeric() {
             assertTrue(VersionRange.compareVersions("1.0-alpha", "1.0-beta") < 0);
             assertTrue(VersionRange.compareVersions("v1", "v2") < 0);
+        }
+    }
+
+    @Nested
+    class ParseTest {
+
+        @Test
+        void parseEmptyOrNullReturnsAny() {
+            assertEquals(VersionSpecifier.any(), VersionSpecifier.parse(null));
+            assertEquals(VersionSpecifier.any(), VersionSpecifier.parse(""));
+            assertEquals(VersionSpecifier.any(), VersionSpecifier.parse("   "));
+        }
+
+        @Test
+        void parseSingleVersionReturnsExact() {
+            VersionSpecifier specifier = VersionSpecifier.parse("1.2.3");
+            assertTrue(specifier.matches("1.2.3"));
+            assertFalse(specifier.matches("1.2.4"));
+        }
+
+        @Test
+        void parseRangeReturnsRange() {
+            VersionSpecifier specifier = VersionSpecifier.parse("1.0 - 2.0");
+            assertTrue(specifier.matches("1.0"));
+            assertTrue(specifier.matches("1.5"));
+            assertTrue(specifier.matches("2.0"));
+            assertFalse(specifier.matches("0.9"));
+            assertFalse(specifier.matches("2.1"));
+            assertFalse(specifier.matches(null));
         }
     }
 }

--- a/messaging/src/test/java/org/axonframework/messaging/core/VersionSpecifierTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/VersionSpecifierTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2010-2026. Axon Framework
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.axonframework.messaging.core;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VersionSpecifierTest {
+
+    @Nested
+    class AnyVersionSpecifierTest {
+
+        @Test
+        void matchesAnything() {
+            VersionSpecifier specifier = VersionSpecifier.any();
+            assertTrue(specifier.matches("1.0"));
+            assertTrue(specifier.matches("2.5.1"));
+            assertTrue(specifier.matches("anything"));
+            assertTrue(specifier.matches(""));
+        }
+
+        @Test
+        void overlapsWithAnything() {
+            VersionSpecifier any = VersionSpecifier.any();
+            assertTrue(any.overlaps(VersionSpecifier.any()));
+            assertTrue(any.overlaps(VersionSpecifier.exact("1.0")));
+            assertTrue(any.overlaps(VersionSpecifier.range("1.0", "2.0")));
+        }
+    }
+
+    @Nested
+    class ExactVersionSpecifierTest {
+
+        @Test
+        void matchesExactVersionOnly() {
+            VersionSpecifier specifier = VersionSpecifier.exact("1.0");
+            assertTrue(specifier.matches("1.0"));
+            assertTrue(specifier.matches("1.0.0")); // Semantic equivalent
+            assertFalse(specifier.matches("1.1"));
+            assertFalse(specifier.matches("2.0"));
+            assertFalse(specifier.matches("0.9"));
+        }
+
+        @Test
+        void overlapsWithSameOrEncompassingRange() {
+            VersionSpecifier exact1 = VersionSpecifier.exact("1.0");
+            VersionSpecifier exact1b = VersionSpecifier.exact("1.0.0");
+            VersionSpecifier exact2 = VersionSpecifier.exact("2.0");
+            VersionSpecifier rangeIncludes = VersionSpecifier.range("0.5", "1.5");
+            VersionSpecifier rangeExcludes = VersionSpecifier.range("1.5", "2.5");
+
+            assertTrue(exact1.overlaps(exact1b));
+            assertFalse(exact1.overlaps(exact2));
+            assertTrue(exact1.overlaps(rangeIncludes));
+            assertFalse(exact1.overlaps(rangeExcludes));
+        }
+    }
+
+    @Nested
+    class RangeVersionSpecifierTest {
+
+        @Test
+        void matchesWithinRange() {
+            VersionSpecifier specifier = VersionSpecifier.range("1.0", "2.0");
+            assertTrue(specifier.matches("1.0"));
+            assertTrue(specifier.matches("1.5"));
+            assertTrue(specifier.matches("2.0"));
+            assertTrue(specifier.matches("2.0.0"));
+            
+            assertFalse(specifier.matches("0.9"));
+            assertFalse(specifier.matches("2.1"));
+        }
+
+        @Test
+        void overlapsWithIntersectingRanges() {
+            VersionSpecifier range1 = VersionSpecifier.range("1.0", "3.0");
+            
+            assertTrue(range1.overlaps(VersionSpecifier.range("2.0", "4.0"))); // Overlap end
+            assertTrue(range1.overlaps(VersionSpecifier.range("0.5", "1.5"))); // Overlap start
+            assertTrue(range1.overlaps(VersionSpecifier.range("1.5", "2.5"))); // Fully inside
+            assertTrue(range1.overlaps(VersionSpecifier.range("0.5", "4.0"))); // Fully encompasses
+
+            assertFalse(range1.overlaps(VersionSpecifier.range("3.1", "4.0"))); // Completely after
+            assertFalse(range1.overlaps(VersionSpecifier.range("0.1", "0.9"))); // Completely before
+        }
+        
+        @Test
+        void rejectsInvalidRange() {
+            assertThrows(IllegalArgumentException.class, () -> VersionSpecifier.range("2.0", "1.0"));
+        }
+    }
+    
+    @Nested
+    class VersionComparisonTest {
+        
+        @Test
+        void comparesSemanticVersionsCorrectly() {
+            assertTrue(VersionRange.compareVersions("1.0", "2.0") < 0);
+            assertTrue(VersionRange.compareVersions("2.0", "1.0") > 0);
+            assertTrue(VersionRange.compareVersions("1.0", "1.0") == 0);
+            
+            assertTrue(VersionRange.compareVersions("1.0.0", "1.0") == 0);
+            assertTrue(VersionRange.compareVersions("1.0", "1.0.0") == 0);
+            
+            assertTrue(VersionRange.compareVersions("1.2", "1.10") < 0);
+            assertTrue(VersionRange.compareVersions("1.10", "1.2") > 0);
+        }
+        
+        @Test
+        void fallsBackToLexicographicalForNonNumeric() {
+            assertTrue(VersionRange.compareVersions("1.0-alpha", "1.0-beta") < 0);
+            assertTrue(VersionRange.compareVersions("v1", "v2") < 0);
+        }
+    }
+}

--- a/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerAttributesTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/core/annotation/AnnotatedHandlerAttributesTest.java
@@ -62,6 +62,7 @@ class AnnotatedHandlerAttributesTest {
         expected.put(HandlerAttributes.PAYLOAD_TYPE, String.class);
         expected.put(HandlerAttributes.COMMAND_NAME, "my-command");
         expected.put(HandlerAttributes.COMMAND_ROUTING_KEY, "my-routing-key");
+        expected.put(HandlerAttributes.COMMAND_VERSION_RANGE, "");
         expected.put(CommandHandler.class.getSimpleName() + ".payloadType", String.class);
 
         AnnotatedHandlerAttributes testSubject = new AnnotatedHandlerAttributes(messageHandlingMember);
@@ -81,6 +82,7 @@ class AnnotatedHandlerAttributesTest {
         expected.put(HandlerAttributes.ALLOW_REPLAY, true);
         expected.put(HandlerAttributes.MESSAGE_TYPE, EventMessage.class);
         expected.put(HandlerAttributes.PAYLOAD_TYPE, Boolean.class);
+        expected.put(HandlerAttributes.EVENT_VERSION_RANGE, "");
         expected.put(EventHandler.class.getSimpleName() + ".payloadType", Boolean.class);
 
         AnnotatedHandlerAttributes testSubject = new AnnotatedHandlerAttributes(messageHandlingMember);
@@ -127,6 +129,7 @@ class AnnotatedHandlerAttributesTest {
         expected.put(HandlerAttributes.PAYLOAD_TYPE, Long.class);
         expected.put(HandlerAttributes.COMMAND_NAME, "custom-custom-name");
         expected.put(HandlerAttributes.COMMAND_ROUTING_KEY, "custom-routing-key");
+        expected.put(HandlerAttributes.COMMAND_VERSION_RANGE, "");
         expected.put(CommandHandler.class.getSimpleName() + ".payloadType", Long.class);
         expected.put(CustomCommandHandler.class.getSimpleName() + ".additionalAttribute", 42);
         expected.put(CustomCommandHandler.class.getSimpleName() + ".payloadType", Long.class);

--- a/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/eventhandling/annotation/AnnotatedEventHandlingComponentTest.java
@@ -111,6 +111,44 @@ class AnnotatedEventHandlingComponentTest {
     }
 
     @Test
+    void subscribesEventHandlerWithVersionRange() {
+        AtomicInteger invocationCount = new AtomicInteger(0);
+        Object annotatedEventHandler = new Object() {
+            @SuppressWarnings("unused")
+            @EventHandler(eventName = "myEventName", versionRange = "1.0-2.0")
+            public void handle(String event) {
+                invocationCount.incrementAndGet();
+            }
+        };
+        MessageTypeResolver messageTypeResolver = spy(new AnnotationMessageTypeResolver());
+        AnnotatedEventHandlingComponent<Object> annotatedComponent = new AnnotatedEventHandlingComponent<>(
+                annotatedEventHandler,
+                ClasspathParameterResolverFactory.forClass(annotatedEventHandler.getClass()),
+                ClasspathHandlerDefinition.forClass(annotatedEventHandler.getClass()),
+                messageTypeResolver,
+                new DelegatingEventConverter(PassThroughConverter.INSTANCE)
+        );
+
+        // Within range
+        org.axonframework.messaging.eventhandling.EventMessage testEvent = 
+                new org.axonframework.messaging.eventhandling.GenericEventMessage(new MessageType("myEventName", "1.5"), "payload");
+        org.axonframework.messaging.core.MessageStream.Empty resultStream =
+                annotatedComponent.handle(testEvent, org.axonframework.messaging.core.unitofwork.StubProcessingContext.forMessage(testEvent));
+        
+        resultStream.isCompleted(); // trigger evaluation
+        assertEquals(1, invocationCount.get());
+        
+        // Outside range
+        org.axonframework.messaging.eventhandling.EventMessage outOfRangeEvent = 
+                new org.axonframework.messaging.eventhandling.GenericEventMessage(new MessageType("myEventName", "2.5"), "payload");
+        org.axonframework.messaging.core.MessageStream.Empty outOfRangeStream =
+                annotatedComponent.handle(outOfRangeEvent, org.axonframework.messaging.core.unitofwork.StubProcessingContext.forMessage(outOfRangeEvent));
+        
+        outOfRangeStream.isCompleted(); // trigger evaluation
+        assertEquals(1, invocationCount.get()); // Should NOT increment!
+    }
+
+    @Test
     void subscribesEventHandlerThroughMessageTypeResolverWhenEventNameIsEmpty() {
         QualifiedName expectedName = new QualifiedName("defaultName");
 

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/SimpleQueryBusTest.java
@@ -112,16 +112,16 @@ class SimpleQueryBusTest {
             testSubject.subscribe(QUERY_NAME, SINGLE_RESPONSE_HANDLER);
             // then...
             testSubject.describeTo(testDescriptor);
-            Map<QualifiedName, QueryHandler> subscriptions = testDescriptor.getProperty("subscriptions");
+            Map<QualifiedName, List<QueryHandler>> subscriptions = testDescriptor.getProperty("subscriptions");
             assertThat(subscriptions.size()).isEqualTo(1);
-            assertThat(subscriptions).containsValue(SINGLE_RESPONSE_HANDLER);
+            assertThat(subscriptions.get(QUERY_NAME)).contains(SINGLE_RESPONSE_HANDLER);
             // when second subscription with different query name...
             testSubject.subscribe(new QualifiedName("test2"), SINGLE_RESPONSE_HANDLER);
             // then...
             testSubject.describeTo(testDescriptor);
             subscriptions = testDescriptor.getProperty("subscriptions");
             assertThat(subscriptions.size()).isEqualTo(2);
-            assertThat(subscriptions).containsValue(SINGLE_RESPONSE_HANDLER);
+            assertThat(subscriptions.get(QUERY_NAME)).contains(SINGLE_RESPONSE_HANDLER);
 
             // when third subscription with the same query name...
             testSubject.subscribe(QUERY_NAME, SINGLE_RESPONSE_HANDLER);
@@ -1180,6 +1180,63 @@ class SimpleQueryBusTest {
             // then only the subscription whose sealExceptionally() succeeded is counted...
             assertThat(completedCount).isEqualTo(1);
         }
+    }
+
+    @Test
+    void overlappingRegistrationIsRejected() {
+        var handler1 = mock(QueryHandler.class);
+        when(handler1.supportedVersions()).thenReturn(org.axonframework.messaging.core.VersionSpecifier.range("1.0", "3.0"));
+
+        var handler2 = mock(QueryHandler.class);
+        when(handler2.supportedVersions()).thenReturn(org.axonframework.messaging.core.VersionSpecifier.range("2.0", "4.0"));
+
+        testSubject.subscribe(QUERY_NAME, handler1);
+        assertThrows(DuplicateQueryHandlerSubscriptionException.class,
+                     () -> testSubject.subscribe(QUERY_NAME, handler2));
+    }
+
+    @Test
+    void nonOverlappingRegistrationIsAllowedAndDispatchesCorrectly() throws Exception {
+        var handler1 = new QueryHandler() {
+            @Override
+            public MessageStream<QueryResponseMessage> handle(QueryMessage message, ProcessingContext context) {
+                return MessageStream.just(new GenericQueryResponseMessage(RESPONSE_TYPE, "V1"));
+            }
+            @Override
+            public org.axonframework.messaging.core.VersionSpecifier supportedVersions() {
+                return org.axonframework.messaging.core.VersionSpecifier.range("1.0", "1.9");
+            }
+        };
+        var handler2 = new QueryHandler() {
+            @Override
+            public MessageStream<QueryResponseMessage> handle(QueryMessage message, ProcessingContext context) {
+                return MessageStream.just(new GenericQueryResponseMessage(RESPONSE_TYPE, "V2"));
+            }
+            @Override
+            public org.axonframework.messaging.core.VersionSpecifier supportedVersions() {
+                return org.axonframework.messaging.core.VersionSpecifier.range("2.0", "2.9");
+            }
+        };
+
+        testSubject.subscribe(QUERY_NAME, handler1);
+        testSubject.subscribe(QUERY_NAME, handler2);
+
+        // Dispatch V1 query
+        QueryMessage queryV1 = new GenericQueryMessage(new MessageType(QUERY_NAME, "1.5"), QUERY_PAYLOAD);
+        var actualV1 = testSubject.query(queryV1, null).first().asCompletableFuture().join();
+        assertThat(actualV1).isNotNull();
+        assertThat(actualV1.message().payload()).isEqualTo("V1");
+
+        // Dispatch V2 query
+        QueryMessage queryV2 = new GenericQueryMessage(new MessageType(QUERY_NAME, "2.1"), QUERY_PAYLOAD);
+        var actualV2 = testSubject.query(queryV2, null).first().asCompletableFuture().join();
+        assertThat(actualV2).isNotNull();
+        assertThat(actualV2.message().payload()).isEqualTo("V2");
+
+        // Dispatch V3 query (no handler)
+        QueryMessage queryV3 = new GenericQueryMessage(new MessageType(QUERY_NAME, "3.0"), QUERY_PAYLOAD);
+        var resultV3 = testSubject.query(queryV3, null);
+        assertThat(resultV3.error()).containsInstanceOf(NoHandlerForQueryException.class);
     }
 
     /**

--- a/messaging/src/test/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponentTest.java
+++ b/messaging/src/test/java/org/axonframework/messaging/queryhandling/annotation/AnnotatedQueryHandlingComponentTest.java
@@ -103,6 +103,42 @@ class AnnotatedQueryHandlingComponentTest {
     }
 
     @Test
+    void subscribesQueryHandlerWithVersionRange() {
+        Object annotatedQueryHandler = new Object() {
+            @SuppressWarnings("unused")
+            @QueryHandler(queryName = "myQueryName", versionRange = "1.0-2.0")
+            public String handle(String query) {
+                return "something";
+            }
+        };
+        MessageTypeResolver messageTypeResolver = spy(new AnnotationMessageTypeResolver());
+        AnnotatedQueryHandlingComponent<Object> annotatedComponent = new AnnotatedQueryHandlingComponent<>(
+                annotatedQueryHandler,
+                ClasspathParameterResolverFactory.forClass(annotatedQueryHandler.getClass()),
+                ClasspathHandlerDefinition.forClass(annotatedQueryHandler.getClass()),
+                messageTypeResolver,
+                new DelegatingMessageConverter(PassThroughConverter.INSTANCE)
+        );
+
+        org.axonframework.messaging.queryhandling.QueryMessage testQuery = 
+                new org.axonframework.messaging.queryhandling.GenericQueryMessage(new MessageType("myQueryName", "1.5"), "payload");
+        MessageStream<org.axonframework.messaging.queryhandling.QueryResponseMessage> resultStream =
+                annotatedComponent.handle(testQuery, org.axonframework.messaging.core.unitofwork.StubProcessingContext.forMessage(testQuery));
+
+        org.junit.jupiter.api.Assertions.assertTrue(resultStream.hasNextAvailable());
+        org.junit.jupiter.api.Assertions.assertFalse(resultStream.error().isPresent());
+        
+        org.axonframework.messaging.queryhandling.QueryMessage outOfRangeQuery = 
+                new org.axonframework.messaging.queryhandling.GenericQueryMessage(new MessageType("myQueryName", "2.5"), "payload");
+        MessageStream<org.axonframework.messaging.queryhandling.QueryResponseMessage> outOfRangeStream =
+                annotatedComponent.handle(outOfRangeQuery, org.axonframework.messaging.core.unitofwork.StubProcessingContext.forMessage(outOfRangeQuery));
+        
+        org.junit.jupiter.api.Assertions.assertFalse(outOfRangeStream.hasNextAvailable());
+        org.junit.jupiter.api.Assertions.assertTrue(outOfRangeStream.error().isPresent());
+        org.junit.jupiter.api.Assertions.assertTrue(outOfRangeStream.error().get() instanceof org.axonframework.messaging.queryhandling.NoHandlerForQueryException);
+    }
+
+    @Test
     void subscribesQueryHandlerThroughMessageTypeResolverWhenQueryNameIsEmpty() {
         QualifiedName expectedName = new QualifiedName("defaultName");
 


### PR DESCRIPTION
This PR allows developers to restrict message handlers to specific versions directly via annotations.
This is the PR after https://github.com/AxonIQ/AxonFramework/pull/5052 and resolves Issue #3306 
This PR may contain changes from the first PR as well because I was not able to create proper stack of PRs due to limitations of forking.

## Changes:

1. Added versionRange attribute to `CommandHandler`, `QueryHandler`, and `EventHandler` (defaults to "" for backward compatibility).
2. Introduced VersionSpecifier to safely parse and match incoming MessageType versions against the handler's requirement.
3. Updated the Annotated...HandlingComponent classes to strictly route messages based on version ranges, ignoring un-versioned or out-of-bounds messages.

# How to use
You can now use versionRange to filter incoming messages. If a message's version does not match the range (or is missing), the handler will safely ignore it (or throw a NoHandlerFor...Exception for commands/queries).

Subscribe to an exact version:

```java
@CommandHandler(versionRange = "2.0")
public void handleV2(MyCommand cmd) { ... }
```
Subscribe to an inclusive range:

```java
@EventHandler(versionRange = "1.0-2.5")
public void handleLegacy(MyEvent evt) { ... }
```
(Omit the attribute to retain default behavior and accept all versions).